### PR TITLE
Add InstallMCPServer support for OpenAI Codex CLI

### DIFF
--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -51,7 +51,9 @@ BeginPackage[ "Wolfram`MCPServer`Common`" ];
 `throwTop;
 `validateMCPServerObjectData;
 `writeRawJSONFile;
+`writeTOMLFile;
 `writeWXFFile;
+`readTOMLFile;
 
 (* Shared symbols with Tools subcontexts: *)
 `exportMarkdownString;

--- a/Kernel/Files.wl
+++ b/Kernel/Files.wl
@@ -199,6 +199,246 @@ writeRawJSONFile // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
+(*TOML Support*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*readTOMLFile*)
+readTOMLFile // beginDefinition;
+
+readTOMLFile[ file_ ] := Enclose[
+    Module[ { content },
+        If[ ! FileExistsQ @ file, Throw[ <| |>, $tomlTag ] ];
+        content = ConfirmBy[ ReadString @ ExpandFileName @ file, StringQ, "Content" ];
+        ConfirmBy[ parseTOML @ content, AssociationQ, "Parse" ]
+    ] ~Catch~ $tomlTag,
+    throwInternalFailure
+];
+
+readTOMLFile // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*writeTOMLFile*)
+writeTOMLFile // beginDefinition;
+
+writeTOMLFile[ file_, data_Association ] := Enclose[
+    Module[ { toml, path },
+        toml = ConfirmBy[ serializeTOML @ data, StringQ, "Serialize" ];
+        path = ConfirmBy[ ensureFilePath @ file, fileQ, "Path" ];
+        ConfirmBy[ WriteString[ ExpandFileName @ path, toml ]; path, fileQ, "Write" ]
+    ],
+    throwInternalFailure
+];
+
+writeTOMLFile // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*parseTOML*)
+parseTOML // beginDefinition;
+
+parseTOML[ content_String ] := Enclose[
+    Module[ { lines, result, currentPath },
+        lines = StringSplit[ content, "\n" ];
+        result = <| |>;
+        currentPath = { };
+
+        Do[
+            With[ { parsed = parseTOMLLine[ line, currentPath ] },
+                Switch[ parsed,
+                    (* Section header *)
+                    { "Section", _List },
+                    currentPath = parsed[[ 2 ]],
+                    (* Key-value pair *)
+                    { "KeyValue", _String, _ },
+                    result = setNestedKey[ result, Append[ currentPath, parsed[[ 2 ]] ], parsed[[ 3 ]] ],
+                    (* Comment or empty line *)
+                    "Skip",
+                    Null,
+                    (* Unknown *)
+                    _,
+                    Null
+                ]
+            ],
+            { line, lines }
+        ];
+
+        result
+    ],
+    throwInternalFailure
+];
+
+parseTOML // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*parseTOMLLine*)
+parseTOMLLine // beginDefinition;
+
+(* Empty line or comment *)
+parseTOMLLine[ line_String, _ ] /; StringMatchQ[ StringTrim @ line, "" | ("#" ~~ ___) ] :=
+    "Skip";
+
+(* Section header: [section.name] *)
+parseTOMLLine[ line_String, _ ] /; StringMatchQ[ StringTrim @ line, "[" ~~ __ ~~ "]" ] :=
+    Module[ { trimmed, sectionName },
+        trimmed = StringTrim @ line;
+        sectionName = StringTake[ trimmed, { 2, -2 } ];
+        { "Section", StringSplit[ sectionName, "." ] }
+    ];
+
+(* Key-value pair *)
+parseTOMLLine[ line_String, currentPath_List ] :=
+    Module[ { trimmed, pos, key, value },
+        trimmed = StringTrim @ line;
+        (* Find first = sign *)
+        pos = StringPosition[ trimmed, "=", 1 ];
+        If[ pos === { },
+            "Skip",
+            key = StringTrim @ StringTake[ trimmed, pos[[ 1, 1 ]] - 1 ];
+            value = parseTOMLValue @ StringTrim @ StringDrop[ trimmed, pos[[ 1, 2 ]] ];
+            { "KeyValue", key, value }
+        ]
+    ];
+
+parseTOMLLine // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*parseTOMLValue*)
+parseTOMLValue // beginDefinition;
+
+(* Quoted string *)
+parseTOMLValue[ s_String ] /; StringMatchQ[ s, "\"" ~~ ___ ~~ "\"" ] :=
+    StringTake[ s, { 2, -2 } ] // StringReplace[ {
+        "\\\"" -> "\"",
+        "\\\\" -> "\\",
+        "\\n" -> "\n",
+        "\\t" -> "\t"
+    } ];
+
+(* Array *)
+parseTOMLValue[ s_String ] /; StringMatchQ[ s, "[" ~~ ___ ~~ "]" ] :=
+    Module[ { inner, elements },
+        inner = StringTrim @ StringTake[ s, { 2, -2 } ];
+        If[ inner === "", Return[ { } ] ];
+        elements = StringSplit[ inner, "," ];
+        parseTOMLValue /@ Map[ StringTrim, elements ]
+    ];
+
+(* Boolean *)
+parseTOMLValue[ "true" ] := True;
+parseTOMLValue[ "false" ] := False;
+
+(* Integer *)
+parseTOMLValue[ s_String ] /; StringMatchQ[ s, DigitCharacter.. | ("-" ~~ DigitCharacter..) ] :=
+    ToExpression @ s;
+
+(* Float *)
+parseTOMLValue[ s_String ] /; StringMatchQ[ s, NumberString ] :=
+    ToExpression @ s;
+
+(* Fallback: treat as unquoted string *)
+parseTOMLValue[ s_String ] := s;
+
+parseTOMLValue // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*setNestedKey*)
+setNestedKey // beginDefinition;
+
+setNestedKey[ assoc_Association, { key_ }, value_ ] :=
+    Append[ assoc, key -> value ];
+
+setNestedKey[ assoc_Association, { first_, rest__ }, value_ ] :=
+    Module[ { current },
+        current = Lookup[ assoc, first, <| |> ];
+        If[ ! AssociationQ @ current, current = <| |> ];
+        Append[ assoc, first -> setNestedKey[ current, { rest }, value ] ]
+    ];
+
+setNestedKey // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*serializeTOML*)
+serializeTOML // beginDefinition;
+
+serializeTOML[ data_Association ] := Enclose[
+    Module[ { lines },
+        lines = Flatten @ serializeTOMLSection[ data, { } ];
+        ConfirmBy[ StringRiffle[ lines, "\n" ] <> "\n", StringQ, "Result" ]
+    ],
+    throwInternalFailure
+];
+
+serializeTOML // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*serializeTOMLSection*)
+serializeTOMLSection // beginDefinition;
+
+serializeTOMLSection[ data_Association, path_List ] :=
+    Module[ { simpleKeys, nestedKeys, simpleLines, nestedLines },
+        (* Separate simple values from nested associations *)
+        simpleKeys = Select[ Keys @ data, ! AssociationQ[ data[ # ] ] & ];
+        nestedKeys = Select[ Keys @ data, AssociationQ[ data[ # ] ] & ];
+
+        (* Generate lines for simple key-values *)
+        simpleLines = KeyValueMap[
+            Function[ { k, v }, k <> " = " <> serializeTOMLValue @ v ],
+            KeyTake[ data, simpleKeys ]
+        ];
+
+        (* Generate lines for nested sections *)
+        nestedLines = Flatten @ Map[
+            Function[ key,
+                Module[ { newPath, header, content },
+                    newPath = Append[ path, key ];
+                    header = "[" <> StringRiffle[ newPath, "." ] <> "]";
+                    content = serializeTOMLSection[ data @ key, newPath ];
+                    { "", header, content }
+                ]
+            ],
+            nestedKeys
+        ];
+
+        (* Combine: simple values first (with section header if needed), then nested sections *)
+        If[ path =!= { } && simpleLines =!= { },
+            { simpleLines, nestedLines },
+            If[ path === { },
+                { simpleLines, nestedLines },
+                { simpleLines, nestedLines }
+            ]
+        ]
+    ];
+
+serializeTOMLSection // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*serializeTOMLValue*)
+serializeTOMLValue // beginDefinition;
+
+serializeTOMLValue[ s_String ] :=
+    "\"" <> StringReplace[ s, { "\\" -> "\\\\", "\"" -> "\\\"", "\n" -> "\\n", "\t" -> "\\t" } ] <> "\"";
+
+serializeTOMLValue[ True ] := "true";
+serializeTOMLValue[ False ] := "false";
+
+serializeTOMLValue[ n_Integer ] := ToString @ n;
+serializeTOMLValue[ n_Real ] := ToString @ n;
+
+serializeTOMLValue[ list_List ] :=
+    "[" <> StringRiffle[ serializeTOMLValue /@ list, ", " ] <> "]";
+
+serializeTOMLValue // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
 (*Package Footer*)
 addToMXInitialization[
     Null

--- a/Kernel/Messages.wl
+++ b/Kernel/Messages.wl
@@ -31,6 +31,8 @@ MCPServer::UninstallMCPServerNamed       = "Successfully uninstalled MCP server 
 MCPServer::UnknownInstallLocation        = "Unable to determine install location for `1` on `2`. Use File[\[Ellipsis]] to specify a custom location.";
 MCPServer::UnknownProjectInstallLocation = "Unable to determine project install location for `1`. Use File[\[Ellipsis]] to specify a custom location.";
 MCPServer::UnsupportedOperatingSystem    = "Unsupported operating system: `1`.";
+MCPServer::InvalidCodexConfiguration     = "Invalid Codex configuration file: `1`.";
+MCPServer::InvalidTOMLFormat             = "Invalid TOML format in file: `1`.";
 
 (* PacletDocumentation messages *)
 MCPServer::NotebookFileExists            = "Notebook already exists: `1`.";

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -455,3 +455,356 @@ VerificationTest[
     SameTest -> MatchQ,
     TestID   -> "InstallMCPServer-DevelopmentMode-Cleanup@@Tests/InstallMCPServer.wlt:452,1-457,2"
 ]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Codex Support*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*TOML Parsing*)
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+VerificationTest[
+    Wolfram`MCPServer`Files`Private`parseTOML[ "" ],
+    <| |>,
+    SameTest -> MatchQ,
+    TestID   -> "ParseTOML-EmptyString@@Tests/InstallMCPServer.wlt:470,1-475,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`Files`Private`parseTOML[ "# This is a comment\n\n" ],
+    <| |>,
+    SameTest -> MatchQ,
+    TestID   -> "ParseTOML-OnlyComments@@Tests/InstallMCPServer.wlt:477,1-482,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`Files`Private`parseTOML[ "key = \"value\"" ],
+    <| "key" -> "value" |>,
+    SameTest -> Equal,
+    TestID   -> "ParseTOML-SimpleKeyValue@@Tests/InstallMCPServer.wlt:484,1-489,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`Files`Private`parseTOML[ "[section]\nkey = \"value\"" ],
+    <| "section" -> <| "key" -> "value" |> |>,
+    SameTest -> Equal,
+    TestID   -> "ParseTOML-Section@@Tests/InstallMCPServer.wlt:491,1-496,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`Files`Private`parseTOML[ "[outer.inner]\nkey = \"value\"" ],
+    <| "outer" -> <| "inner" -> <| "key" -> "value" |> |> |>,
+    SameTest -> Equal,
+    TestID   -> "ParseTOML-NestedSection@@Tests/InstallMCPServer.wlt:498,1-503,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`Files`Private`parseTOML[ "args = [\"a\", \"b\", \"c\"]" ],
+    <| "args" -> { "a", "b", "c" } |>,
+    SameTest -> Equal,
+    TestID   -> "ParseTOML-StringArray@@Tests/InstallMCPServer.wlt:505,1-510,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`Files`Private`parseTOML[ "enabled = true\ndisabled = false" ],
+    <| "enabled" -> True, "disabled" -> False |>,
+    SameTest -> Equal,
+    TestID   -> "ParseTOML-Booleans@@Tests/InstallMCPServer.wlt:512,1-517,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`Files`Private`parseTOML[ "count = 42\nnegative = -5" ],
+    <| "count" -> 42, "negative" -> -5 |>,
+    SameTest -> Equal,
+    TestID   -> "ParseTOML-Integers@@Tests/InstallMCPServer.wlt:519,1-524,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*TOML Serialization*)
+
+VerificationTest[
+    Wolfram`MCPServer`Files`Private`serializeTOML[ <| |> ],
+    "\n",
+    SameTest -> Equal,
+    TestID   -> "SerializeTOML-Empty@@Tests/InstallMCPServer.wlt:530,1-535,2"
+]
+
+VerificationTest[
+    StringContainsQ[
+        Wolfram`MCPServer`Files`Private`serializeTOML[ <| "key" -> "value" |> ],
+        "key = \"value\""
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "SerializeTOML-SimpleKeyValue@@Tests/InstallMCPServer.wlt:537,1-545,2"
+]
+
+VerificationTest[
+    StringContainsQ[
+        Wolfram`MCPServer`Files`Private`serializeTOML[ <| "section" -> <| "key" -> "value" |> |> ],
+        "[section]"
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "SerializeTOML-SectionHeader@@Tests/InstallMCPServer.wlt:547,1-555,2"
+]
+
+VerificationTest[
+    StringContainsQ[
+        Wolfram`MCPServer`Files`Private`serializeTOML[ <| "args" -> { "a", "b" } |> ],
+        "args = [\"a\", \"b\"]"
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "SerializeTOML-Array@@Tests/InstallMCPServer.wlt:557,1-565,2"
+]
+
+VerificationTest[
+    StringContainsQ[
+        Wolfram`MCPServer`Files`Private`serializeTOML[ <| "flag" -> True |> ],
+        "flag = true"
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "SerializeTOML-Boolean@@Tests/InstallMCPServer.wlt:567,1-575,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*TOML Round-Trip*)
+
+VerificationTest[
+    Module[ { original, serialized, parsed },
+        original = <|
+            "mcp_servers" -> <|
+                "wolfram" -> <|
+                    "command" -> "wolframscript",
+                    "args" -> { "-run", "test", "-noinit" },
+                    "env" -> <| "VAR" -> "value" |>
+                |>
+            |>
+        |>;
+        serialized = Wolfram`MCPServer`Files`Private`serializeTOML @ original;
+        parsed = Wolfram`MCPServer`Files`Private`parseTOML @ serialized;
+        parsed
+    ],
+    <| "mcp_servers" -> <| "wolfram" -> <| "command" -> "wolframscript", "args" -> { "-run", "test", "-noinit" }, "env" -> <| "VAR" -> "value" |> |> |> |>,
+    SameTest -> Equal,
+    TestID   -> "TOML-RoundTrip@@Tests/InstallMCPServer.wlt:581,1-599,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Codex Install Location*)
+
+VerificationTest[
+    Wolfram`MCPServer`InstallMCPServer`Private`installLocation[ "Codex", "Windows" ],
+    _File,
+    SameTest -> MatchQ,
+    TestID   -> "InstallLocation-Codex-Windows@@Tests/InstallMCPServer.wlt:605,1-610,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`InstallMCPServer`Private`installLocation[ "Codex", "MacOSX" ],
+    _File,
+    SameTest -> MatchQ,
+    TestID   -> "InstallLocation-Codex-MacOSX@@Tests/InstallMCPServer.wlt:612,1-617,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`InstallMCPServer`Private`installLocation[ "Codex", "Unix" ],
+    _File,
+    SameTest -> MatchQ,
+    TestID   -> "InstallLocation-Codex-Unix@@Tests/InstallMCPServer.wlt:619,1-624,2"
+]
+
+VerificationTest[
+    StringEndsQ[ First @ Wolfram`MCPServer`InstallMCPServer`Private`installLocation[ "Codex", "Windows" ], "config.toml" ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallLocation-Codex-EndsWithTOML@@Tests/InstallMCPServer.wlt:626,1-631,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`InstallMCPServer`Private`installDisplayName[ "Codex" ],
+    "Codex",
+    SameTest -> Equal,
+    TestID   -> "InstallDisplayName-Codex@@Tests/InstallMCPServer.wlt:633,1-638,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`InstallMCPServer`Private`toInstallName[ "codex" ],
+    "Codex",
+    SameTest -> Equal,
+    TestID   -> "ToInstallName-codex@@Tests/InstallMCPServer.wlt:640,1-645,2"
+]
+
+VerificationTest[
+    Wolfram`MCPServer`InstallMCPServer`Private`toInstallName[ "OpenAICodex" ],
+    "Codex",
+    SameTest -> Equal,
+    TestID   -> "ToInstallName-OpenAICodex@@Tests/InstallMCPServer.wlt:647,1-652,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Codex Install and Uninstall*)
+
+(* Setup a temporary TOML file to use for testing Codex installations *)
+testCodexConfigFile = Function[
+    File @ FileNameJoin @ { $TemporaryDirectory, StringJoin["codex_test_config_", CreateUUID[], ".toml"] }
+];
+
+VerificationTest[
+    codexConfigFile = testCodexConfigFile[];
+    Block[ { Wolfram`MCPServer`InstallMCPServer`Private`$installName = "Codex" },
+        InstallMCPServer[ codexConfigFile, "WolframLanguage" ]
+    ],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Codex-Basic@@Tests/InstallMCPServer.wlt:665,1-673,2"
+]
+
+VerificationTest[
+    FileExistsQ[ codexConfigFile ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Codex-FileExists@@Tests/InstallMCPServer.wlt:675,1-680,2"
+]
+
+VerificationTest[
+    Module[ { content, parsed },
+        content = ReadString @ First @ codexConfigFile;
+        parsed = Wolfram`MCPServer`Files`Private`parseTOML @ content;
+        KeyExistsQ[ parsed, "mcp_servers" ] && KeyExistsQ[ parsed[ "mcp_servers" ], "WolframLanguage" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Codex-VerifyContent@@Tests/InstallMCPServer.wlt:682,1-691,2"
+]
+
+VerificationTest[
+    Module[ { content, parsed },
+        content = ReadString @ First @ codexConfigFile;
+        parsed = Wolfram`MCPServer`Files`Private`parseTOML @ content;
+        KeyExistsQ[ parsed[ "mcp_servers", "WolframLanguage" ], "command" ] &&
+        KeyExistsQ[ parsed[ "mcp_servers", "WolframLanguage" ], "args" ] &&
+        KeyExistsQ[ parsed[ "mcp_servers", "WolframLanguage" ], "env" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Codex-HasRequiredFields@@Tests/InstallMCPServer.wlt:693,1-704,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`MCPServer`InstallMCPServer`Private`$installName = "Codex" },
+        UninstallMCPServer[ codexConfigFile, "WolframLanguage" ]
+    ],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "UninstallMCPServer-Codex-Basic@@Tests/InstallMCPServer.wlt:706,1-713,2"
+]
+
+VerificationTest[
+    Module[ { content, parsed },
+        content = ReadString @ First @ codexConfigFile;
+        parsed = Wolfram`MCPServer`Files`Private`parseTOML @ content;
+        KeyExistsQ[ parsed, "mcp_servers" ] && ! KeyExistsQ[ parsed[ "mcp_servers" ], "WolframLanguage" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "UninstallMCPServer-Codex-VerifyRemoved@@Tests/InstallMCPServer.wlt:715,1-724,2"
+]
+
+VerificationTest[
+    cleanupTestFiles[ codexConfigFile ],
+    { Null },
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Codex-Cleanup@@Tests/InstallMCPServer.wlt:726,1-731,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Codex Install With Existing Config*)
+
+VerificationTest[
+    codexConfigFile = testCodexConfigFile[];
+    (* Create a config file with existing settings *)
+    WriteString[
+        First @ codexConfigFile,
+        "model = \"gpt-4\"\napproval_mode = \"suggest\"\n\n[other_section]\nkey = \"value\"\n"
+    ];
+    Close @ First @ codexConfigFile;
+    Block[ { Wolfram`MCPServer`InstallMCPServer`Private`$installName = "Codex" },
+        InstallMCPServer[ codexConfigFile, "WolframLanguage" ]
+    ],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Codex-PreservesExisting@@Tests/InstallMCPServer.wlt:737,1-751,2"
+]
+
+VerificationTest[
+    Module[ { content, parsed },
+        content = ReadString @ First @ codexConfigFile;
+        parsed = Wolfram`MCPServer`Files`Private`parseTOML @ content;
+        (* Check both old settings and new server are present *)
+        parsed[ "model" ] === "gpt-4" &&
+        KeyExistsQ[ parsed[ "other_section" ], "key" ] &&
+        KeyExistsQ[ parsed[ "mcp_servers", "WolframLanguage" ], "command" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Codex-VerifyPreserved@@Tests/InstallMCPServer.wlt:753,1-765,2"
+]
+
+VerificationTest[
+    cleanupTestFiles[ codexConfigFile ],
+    { Null },
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Codex-CleanupPreserved@@Tests/InstallMCPServer.wlt:767,1-772,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Codex Install With Environment Variables*)
+
+VerificationTest[
+    codexConfigFile = testCodexConfigFile[];
+    Block[ { Wolfram`MCPServer`InstallMCPServer`Private`$installName = "Codex" },
+        InstallMCPServer[
+            codexConfigFile,
+            "WolframLanguage",
+            ProcessEnvironment -> <| "CUSTOM_VAR" -> "custom_value" |>
+        ]
+    ],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Codex-WithEnv@@Tests/InstallMCPServer.wlt:778,1-790,2"
+]
+
+VerificationTest[
+    Module[ { content, parsed, env },
+        content = ReadString @ First @ codexConfigFile;
+        parsed = Wolfram`MCPServer`Files`Private`parseTOML @ content;
+        env = parsed[ "mcp_servers", "WolframLanguage", "env" ];
+        KeyExistsQ[ env, "CUSTOM_VAR" ] && env[ "CUSTOM_VAR" ] === "custom_value" &&
+        KeyExistsQ[ env, "MCP_SERVER_NAME" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Codex-VerifyEnv@@Tests/InstallMCPServer.wlt:792,1-803,2"
+]
+
+VerificationTest[
+    cleanupTestFiles[ codexConfigFile ],
+    { Null },
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Codex-CleanupEnv@@Tests/InstallMCPServer.wlt:805,1-810,2"
+]


### PR DESCRIPTION
## Summary

- Add support for installing MCP servers to OpenAI Codex CLI, which uses TOML configuration at `~/.codex/config.toml`
- Implement pure Wolfram Language TOML parser and serializer (no external dependencies)
- Add Codex-specific install and uninstall handlers that work with TOML format

## Changes

**TOML Support (`Kernel/Files.wl`):**
- `readTOMLFile[file]` - Parse TOML file into nested Association
- `writeTOMLFile[file, data]` - Write Association to TOML format
- Support for strings, arrays, booleans, integers, sections, and comments

**Codex Client Registration (`Kernel/InstallMCPServer.wl`):**
- Install location: `~/.codex/config.toml`
- Name mappings: `"codex"`, `"OpenAICodex"` → `"Codex"`
- Codex-specific install/uninstall logic using TOML

**Other:**
- Error messages for Codex/TOML handling in `Messages.wl`
- Symbol exports in `CommonSymbols.wl`

## Test plan

- [x] TOML parsing tests (empty, comments, key-values, sections, arrays, booleans, integers)
- [x] TOML serialization tests
- [x] TOML round-trip consistency test
- [x] Codex install location resolution tests (Windows, MacOSX, Unix)
- [x] Codex install and uninstall operations
- [x] Preserving existing Codex config settings
- [x] Environment variables handling

Run tests with:
```wl
TestReport["Tests/InstallMCPServer.wlt"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)