### PR TITLE
Replace Return with Catch/Throw and add linting rule

### DIFF
--- a/Kernel/TOML.wl
+++ b/Kernel/TOML.wl
@@ -235,9 +235,9 @@ parseTOMLValue // endDefinition;
 parseTOMLArray // beginDefinition;
 
 parseTOMLArray[ s_String ] := Enclose[
-    Module[ { inner, elements },
+    Catch @ Module[ { inner, elements },
         inner = StringTrim @ StringTake[ s, { 2, -2 } ];
-        If[ inner === "", Return[ { }, Module ] ];
+        If[ inner === "", Throw @ { } ];
         elements = splitTOMLElements[ inner, "," ];
         ConfirmMatch[ parseTOMLValue /@ elements, { ___? validTOMLValueQ }, "Elements" ]
     ],
@@ -305,9 +305,9 @@ splitTOMLElements // endDefinition;
 parseTOMLInlineTable // beginDefinition;
 
 parseTOMLInlineTable[ s_String ] := Enclose[
-    Module[ { inner, pairs, result },
+    Catch @ Module[ { inner, pairs, result },
         inner = StringTrim @ StringTake[ s, { 2, -2 } ];
-        If[ inner === "", Return[ <| |>, Module ] ];
+        If[ inner === "", Throw @ <| |> ];
         pairs = splitTOMLElements[ inner, "," ];
         result = <| |>;
         Do[
@@ -424,10 +424,10 @@ buildOutputLines // endDefinition;
 generateMCPServerLines // beginDefinition;
 
 generateMCPServerLines[ data_Association ] := Enclose[
-    Module[ { mcpServers, lines },
+    Catch @ Module[ { mcpServers, lines },
         mcpServers = Lookup[ data, "mcp_servers", <| |> ];
         If[ ! AssociationQ @ mcpServers || mcpServers === <| |>,
-            Return[ { }, Module ]
+            Throw @ { }
         ];
 
         lines = Flatten @ KeyValueMap[

--- a/Kernel/Tools/PacletDocumentation/EditSymbolPacletDocumentation.wl
+++ b/Kernel/Tools/PacletDocumentation/EditSymbolPacletDocumentation.wl
@@ -203,12 +203,12 @@ replaceNotesCells // endDefinition;
 replaceNotesInGroup // beginDefinition;
 
 replaceNotesInGroup[ groupCells_List, notesCells_List ] :=
-    Module[ { usagePos, beforeNotes },
+    Catch @ Module[ { usagePos, beforeNotes },
         (* Find Usage position *)
         usagePos = FirstPosition[ groupCells, Cell[ _, "Usage", ___ ], None, { 1 } ];
 
         If[ usagePos === None,
-            Return @ groupCells
+            Throw @ groupCells
         ];
 
         (* Take cells up to and including Usage *)
@@ -290,11 +290,11 @@ insertNoteCell // endDefinition;
 insertNoteInGroup // beginDefinition;
 
 insertNoteInGroup[ groupCells_List, noteCell_Cell, position_ ] :=
-    Module[ { usagePos, existingNotes, insertPos, beforeInsert, afterInsert },
+    Catch @ Module[ { usagePos, existingNotes, insertPos, beforeInsert, afterInsert },
         usagePos = FirstPosition[ groupCells, Cell[ _, "Usage", ___ ], None, { 1 } ];
 
         If[ usagePos === None,
-            Return @ groupCells
+            Throw @ groupCells
         ];
 
         (* Get existing notes (all cells after Usage) *)
@@ -318,7 +318,7 @@ insertNoteInGroup // endDefinition;
 setDetailsTableInNotebook // beginDefinition;
 
 setDetailsTableInNotebook[ Notebook[ cells_List, opts___ ], tableMarkdown_String, position_ ] := Enclose[
-    Module[ { tableCells, newCells },
+    Catch @ Module[ { tableCells, newCells },
         (* Generate cells from the markdown, which may include text before the table *)
         tableCells = ConfirmMatch[
             generateNotesCells @ tableMarkdown,
@@ -327,7 +327,7 @@ setDetailsTableInNotebook[ Notebook[ cells_List, opts___ ], tableMarkdown_String
         ];
 
         If[ Length @ tableCells === 0,
-            Return @ Notebook[ cells, opts ]
+            Throw @ Notebook[ cells, opts ]
         ];
 
         newCells = ConfirmMatch[
@@ -361,11 +361,11 @@ insertNotesCells // endDefinition;
 insertNotesInGroup // beginDefinition;
 
 insertNotesInGroup[ groupCells_List, noteCells_List, position_ ] :=
-    Module[ { usagePos, existingNotes, insertPos, beforeInsert, afterInsert },
+    Catch @ Module[ { usagePos, existingNotes, insertPos, beforeInsert, afterInsert },
         usagePos = FirstPosition[ groupCells, Cell[ _, "Usage", ___ ], None, { 1 } ];
 
         If[ usagePos === None,
-            Return @ groupCells
+            Throw @ groupCells
         ];
 
         (* Get existing notes (all cells after Usage) *)
@@ -463,11 +463,11 @@ replaceCellsInSection // endDefinition;
 replaceSectionContent // beginDefinition;
 
 replaceSectionContent[ groupCells_List, headerStyle_String, contentStyle_String, newContentCells_List ] :=
-    Module[ { headerPos, header },
+    Catch @ Module[ { headerPos, header },
         headerPos = FirstPosition[ groupCells, Cell[ _, headerStyle, ___ ], None, { 1 } ];
 
         If[ headerPos === None,
-            Return @ groupCells
+            Throw @ groupCells
         ];
 
         header = groupCells[[ First @ headerPos ]];
@@ -848,7 +848,7 @@ insertInExtendedExamplesSection // endDefinition;
 insertInExampleSection // beginDefinition;
 
 insertInExampleSection[ groupCells_List, sectionTitle_String, newCells_List, mode_String ] := Enclose[
-    Module[ { sectionIndex, beforeSection, sectionCell, afterSection, modifiedSection },
+    Catch @ Module[ { sectionIndex, beforeSection, sectionCell, afterSection, modifiedSection },
 
         (* Find the index of the target section *)
         sectionIndex = FirstPosition[
@@ -860,7 +860,7 @@ insertInExampleSection[ groupCells_List, sectionTitle_String, newCells_List, mod
 
         If[ sectionIndex === None,
             (* Section not found, return cells unchanged *)
-            Return @ groupCells
+            Throw @ groupCells
         ];
 
         sectionIndex = First @ sectionIndex;
@@ -957,7 +957,7 @@ clearExtendedExamplesSection // endDefinition;
 clearExamplesFromExtendedSection // beginDefinition;
 
 clearExamplesFromExtendedSection[ groupCells_List, sectionTitle_String ] := Enclose[
-    Module[ { sectionIndex, sectionEndIndex, newCells },
+    Catch @ Module[ { sectionIndex, sectionEndIndex, newCells },
 
         sectionIndex = FirstPosition[
             groupCells,
@@ -967,7 +967,7 @@ clearExamplesFromExtendedSection[ groupCells_List, sectionTitle_String ] := Encl
         ];
 
         If[ sectionIndex === None,
-            Return @ groupCells
+            Throw @ groupCells
         ];
 
         sectionIndex = First @ sectionIndex;

--- a/Kernel/Tools/PacletDocumentation/EditSymbolPacletDocumentationExamples.wl
+++ b/Kernel/Tools/PacletDocumentation/EditSymbolPacletDocumentationExamples.wl
@@ -234,7 +234,7 @@ insertAtPositionInExtendedExamples // endDefinition;
 insertInExtendedSectionAtPosition // beginDefinition;
 
 insertInExtendedSectionAtPosition[ groupCells_List, sectionTitle_String, newCells_List, position_Integer ] := Enclose[
-    Module[ { sectionIndex, sectionEndIndex, sectionContent, groups, insertedContent, newSectionContent },
+    Catch @ Module[ { sectionIndex, sectionEndIndex, sectionContent, groups, insertedContent, newSectionContent },
 
         (* Find the section header *)
         sectionIndex = FirstPosition[
@@ -245,7 +245,7 @@ insertInExtendedSectionAtPosition[ groupCells_List, sectionTitle_String, newCell
         ];
 
         If[ sectionIndex === None,
-            Return @ groupCells
+            Throw @ groupCells
         ];
 
         sectionIndex = First @ sectionIndex;
@@ -485,7 +485,7 @@ replaceAtPositionInExtendedExamples // endDefinition;
 replaceInExtendedSectionAtPosition // beginDefinition;
 
 replaceInExtendedSectionAtPosition[ groupCells_List, sectionTitle_String, newCells_List, position_Integer ] := Enclose[
-    Module[ { sectionIndex, sectionEndIndex, sectionContent, groups, replacedContent, newSectionContent },
+    Catch @ Module[ { sectionIndex, sectionEndIndex, sectionContent, groups, replacedContent, newSectionContent },
 
         sectionIndex = FirstPosition[
             groupCells,
@@ -495,7 +495,7 @@ replaceInExtendedSectionAtPosition[ groupCells_List, sectionTitle_String, newCel
         ];
 
         If[ sectionIndex === None,
-            Return @ groupCells
+            Throw @ groupCells
         ];
 
         sectionIndex = First @ sectionIndex;
@@ -539,13 +539,13 @@ replaceExampleGroupAtPosition // endDefinition;
 replaceExampleGroupAtList // beginDefinition;
 
 replaceExampleGroupAtList[ groups_List, newCells_List, position_Integer ] :=
-    Module[ { pos, before, after, result },
+    Catch @ Module[ { pos, before, after, result },
         (* Normalize position using 1-indexed with negative support *)
         pos = normalizeElementPosition[ position, Length @ groups ];
 
         If[ Length @ groups === 0,
             (* No existing groups, just add the new cells *)
-            Return @ newCells
+            Throw @ newCells
         ];
 
         before = Take[ groups, pos - 1 ];
@@ -650,7 +650,7 @@ removeAtPositionInExtendedExamples // endDefinition;
 removeInExtendedSectionAtPosition // beginDefinition;
 
 removeInExtendedSectionAtPosition[ groupCells_List, sectionTitle_String, position_Integer ] := Enclose[
-    Module[ { sectionIndex, sectionEndIndex, sectionContent, groups, removedContent, newSectionContent },
+    Catch @ Module[ { sectionIndex, sectionEndIndex, sectionContent, groups, removedContent, newSectionContent },
 
         sectionIndex = FirstPosition[
             groupCells,
@@ -660,7 +660,7 @@ removeInExtendedSectionAtPosition[ groupCells_List, sectionTitle_String, positio
         ];
 
         If[ sectionIndex === None,
-            Return @ groupCells
+            Throw @ groupCells
         ];
 
         sectionIndex = First @ sectionIndex;
@@ -704,12 +704,12 @@ removeExampleGroupAtPosition // endDefinition;
 removeExampleGroupAtList // beginDefinition;
 
 removeExampleGroupAtList[ groups_List, position_Integer ] :=
-    Module[ { pos, remaining },
+    Catch @ Module[ { pos, remaining },
         (* Normalize position using 1-indexed with negative support *)
         pos = normalizeElementPosition[ position, Length @ groups ];
 
         If[ Length @ groups === 0,
-            Return @ { }
+            Throw @ { }
         ];
 
         remaining = Delete[ groups, pos ];

--- a/Scripts/Resources/CodeInspectorRules.wl
+++ b/Scripts/Resources/CodeInspectorRules.wl
@@ -14,6 +14,7 @@ $inGitHub := $inGitHub = StringQ @ Environment[ "GITHUB_ACTIONS" ];
 CodeInspector`AbstractRules`$DefaultAbstractRules = <|
     CodeInspector`AbstractRules`$DefaultAbstractRules,
     cp`CallNode[ cp`LeafNode[ Symbol, "Throw", _ ], { _ }, _ ] -> scanSingleArgThrow,
+    CodeParser`CallNode[ CodeParser`LeafNode[ Symbol, "Return"|"System`Return", _ ], _, _ ] -> scanReturn,
     cp`LeafNode[ Symbol, _String? privateContextQ, _ ] -> scanPrivateContext,
     cp`LeafNode[ Symbol, _String? globalSymbolQ, _ ] -> scanGlobalSymbol
 |>;
@@ -58,6 +59,22 @@ walkASTForCatch[ cp`CallNode[ cp`LeafNode[ Symbol, "Catch"|"Hold"|"HoldForm"|"Ho
 
 walkASTForCatch[ ast_, pos_ ] :=
     Extract[ ast, pos ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*scanReturn*)
+scanReturn // ClearAll;
+scanReturn[ pos_, ast_ ] :=
+    Enclose @ Module[ { node, as },
+        node = ConfirmMatch[ Extract[ ast, pos ], _[ _, _, __ ], "Node" ];
+        as = ConfirmBy[ node[[ 3 ]], AssociationQ, "Metadata" ];
+        ci`InspectionObject[
+            "ReturnAmbiguous",
+            "The return point of ``Return`` is ambiguous, consider using ``Catch``/``Throw`` instead",
+            "Warning",
+            <| as, ConfidenceLevel -> 0.9 |>
+        ]
+    ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)


### PR DESCRIPTION
## Summary

- Replace ambiguous `Return` statements with explicit `Catch`/`Throw` patterns in TOML parsing and paclet documentation editing functions
- Add a new CodeInspector rule (`scanReturn`) that warns about `Return` usage, encouraging `Catch`/`Throw` instead

## Motivation

The return point of `Return` can be ambiguous in Wolfram Language, especially within `Module` or nested control structures. Using explicit `Catch`/`Throw` makes the control flow clearer and follows the project's coding guidelines (see AGENTS.md).

## Changes

- **Kernel/TOML.wl**: Updated `parseTOMLArray`, `parseTOMLInlineTable`, and `generateMCPServerLines`
- **Kernel/Tools/PacletDocumentation/EditSymbolPacletDocumentation.wl**: Updated multiple functions including `replaceNotesInGroup`, `insertNoteInGroup`, `setDetailsTableInNotebook`, `insertNotesInGroup`, `replaceSectionContent`, `insertInExampleSection`, and `clearExamplesFromExtendedSection`
- **Kernel/Tools/PacletDocumentation/EditSymbolPacletDocumentationExamples.wl**: Updated `insertInExtendedSectionAtPosition`, `replaceInExtendedSectionAtPosition`, `replaceExampleGroupAtList`, `removeInExtendedSectionAtPosition`, and `removeExampleGroupAtList`
- **Scripts/Resources/CodeInspectorRules.wl**: Added `scanReturn` rule to detect and warn about `Return` usage

## Test plan

- [ ] Run existing tests to ensure no regressions: `TestReport` on the Tests directory
- [ ] Build the paclet with `Scripts/BuildPaclet.wls -c` to verify the new linting rule catches any remaining `Return` usage
- [ ] Manually verify TOML parsing still works correctly
- [ ] Verify paclet documentation editing tools function as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)