### PR TITLE
Add Cursor Cloud specific development environment instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,38 +176,22 @@ While working on this paclet, you are also working on the code that's running th
 
 ### Runtime Environment
 
-Wolfram Engine 14.3 runs inside a Docker container (`wolframresearch/wolframengine:14.3`). A `wolframscript` wrapper at `/usr/local/bin/wolframscript` transparently delegates to the Docker container, mounting `/workspace` and passing the `WOLFRAMSCRIPT_ENTITLEMENTID` secret.
+Wolfram Engine 14.3 is installed natively. The `WOLFRAMSCRIPT_ENTITLEMENTID` environment variable must be set as a secret for licensing. If you see `"License refused because all licenses are currently in use"`, wait a few minutes and retry — this is a shared entitlement with concurrent license limits.
 
-The `WOLFRAMSCRIPT_ENTITLEMENTID` environment variable must be set as a secret for all Wolfram operations to work. This is a shared cloud-managed entitlement with concurrent license limits — if you see `"License refused because all licenses are currently in use"`, wait a few minutes and retry.
+### Running Tests, Building, and MCP Server
 
-### Running Tests
+See `docs/testing.md`, `docs/building.md`, and `docs/getting-started.md` for standard commands. Key quick-reference:
 
 ```bash
-wolframscript -f Scripts/TestPaclet.wls                         # all tests
+wolframscript -f Scripts/TestPaclet.wls                         # all tests (~1 min)
 wolframscript -f Scripts/TestPaclet.wls Tests/SomeFile.wlt      # specific test file
+wolframscript -f Scripts/BuildPaclet.wls --check=false          # fast build
 ```
 
-Tests load the paclet from the source directory automatically. No pre-build step is needed.
-
-### Building the Paclet
-
-```bash
-wolframscript -f Scripts/BuildPaclet.wls                   # full build
-wolframscript -f Scripts/BuildPaclet.wls --check=false     # fast build (skip code checks)
-```
-
-Build output goes to `build/`. The `git` binary is not available inside the Docker container, so builds will show a `RunProcess::pnfd` warning for git — this is harmless.
-
-### MCP Server
-
-The MCP server communicates via stdin/stdout JSON-RPC. To test core paclet functionality without starting the full server:
-
-```bash
-wolframscript -code 'PacletDirectoryLoad["/workspace"]; Needs["Wolfram`AgentTools`"]; Print[Keys[$DefaultMCPServers]]'
-```
+The MCP server communicates via stdin/stdout JSON-RPC and can be started with `MCP_SERVER_NAME=WolframLanguage wolframscript -f Scripts/StartMCPServer.wls`. The server takes ~15-20 seconds to initialize before accepting requests.
 
 ### Key Caveats
 
 - Delete `Kernel/64Bit/AgentTools.mx` before testing source changes if it exists (MX file takes priority over source files).
-- The Docker container does not have `git` installed, so any scripts that call `git` from inside `wolframscript` will emit warnings.
-- Each `wolframscript` invocation spins up a new Docker container and consumes a license slot. Avoid running many concurrent `wolframscript` commands to prevent hitting the license limit.
+- Some tests in `InstallMCPServer.wlt` and `UninstallMCPServer.wlt` produce `MessagesFailure` due to an `LLMKitSuggested` warning — these are pre-existing and not environment-related.
+- Tests in `Prompts.wlt` that exercise `WolframAlphaSearch` may fail without an LLMKit subscription.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,3 +171,43 @@ The `Enclose` wrapper is only necessary if you are using any `Confirm`, `Confirm
 ## Special Considerations
 
 While working on this paclet, you are also working on the code that's running the MCP server providing your Wolfram tools. Sometimes you might run into issues related to this and you'll need to carefully consider how current changes might be affecting the MCP server.
+
+## Cursor Cloud specific instructions
+
+### Runtime Environment
+
+Wolfram Engine 14.3 runs inside a Docker container (`wolframresearch/wolframengine:14.3`). A `wolframscript` wrapper at `/usr/local/bin/wolframscript` transparently delegates to the Docker container, mounting `/workspace` and passing the `WOLFRAMSCRIPT_ENTITLEMENTID` secret.
+
+The `WOLFRAMSCRIPT_ENTITLEMENTID` environment variable must be set as a secret for all Wolfram operations to work. This is a shared cloud-managed entitlement with concurrent license limits — if you see `"License refused because all licenses are currently in use"`, wait a few minutes and retry.
+
+### Running Tests
+
+```bash
+wolframscript -f Scripts/TestPaclet.wls                         # all tests
+wolframscript -f Scripts/TestPaclet.wls Tests/SomeFile.wlt      # specific test file
+```
+
+Tests load the paclet from the source directory automatically. No pre-build step is needed.
+
+### Building the Paclet
+
+```bash
+wolframscript -f Scripts/BuildPaclet.wls                   # full build
+wolframscript -f Scripts/BuildPaclet.wls --check=false     # fast build (skip code checks)
+```
+
+Build output goes to `build/`. The `git` binary is not available inside the Docker container, so builds will show a `RunProcess::pnfd` warning for git — this is harmless.
+
+### MCP Server
+
+The MCP server communicates via stdin/stdout JSON-RPC. To test core paclet functionality without starting the full server:
+
+```bash
+wolframscript -code 'PacletDirectoryLoad["/workspace"]; Needs["Wolfram`AgentTools`"]; Print[Keys[$DefaultMCPServers]]'
+```
+
+### Key Caveats
+
+- Delete `Kernel/64Bit/AgentTools.mx` before testing source changes if it exists (MX file takes priority over source files).
+- The Docker container does not have `git` installed, so any scripts that call `git` from inside `wolframscript` will emit warnings.
+- Each `wolframscript` invocation spins up a new Docker container and consumes a license slot. Avoid running many concurrent `wolframscript` commands to prevent hitting the license limit.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting the development environment for Cursor Cloud agents working on this repository.

## Changes

- Added native Wolfram Engine 14.3 runtime documentation  
- Documented key commands for running tests, building, and starting the MCP server  
- Noted pre-existing test caveats (LLMKitSuggested warnings, WolframAlphaSearch failures without LLMKit)

## Environment Verification

| Check | Command | Result |
|-------|---------|--------|
| Tests | `wolframscript -f Scripts/TestPaclet.wls` | 1457/1467 passed (99.3%) |
| Build | `wolframscript -f Scripts/BuildPaclet.wls --check=false` | Paclet built successfully |
| Paclet load | `Needs["Wolfram\`AgentTools\`"]` | All 4 servers and 15 tools verified |
| MCP Server | `MCP_SERVER_NAME=WolframLanguage wolframscript -f Scripts/StartMCPServer.wls` | Server initialized, tools listed, code evaluated |
| Tool call | `Solve[x^2 + 2x - 3 == 0, x]` via MCP | Returned `{{x -> -3}, {x -> 1}}` |

The 10 test failures are all pre-existing:
- 6 in `InstallMCPServer.wlt` and 2 in `UninstallMCPServer.wlt`: `MessagesFailure` from unexpected `LLMKitSuggested` warning  
- 2 in `Prompts.wlt`: `WolframAlphaSearch` requires LLMKit subscription

Test results log:
[test_suite_results.log](https://cursor.com/agents/bc-cc234bd1-62d5-43a4-9e4f-f199c9b1bf05/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_suite_results.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc234bd1-62d5-43a4-9e4f-f199c9b1bf05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc234bd1-62d5-43a4-9e4f-f199c9b1bf05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

