### PR TITLE
docs: align developer docs with codebase and client paths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This is the developer documentation for contributing to AgentTools. For user doc
 
 ## Core Concepts
 
-- **[Error Handling](error-handling.md)** - Error handling architecture using `catchTop`, `throwFailure`, and the `Enclose`/`Confirm` pattern
+- **[Error Handling](error-handling.md)** - Error handling architecture using `catchTop`, `catchMine`, `throwFailure`, and the `Enclose`/`Confirm` pattern
 - **[MCP Tools](tools.md)** - How MCP tools work, tool options, and how to add new tools
 - **[MCP Prompts](mcp-prompts.md)** - How MCP prompts work and how to add new prompts
 - **[MCP Apps](mcp-apps.md)** - Interactive UI resources for supported clients
@@ -31,5 +31,6 @@ This is the developer documentation for contributing to AgentTools. For user doc
 
 ## Additional Resources
 
+- [Docker](docker.md) - Running the Wolfram MCP server in containers
 - [AGENTS.md](../AGENTS.md) - Detailed development guidelines and AI agent guidance
 - [README.md](../README.md) - Project overview and quick start for users

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -105,7 +105,7 @@ docker run -i --rm `
 
 ### Claude Desktop
 
-Add to `~/.config/claude/claude_desktop_config.json` (Linux) or `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
+Add to `~/.config/Claude/claude_desktop_config.json` (Linux; adjust if your install uses a different path) or `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
 
 ```json
 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,20 +158,34 @@ AgentTools/
 ├── Assets/                    # Static assets bundled with the paclet
 │   └── Apps/                  # HTML/JSON files for MCP Apps UI resources
 ├── Kernel/                    # Core implementation
-│   ├── AgentTools.wl          # Main entry point
+│   ├── AgentTools.wl          # Main entry point (MX or Main.wl)
+│   ├── AgentToolsLoader.wl    # Reload and symbol cleanup for development
 │   ├── Main.wl                # Package loading, exported symbols
 │   ├── Common.wl              # Utilities and [error handling](error-handling.md)
+│   ├── CommonSymbols.wl       # Shared symbols between paclet files
 │   ├── CreateMCPServer.wl     # Server creation
-│   ├── StartMCPServer.wl      # Server startup
-│   ├── UIResources.wl         # MCP Apps UI resource registry
+│   ├── DefaultServers.wl      # Predefined named MCP servers
+│   ├── DeployAgentTools.wl    # Managed deployments to MCP clients
+│   ├── Files.wl               # File helpers
+│   ├── Formatting.wl          # Notebook formatting
+│   ├── InstallMCPServer.wl    # Install into supported MCP clients
+│   ├── MCPServerObject.wl     # MCP server object implementation
 │   ├── Messages.wl            # Error messages
-│   └── Tools/                 # Predefined MCP tools
+│   ├── PacletExtension.wl     # Third-party paclet extension loading
+│   ├── StartMCPServer.wl      # Server startup
+│   ├── SupportedClients.wl    # MCP client metadata and install paths
+│   ├── UIResources.wl         # MCP Apps UI resource registry
+│   ├── ValidateAgentToolsPacletExtension.wl  # Extension validation
+│   ├── Utilities.wl           # General utilities
+│   ├── Tools/                 # Predefined MCP tools
+│   └── Prompts/               # Predefined MCP prompts
 ├── Scripts/                   # Build and utility scripts
 ├── AgentSkills/               # Distributable agent skills (see [agent-skills.md](agent-skills.md))
 │   ├── Manifest.wl            # Tool-to-skill mapping
 │   ├── References/            # Shared reference files
 │   └── Skills/                # Generated skill directories
 ├── Tests/                     # Test files (.wlt)
+├── TestResources/             # Mock paclets and fixtures for tests
 ├── Specs/                     # Design specifications for features
 ├── Notes/                     # Development notes and design explorations
 ├── Documentation/             # Paclet documentation notebooks

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -79,6 +79,9 @@ UninstallMCPServer[myServerObject]               (* Remove from all locations *)
 |----|----------------|
 | macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
 | Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | Not registered for automatic install (see note below) |
+
+**Linux:** `InstallMCPServer["ClaudeDesktop"]` only resolves install paths on macOS and Windows (`Kernel/SupportedClients.wl`). On Linux, install manually or pass an explicit file, for example ``InstallMCPServer[File["~/.config/Claude/claude_desktop_config.json"]]`` (adjust the path if your Claude app stores its config elsewhere).
 
 **Format:**
 ```json

--- a/docs/quickstart-chat.md
+++ b/docs/quickstart-chat.md
@@ -30,6 +30,7 @@ This installs the default Wolfram server into Claude Desktop's configuration fil
 |----|------|
 | macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
 | Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | Use ``InstallMCPServer[File["/path/to/claude_desktop_config.json"]]`` — automatic resolution for `"ClaudeDesktop"` is not registered on Linux (see [mcp-clients.md](mcp-clients.md#claude-desktop)). A common location is `~/.config/Claude/claude_desktop_config.json`. |
 
 After installation, **fully restart Claude Desktop** to load the new tools.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -95,7 +95,7 @@ Run multiple test files:
 wolframscript -f Scripts/TestPaclet.wls Tests/CreateMCPServer.wlt Tests/StartMCPServer.wlt
 ```
 
-**Path resolution**: The script accepts both absolute paths and paths relative to the paclet root directory. For example, `Tests/Foo.wlt` is equivalent to the full path `H:\Documents\AgentTools\Tests\Foo.wlt`.
+**Path resolution**: The script accepts both absolute paths and paths relative to the paclet root directory (the repository root). For example, if the paclet lives at `/path/to/AgentTools`, then `Tests/Foo.wlt` resolves to `/path/to/AgentTools/Tests/Foo.wlt`.
 
 ## Unit Tests for Private Symbols
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This updates developer documentation in `docs/` for accuracy against the current repository layout and `InstallMCPServer` behavior.

## Changes

- **README.md**: Error handling bullet now mentions `catchMine` (used for exported functions); **Additional Resources** links to [docker.md](docs/docker.md).
- **getting-started.md**: Project structure tree expanded to match `Kernel/` (including `AgentToolsLoader.wl`, `Prompts/`, `SupportedClients.wl`, etc.) and adds `TestResources/`.
- **testing.md**: Path resolution example is OS-neutral (paclet root) instead of a Windows-only path.
- **mcp-clients.md** / **quickstart-chat.md**: Documents that Claude Desktop automatic install paths are only defined for macOS and Windows in `Kernel/SupportedClients.wl`; Linux users should use `File[...]` or install manually.
- **docker.md**: Linux Claude config path uses `~/.config/Claude/` (capital C) and notes the path may vary.

## Verification

Cross-checked against `Kernel/DefaultServers.wl`, `Kernel/SupportedClients.wl`, and `Kernel/` file listing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1efc1a01-c437-40c5-8c55-a5c8a235eb6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1efc1a01-c437-40c5-8c55-a5c8a235eb6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

