### PR TITLE
Bugfix: Fix missing tools in Claude Desktop and CloudDeploy fallback error

### DIFF
--- a/Kernel/Tools/WolframAlpha.wl
+++ b/Kernel/Tools/WolframAlpha.wl
@@ -96,7 +96,7 @@ wolframAlphaToolEvaluateUI[ as_ ] :=
         ];
 
         (* Try to create UI-enhanced result with cloud notebook *)
-        uiResult = Quiet @ makeUIResult[ as, result ];
+        uiResult = Quiet @ catchAlways @ makeUIResult[ as, result ];
 
         (* If UI result succeeded, return it; otherwise fall back to standard behavior *)
         If[ MatchQ[ uiResult, KeyValuePattern[ "Content" -> { __Association } ] ],

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -39,14 +39,14 @@ Do not ask permission to evaluate code.
 You have read access to local files.
 Always use the Wolfram context tool before using this tool to make sure you have the most up-to-date information.
 
-Use `\[FreeformPrompt][\"query\"]` to parse natural language into Wolfram Language expressions \
+Use `\\[FreeformPrompt][\"query\"]` to parse natural language into Wolfram Language expressions \
 (like ctrl+= in notebooks). Always use this for `Quantity`, `Entity`, `EntityClass`, etc. \
-It composes freely: `ColorNegate[\[FreeformPrompt][\"picture of a cat\"]]`.
+It composes freely: `ColorNegate[\\[FreeformPrompt][\"picture of a cat\"]]`.
 
 Examples:
 ```
-\[FreeformPrompt][\"France population\"]  (* Entity property value *)
-\[FreeformPrompt][\"123 terawatt hours\"] (* Quantity *)
+\\[FreeformPrompt][\"France population\"]  (* Entity property value *)
+\\[FreeformPrompt][\"123 terawatt hours\"] (* Quantity *)
 ```
 
 The argument MUST be a string literal \[LongDash] it parses before evaluation, so runtime construction will not work.";
@@ -246,7 +246,7 @@ evaluateWolframLanguageUI[ code_String, timeConstraint_Integer ] :=
     Module[ { savedLine, result, uiResult },
         savedLine = $line;
         result = evaluateWolframLanguageForUI[ code, timeConstraint ];
-        uiResult = Quiet @ UsingFrontEnd @ makeEvaluatorUIResult[ code, result ];
+        uiResult = Quiet @ UsingFrontEnd @ catchAlways @ makeEvaluatorUIResult[ code, result ];
         If[ MatchQ[ uiResult, KeyValuePattern[ "Content" -> { __Association } ] ],
             uiResult,
             (* UI result creation failed; reuse already-computed string to avoid re-evaluation *)

--- a/Tests/StartMCPServer.wlt
+++ b/Tests/StartMCPServer.wlt
@@ -123,6 +123,29 @@ skipIfScript @ VerificationTest[
     TestID   -> "WolframLanguage-ToolSchemaComplete@@Tests/StartMCPServer.wlt:118,16-124,2"
 ]
 
+(* Regression: all 7 WolframLanguage server tools must be present (issue #155) *)
+skipIfScript @ VerificationTest[
+    Sort @ $toolsResponse[[ "result", "tools", All, "name" ]],
+    Sort @ { "WolframLanguageContext", "WolframLanguageEvaluator", "ReadNotebook",
+             "WriteNotebook", "SymbolDefinition", "CodeInspector", "TestReport" },
+    TestID -> "WolframLanguage-ToolsListAllSeven@@Tests/StartMCPServer.wlt:128,16-133,2"
+]
+
+(* Regression: WolframLanguageEvaluator description must contain \[FreeformPrompt] as plain text
+   (not as a PUA Unicode character which can produce invalid JSON escapes) *)
+skipIfScript @ VerificationTest[
+    StringContainsQ[ $toolSchema[ "description" ], "\\[FreeformPrompt]" ],
+    True,
+    TestID -> "WolframLanguage-EvaluatorDescriptionFreeformPrompt@@Tests/StartMCPServer.wlt:136,16-140,2"
+]
+
+(* Regression: the full tools/list JSON response must be valid and round-trip through a JSON parser *)
+skipIfScript @ VerificationTest[
+    AssociationQ @ Developer`ReadRawJSONString @ Developer`WriteRawJSONString[ $toolsResponse, "Compact" -> True ],
+    True,
+    TestID -> "WolframLanguage-ToolsListJSONParses@@Tests/StartMCPServer.wlt:143,16-147,2"
+]
+
 skipIfScript @ VerificationTest[
     $evalResponse = SendMCPRequest[
         "tools/call",

--- a/Tests/WolframAlpha-UI.wlt
+++ b/Tests/WolframAlpha-UI.wlt
@@ -102,6 +102,22 @@ VerificationTest[
 ]
 
 (* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*CloudDeploy Failure Fallback*)
+
+(* Regression test: when CloudDeploy fails, wolframAlphaToolEvaluateUI must fall back gracefully
+   instead of surfacing an internal AgentTools error *)
+VerificationTest[
+    Block[
+        { Wolfram`AgentTools`Common`$clientSupportsUI = True, CloudDeploy = ($Failed &) },
+        $DefaultMCPTools[ "WolframAlpha" ][ <| "query" -> "2+2" |> ]
+    ],
+    _String | KeyValuePattern[ "Content" -> { __Association } ],
+    SameTest -> MatchQ,
+    TestID   -> "wolframAlphaToolEvaluate-CloudDeployFallback@@Tests/WolframAlpha-UI.wlt:104,1-113,2"
+]
+
+(* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*makeUIResult*)
 

--- a/Tests/WolframLanguageEvaluator-UI.wlt
+++ b/Tests/WolframLanguageEvaluator-UI.wlt
@@ -134,6 +134,22 @@ VerificationTest[
 ]
 
 (* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*CloudDeploy Failure Fallback*)
+
+(* Regression test: when CloudDeploy fails, evaluateWolframLanguageUI must fall back gracefully
+   instead of surfacing an internal AgentTools error (previously threw $catchTopTag through Quiet) *)
+VerificationTest[
+    Block[
+        { Wolfram`AgentTools`Common`$clientSupportsUI = True, CloudDeploy = ($Failed &) },
+        $DefaultMCPTools[ "WolframLanguageEvaluator" ][ <| "code" -> "1+1", "timeConstraint" -> 30 |> ]
+    ],
+    _String | KeyValuePattern[ "Content" -> { __Association } ],
+    SameTest -> MatchQ,
+    TestID   -> "evaluateWolframLanguage-CloudDeployFallback@@Tests/WolframLanguageEvaluator-UI.wlt:136,1-144,2"
+]
+
+(* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*makeEvaluatorUIResult*)
 


### PR DESCRIPTION
## Summary

Fixes #155 — `WolframLanguageEvaluator`, `ReadNotebook`, and `WriteNotebook` were absent from Claude Desktop's tool list while appearing correctly in Claude Code.

### Root cause: invalid JSON escape from a PUA character

`\[FreeformPrompt]` in `$wolframLanguageEvaluatorToolDescription` is a Wolfram Language Private Use Area character (U+F74B). At runtime, `convertPUACharacters` converts it to a literal backslash followed by `[FreeformPrompt]`. `Developer\`WriteRawJSONString` does not escape this backslash, so the tools/list JSON contains `\[` — an invalid escape sequence. Claude Desktop's strict JSON parser fails at that point in tool 2 (WolframLanguageEvaluator) and drops tools 2-4 before recovering at tool 5. Claude Code's lenient parser accepts the malformed JSON.

**Fix:** double-escape `\[FreeformPrompt]` in the source (`\\[FreeformPrompt]`) so the runtime string contains a literal backslash, which `Developer\`WriteRawJSONString` correctly serializes as `\\[` in JSON.

### Secondary fix: CloudDeploy failure surfaced as an internal error

Found while testing: when `CloudDeploy` fails (e.g. the MCP server kernel is not authenticated to Wolfram Cloud), `makeEvaluatorUIResult` and `makeUIResult` throw via `throwInternalFailure`. Because `$catching = True` from the enclosing `catchMine`, this throw bypasses the `Quiet` wrapper and the graceful fallback logic, surfacing as an `AgentTools::Internal::ConfirmMatch::None::CloudDeploy` error instead of silently returning the plain-text result.

**Fix:** wrap both call sites with `catchAlways @` so internal failures from cloud notebook creation are caught locally and the fallback executes.

## Changes

- `Kernel/Tools/WolframLanguageEvaluator.wl` — escape `\[FreeformPrompt]` (4x); add `catchAlways` to UI result path
- `Kernel/Tools/WolframAlpha.wl` — add `catchAlways` to UI result path
- `Tests/StartMCPServer.wlt` — 3 regression tests: all 7 tools present, description contains plain-text `\[FreeformPrompt]`, tools/list JSON round-trips through a parser
- `Tests/WolframLanguageEvaluator-UI.wlt` — regression test: `CloudDeploy` failure causes graceful fallback
- `Tests/WolframAlpha-UI.wlt` — same regression test for WolframAlpha
