### PR TITLE
Fix CodeInspector tool failing when running from MX build

### DIFF
--- a/Kernel/Tools/CodeInspector/Inspection.wl
+++ b/Kernel/Tools/CodeInspector/Inspection.wl
@@ -22,6 +22,10 @@ codeInspect // beginDefinition;
 codeInspect[ code: _String | File[ _String ], opts_Association ] := Enclose[
     Module[ { abstractRules, concreteRules, aggregateRules, tagExclusions, severityExclusions, confidenceLevel },
 
+        (* We need to make sure CodeInspector is loaded at runtime, since we might be running from an MX build *)
+        Needs[ "CodeInspector`" -> None ];
+        Needs[ "CodeParser`"    -> None ];
+
         abstractRules  = ConfirmBy[ $abstractRules , AssociationQ, "AbstractRules"  ];
         concreteRules  = ConfirmBy[ $concreteRules , AssociationQ, "ConcreteRules"  ];
         aggregateRules = ConfirmBy[ $aggregateRules, AssociationQ, "AggregateRules" ];


### PR DESCRIPTION
## Summary
- Add explicit `Needs` calls for `CodeInspector`` and `CodeParser`` at runtime in the CodeInspector tool
- Fixes issue where the tool fails when running from an MX build because these packages may not be loaded even though the code references their symbols

## Test plan
- [ ] Build an MX file with `Scripts/BuildMX.wls`
- [ ] Start the MCP server from the MX build
- [ ] Run the CodeInspector tool and verify it works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)