### PR TITLE
Disable stderr output for Claude Code client

### DIFF
--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -995,7 +995,6 @@ writeLog // endDefinition;
 (* stderr output causes issues with several clients, so we disable it unless we know it's safe to use *)
 stderrEnabledQ // beginDefinition;
 stderrEnabledQ[ ] := stderrEnabledQ @ $clientName;
-stderrEnabledQ[ "claude-code" ] := True;
 stderrEnabledQ[ "claude-ai" ] := True;
 stderrEnabledQ[ _ ] := False;
 stderrEnabledQ // endDefinition;


### PR DESCRIPTION
## Summary

- Removes Claude Code from the allowlist in `stderrEnabledQ` so stderr output is suppressed when the MCP server is connected to that client.
- Recent Claude Code versions attempt to parse stderr as JSON-RPC, causing issues when the Wolfram kernel writes non-protocol text there.

## Test plan

- [x] Connect Claude Code to a Wolfram MCP server and confirm no JSON-RPC parsing errors appear in the client logs.
- [x] Verify stderr output still flows for `claude-ai` (unchanged behavior).
- [x] Run `TestReport` to confirm no regressions in the server test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)