### PR TITLE
Add support for Claude Code

### DIFF
--- a/Kernel/InstallMCPServer.wl
+++ b/Kernel/InstallMCPServer.wl
@@ -473,6 +473,12 @@ installLocation[ "ClaudeDesktop", "Windows" ] :=
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
+(*Claude Code*)
+installLocation[ "ClaudeCode", _ ] :=
+    fileNameJoin[ $HomeDirectory, ".claude.json" ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
 (*Cursor*)
 installLocation[ "Cursor", _ ] := fileNameJoin[ $HomeDirectory, ".cursor", "mcp.json" ];
 
@@ -504,11 +510,12 @@ installLocation // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*toInstallName*)
 toInstallName // beginDefinition;
-toInstallName[ "Claude"    ] := "ClaudeDesktop";
-toInstallName[ "VSCode"    ] := "VisualStudioCode";
-toInstallName[ "Code"      ] := "VisualStudioCode";
-toInstallName[ "Gemini"    ] := "GeminiCLI";
-toInstallName[ name_String ] := name;
+toInstallName[ "Claude"      ] := "ClaudeDesktop";
+toInstallName[ "claude-code" ] := "ClaudeCode";
+toInstallName[ "VSCode"      ] := "VisualStudioCode";
+toInstallName[ "Code"        ] := "VisualStudioCode";
+toInstallName[ "Gemini"      ] := "GeminiCLI";
+toInstallName[ name_String   ] := name;
 toInstallName // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -516,6 +523,7 @@ toInstallName // endDefinition;
 (*installDisplayName*)
 installDisplayName // beginDefinition;
 installDisplayName[ "ClaudeDesktop"    ] := "Claude Desktop";
+installDisplayName[ "ClaudeCode"       ] := "Claude Code";
 installDisplayName[ "VisualStudioCode" ] := "Visual Studio Code";
 installDisplayName[ "GeminiCLI"        ] := "Gemini CLI";
 installDisplayName[ name_String        ] := name;

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -232,6 +232,49 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*Named Client Installations*)
+VerificationTest[
+    (* Create a temporary .claude.json-like file with existing data *)
+    configFile = testConfigFile[];
+    Export[configFile, <|"numStartups" -> 1, "mcpServers" -> <||>|>, "JSON"];
+    installResult = InstallMCPServer[configFile, "WolframLanguage"],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-ClaudeCodeLike@@Tests/InstallMCPServer.wlt"
+]
+
+VerificationTest[
+    (* Verify the server was added and other data preserved *)
+    jsonContent = Import[configFile, "RawJSON"];
+    KeyExistsQ[jsonContent, "mcpServers"] &&
+    KeyExistsQ[jsonContent["mcpServers"], "WolframLanguage"] &&
+    KeyExistsQ[jsonContent, "numStartups"] &&
+    jsonContent["numStartups"] === 1,
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-PreservesOtherData@@Tests/InstallMCPServer.wlt"
+]
+
+VerificationTest[
+    (* Install a second server to verify multiple installations work *)
+    installResult2 = InstallMCPServer[configFile, "WolframAlpha"];
+    jsonContent = Import[configFile, "RawJSON"];
+    Length[Keys[jsonContent["mcpServers"]]] === 2,
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-MultipleInClaudeCodeLike@@Tests/InstallMCPServer.wlt"
+]
+
+VerificationTest[
+    UninstallMCPServer[configFile];
+    cleanupTestFiles[configFile],
+    {Null},
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-CleanupClaudeCodeLike@@Tests/InstallMCPServer.wlt"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*Error Cases*)
 VerificationTest[
     configFile = testConfigFile[];


### PR DESCRIPTION
## Summary

Adds support for installing MCP servers to Claude Code via `InstallMCPServer`.

## Changes

-   Added installation location for Claude Code: `~/.claude.json`
-   Added name aliases: `"claude-code"` and `"ClaudeCode"`
-   Added tests verifying `.claude.json` format compatibility and data preservation

## Usage

```wl
InstallMCPServer["ClaudeCode"]
```

Verify with: 

```sh
claude mcp list
```

## Implementation Notes

Current implementation writes directly to ~/.claude.json for consistency with other clients (Claude Desktop, Cursor, etc.).

Alternative approach would be using claude mcp add-json CLI command, which offers better validation and forward compatibility but breaks the unified implementation pattern.

Open to feedback on preferred approach.

## Screenshot

<img width="1193" height="491" alt="image" src="https://github.com/user-attachments/assets/35f1657d-67d6-4ecd-b948-4fadd441eb33" />
