### PR TITLE
Source git SHA from TeamCity and GitHub env vars

### DIFF
--- a/Kernel/Common.wl
+++ b/Kernel/Common.wl
@@ -29,12 +29,13 @@ $resourceFunctionContext = "Wolfram`AgentTools`ResourceFunctions`";
 $internalFailureLogDirectory := FileNameJoin @ { $UserBaseDirectory, "Logs", "AgentTools", "InternalFailures" };
 
 $resourceVersions = <|
-    "ASTPattern"           -> "1.0.0",
-    "ExportMarkdownString" -> "1.0.0",
-    "ImportMarkdownString" -> "1.0.0",
-    "MessageFailure"       -> "1.0.1",
-    "ReadableForm"         -> "2.1.1",
-    "ReplaceContext"       -> "1.0.0"
+    "ASTPattern"              -> "1.0.0",
+    "ExportMarkdownString"    -> "1.0.0",
+    "ImportMarkdownString"    -> "1.0.0",
+    "MessageFailure"          -> "1.0.1",
+    "ReadableForm"            -> "2.1.1",
+    "ReplaceContext"          -> "1.0.0",
+    "ResourceFunctionMessage" -> "2.1.1"
 |>;
 
 (* ::**************************************************************************************************************:: *)

--- a/Kernel/Common.wl
+++ b/Kernel/Common.wl
@@ -570,7 +570,9 @@ $maxBugReportURLSize = 7000;
 
 $maxPartLength = 500;
 
