### PR TITLE
Shorten paclet documentation tool names

### DIFF
--- a/Kernel/DefaultServers.wl
+++ b/Kernel/DefaultServers.wl
@@ -98,9 +98,9 @@ $defaultMCPServers[ "WolframPacletDevelopment" ] := <|
             "WriteNotebook",
             "SymbolDefinition",
             "TestReport",
-            "CreateSymbolPacletDocumentation",
-            "EditSymbolPacletDocumentation",
-            "EditSymbolPacletDocumentationExamples"
+            "CreateSymbolDoc",
+            "EditSymbolDoc",
+            "EditSymbolDocExamples"
         }
     |>
 |>;

--- a/Kernel/Tools/PacletDocumentation/PacletDocumentation.wl
+++ b/Kernel/Tools/PacletDocumentation/PacletDocumentation.wl
@@ -35,8 +35,8 @@ Returns the generated content as markdown for verification.";
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*CreateSymbolPacletDocumentation*)
-$defaultMCPTools[ "CreateSymbolPacletDocumentation" ] := LLMTool @ <|
-    "Name"        -> "CreateSymbolPacletDocumentation",
+$defaultMCPTools[ "CreateSymbolDoc" ] := LLMTool @ <|
+    "Name"        -> "CreateSymbolDoc",
     "DisplayName" -> "Create Symbol Documentation",
     "Description" -> $createSymbolDocDescription,
     "Function"    -> createSymbolPacletDocumentation,
@@ -118,8 +118,8 @@ $defaultMCPTools[ "CreateSymbolPacletDocumentation" ] := LLMTool @ <|
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*EditSymbolPacletDocumentation*)
-$defaultMCPTools[ "EditSymbolPacletDocumentation" ] := LLMTool @ <|
-    "Name"        -> "EditSymbolPacletDocumentation",
+$defaultMCPTools[ "EditSymbolDoc" ] := LLMTool @ <|
+    "Name"        -> "EditSymbolDoc",
     "DisplayName" -> "Edit Symbol Documentation",
     "Description" -> $editSymbolDocDescription,
     "Function"    -> editSymbolPacletDocumentation,
@@ -151,8 +151,8 @@ $defaultMCPTools[ "EditSymbolPacletDocumentation" ] := LLMTool @ <|
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*EditSymbolPacletDocumentationExamples*)
-$defaultMCPTools[ "EditSymbolPacletDocumentationExamples" ] := LLMTool @ <|
-    "Name"        -> "EditSymbolPacletDocumentationExamples",
+$defaultMCPTools[ "EditSymbolDocExamples" ] := LLMTool @ <|
+    "Name"        -> "EditSymbolDocExamples",
     "DisplayName" -> "Edit Symbol Documentation Examples",
     "Description" -> $editSymbolDocExamplesDescription,
     "Function"    -> editSymbolPacletDocumentationExamples,

--- a/Tests/PacletDocumentationTools.wlt
+++ b/Tests/PacletDocumentationTools.wlt
@@ -22,24 +22,24 @@ VerificationTest[
 (*Tool Retrieval*)
 
 VerificationTest[
-    $createDocTool = $DefaultMCPTools[ "CreateSymbolPacletDocumentation" ],
+    $createDocTool = $DefaultMCPTools[ "CreateSymbolDoc" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "CreateSymbolPacletDocumentation-GetTool@@Tests/PacletDocumentationTools.wlt:24,1-29,2"
+    TestID   -> "CreateSymbolDoc-GetTool@@Tests/PacletDocumentationTools.wlt:24,1-29,2"
 ]
 
 VerificationTest[
-    $editDocTool = $DefaultMCPTools[ "EditSymbolPacletDocumentation" ],
+    $editDocTool = $DefaultMCPTools[ "EditSymbolDoc" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "EditSymbolPacletDocumentation-GetTool@@Tests/PacletDocumentationTools.wlt:31,1-36,2"
+    TestID   -> "EditSymbolDoc-GetTool@@Tests/PacletDocumentationTools.wlt:31,1-36,2"
 ]
 
 VerificationTest[
-    $editExamplesTool = $DefaultMCPTools[ "EditSymbolPacletDocumentationExamples" ],
+    $editExamplesTool = $DefaultMCPTools[ "EditSymbolDocExamples" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "EditSymbolPacletDocumentationExamples-GetTool@@Tests/PacletDocumentationTools.wlt:38,1-43,2"
+    TestID   -> "EditSymbolDocExamples-GetTool@@Tests/PacletDocumentationTools.wlt:38,1-43,2"
 ]
 
 (* ::**************************************************************************************************************:: *)

--- a/Tests/Tools.wlt
+++ b/Tests/Tools.wlt
@@ -31,9 +31,9 @@ VerificationTest[
     Keys @ $DefaultMCPTools,
     {
         OrderlessPatternSequence[
-            "CreateSymbolPacletDocumentation",
-            "EditSymbolPacletDocumentation",
-            "EditSymbolPacletDocumentationExamples",
+            "CreateSymbolDoc",
+            "EditSymbolDoc",
+            "EditSymbolDocExamples",
             "ReadNotebook",
             "SymbolDefinition",
             "TestReport",


### PR DESCRIPTION
## Summary

- Renamed `CreateSymbolPacletDocumentation` to `CreateSymbolDoc`
- Renamed `EditSymbolPacletDocumentation` to `EditSymbolDoc`
- Renamed `EditSymbolPacletDocumentationExamples` to `EditSymbolDocExamples`

These shorter names improve usability when invoking the tools while maintaining clarity.

Closes #58

## Test plan

- [ ] Verify tools are accessible via new names in `$DefaultMCPTools`
- [ ] Run `Tests/PacletDocumentationTools.wlt` to confirm tool retrieval tests pass
- [ ] Run `Tests/Tools.wlt` to confirm tool listing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)