### PR TITLE
Change stderr output to whitelist approach

### DIFF
--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -406,8 +406,12 @@ writeLog // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*stderrEnabledQ*)
+(* stderr output causes issues with several clients, so we disable it unless we know it's safe to use *)
 stderrEnabledQ // beginDefinition;
-stderrEnabledQ[ ] := $clientName =!= "antigravity-client";
+stderrEnabledQ[ ] := stderrEnabledQ @ $clientName;
+stderrEnabledQ[ "claude-code" ] := True;
+stderrEnabledQ[ "claude-ai" ] := True;
+stderrEnabledQ[ _ ] := False;
 stderrEnabledQ // endDefinition;
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
## Summary

- Switch `stderrEnabledQ` from a blacklist approach to a whitelist approach for stderr output
- Only Claude Code and Claude AI clients now receive stderr output
- All other clients default to stderr disabled, as many have compatibility issues with it

## Test plan

- [x] Verify stderr output works correctly with Claude Code client
- [x] Verify stderr output works correctly with Claude AI client  
- [x] Verify stderr is disabled for other clients (e.g., Antigravity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)