### PR TITLE
Add Visual Studio Code support to InstallMCPServer

### DIFF
--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -2,7 +2,7 @@ PacletObject[ <|
     "Name"             -> "RickHennigan/MCPServer",
     "Description"      -> "Implements a model context protocol server using Wolfram Language",
     "Creator"          -> "Richard Hennigan (Wolfram Research)",
-    "Version"          -> "1.2.0",
+    "Version"          -> "1.2.1",
     "WolframVersion"   -> "14.2+",
     "PublisherID"      -> "RickHennigan",
     "License"          -> "MIT",


### PR DESCRIPTION
## Summary
- Add support for installing MCP servers in Visual Studio Code
- Handle VS Code's different configuration format (uses `mcp.servers` instead of `mcpServers`)
- Add installation paths for macOS, Windows, and Linux

## Test plan
- [ ] Build tests pass in GitHub Actions
- [ ] Manual testing of `InstallMCPServer["VisualStudioCode", ...]`
- [ ] Verify configuration is written correctly to VS Code settings.json
- [ ] Test uninstall functionality works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)