### PR TITLE
Bugfix: Avoid unnecessary FrontEnd startup during server initialization

### DIFF
--- a/Kernel/Common.wl
+++ b/Kernel/Common.wl
@@ -604,7 +604,7 @@ debugData[ as_Association? AssociationQ ] := <|
     KeyTake[ as, { "Name", "Version" } ],
     "ReleaseID"             -> $releaseID,
     "EvaluationEnvironment" -> $EvaluationEnvironment,
-    "FrontEndVersion"       -> $frontEndVersion,
+    "FrontEndVersion"       -> If[ TrueQ @ $Notebooks, $frontEndVersion, "None" ],
     "KernelVersion"         -> SystemInformation[ "Kernel", "Version" ],
     "SystemID"              -> $SystemID,
     "Notebooks"             -> $Notebooks,

--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -4,7 +4,6 @@ BeginPackage[ "Wolfram`MCPServer`Common`" ];
 `$catchTopTag;
 `$cloudNotebooks;
 `$debug;
-`$debugData;
 `$defaultMCPServer;
 `$imagePath;
 `$objectVersion;


### PR DESCRIPTION
## Summary

- Avoids an unnecessary call to `UsingFrontEnd[...]` when starting the MCP server without a notebook frontend
- Removes unused `$debugData` symbol from `CommonSymbols.wl`

When `$Notebooks` is `False` (i.e., running without a frontend), the `$frontEndVersion` lookup would previously trigger an unnecessary frontend startup. This change conditionally returns `"None"` instead, improving server startup performance in headless environments.

## Test plan

- [ ] Start the MCP server without a frontend and verify no frontend process is spawned
- [ ] Start the MCP server with a frontend and verify `$frontEndVersion` is still correctly reported
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)