-$thisPaclet    := PacletObject[ "Wolfram/AgentTools" ];
+(* This is a temporary setting that's dynamically overwritten at load time in AgentToolsLoader.wl *)
+$thisPaclet = PacletObject @ File @ DirectoryName[ $InputFileName, 2 ];
+
 $pacletVersion := $thisPaclet[ "Version" ];
 $debugData     := debugData @ $thisPaclet[ "PacletInfo" ];
 $releaseID     := $releaseID = getReleaseID @ $thisPaclet;
@@ -587,15 +589,19 @@ getReleaseID[ paclet_PacletObject, "$RELEASE_ID$" | "None" | Except[ _String ] ]
 getReleaseID[ paclet_, id_String ] := id;
 
 
-getReleaseID0[ dir_? DirectoryQ ] :=
-    Module[ { stdOut, id },
-        stdOut = Quiet @ RunProcess[ { "git", "rev-parse", "HEAD" }, "StandardOutput", ProcessDirectory -> dir ];
-        id = If[ StringQ @ stdOut, StringTrim @ stdOut, "" ];
-        If[ StringMatchQ[ id, Repeated[ HexadecimalCharacter, { 40 } ] ],
-            id,
-            "None"
-        ]
-    ];
+getReleaseID0[ dir_? DirectoryQ ] := FirstCase[
+    Unevaluated @ {
+        Environment[ "BUILD_VCS_NUMBER_WolframLanguage_Paclets_AgentTools_AgentTools" ],
+        Environment[ "GITHUB_SHA" ],
+        Quiet @ RunProcess[ { "git", "rev-parse", "HEAD" }, "StandardOutput", ProcessDirectory -> dir ]
+    },
+    res_ :> With[
+        { str1 = res },
+        { str2 = If[ StringQ @ str1, StringTrim @ str1, "None" ] },
+        str2 /; StringMatchQ[ str2, Repeated[ HexadecimalCharacter, { 40 } ] ]
+    ],
+    "None"
+];
 
 getReleaseID0[ ___ ] := "None";
 

--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -46,6 +46,7 @@ BeginPackage[ "Wolfram`AgentTools`Common`" ];
 `mcpServerLogFile;
 `messageFailure;
 `messagePrint;
+`mxInitialize;
 `readRawJSONFile;
 `readWXFFile;
 `relatedDocumentation;

--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -11,6 +11,7 @@ BeginPackage[ "Wolfram`AgentTools`Common`" ];
 `$mcpEvaluation;
 `$objectVersion;
 `$pacletVersion;
+`$releaseID;
 `$rootPath;
 `$serverVersion;
 `$storagePath;

--- a/Scripts/BuildMX.wls
+++ b/Scripts/BuildMX.wls
@@ -52,9 +52,28 @@ copyTemporary[ dir_ ] :=
     ];
 
 copyTemporary0[ dir_, tmp_, file_ ] :=
-    With[ { rel = StringReplace[ ResourceFunction[ "RelativePath" ][ dir, file ], "\\" -> "/" ] },
-        CopyFile[ file, ResourceFunction[ "EnsureFilePath" ][ FileNameJoin @ { tmp, rel } ] ]
+    With[ { rel = relativePath[ dir, file ] },
+        CopyFile[ file, ensureFilePath @ FileNameJoin @ { tmp, rel } ]
     ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*relativePath*)
+relativePath[ dir0_, file0_ ] :=
+    Enclose @ Module[ { dir, file, relative },
+        dir = ConfirmBy[ ExpandFileName @ dir0, StringQ, "Directory" ];
+        file = ConfirmBy[ ExpandFileName @ file0, StringQ, "File" ];
+        relative = StringDelete[ file, StartOfString~~dir~~($PathnameSeparator|"") ];
+        StringReplace[ relative, "\\" -> "/" ]
+    ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*ensureFilePath*)
+ensureFilePath[ file_ ] := Enclose[
+    ConfirmBy[ GeneralUtilities`EnsureDirectory @ DirectoryName @ file, DirectoryQ, "Directory" ];
+    file
+];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -91,11 +110,11 @@ expandTags[ root_, file_ ] :=
 getNewTags[ root_, file_ ] :=
     Module[ { relativeFile },
 
-        relativeFile = StringReplace[ ResourceFunction[ "RelativePath" ][ root, file ], "\\" -> "/" ];
+        relativeFile = relativePath[ root, file ];
 
         Cases[
             codeParse @ file,
-            ResourceFunction[ "ASTPattern" ][
+            astPattern[
                 HoldPattern @ Alternatives[
                     (Confirm|ConfirmAssert)[ _, $tag1_String ],
                     (ConfirmBy|ConfirmMatch|ConfirmQuiet)[ _, _, $tag2_String ]
@@ -121,12 +140,14 @@ getNewTags[ root_, file_ ] :=
 
 $tagTemplate = StringTemplate[ "\"`Tag`@@`File`:`Line1`,`Column1`-`Line2`,`Column2`\"" ];
 
+astPattern := astPattern = ResourceFunction[ "ASTPattern", "Function" ];
+
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*getTagPos*)
 getTagPos[ file_ ] := Cases[
     codeParseIndexed @ file,
-    ResourceFunction[ "ASTPattern" ][
+    astPattern[
         HoldPattern[
             Alternatives[
                 (Confirm|ConfirmAssert)[ _, $tag1_String ],


### PR DESCRIPTION
## Summary
- Resolve the release ID by falling back through `BUILD_VCS_NUMBER_WolframLanguage_Paclets_AgentTools_AgentTools`, `GITHUB_SHA`, and `git rev-parse HEAD`, so TeamCity and GitHub builds without a git working tree still report an accurate SHA.
- Resolve `$thisPaclet` via the on-disk paclet directory (overwritten at load time) to avoid depending on the paclet being registered.
- Expose `$releaseID` as a shared symbol in `Common`.

## Test plan
- [ ] Local build: confirm `$releaseID` still resolves to the current `HEAD` SHA when neither env var is set.
- [ ] TeamCity build: confirm `$releaseID` picks up `BUILD_VCS_NUMBER_WolframLanguage_Paclets_AgentTools_AgentTools` and matches the built revision.
- [ ] GitHub Actions: confirm `$releaseID` picks up `GITHUB_SHA`.
- [ ] Verify `$thisPaclet` still resolves correctly when the paclet is not yet registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)