### PR TITLE
Add Junie MCP client support

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,6 +11,7 @@
         "evals",
         "FelisCatus",
         "frontmatter",
+        "Junie",
         "Kiro",
         "Legended",
         "libgomp",

--- a/AgentSkills/References/SetUpWolframMCPServer.md
+++ b/AgentSkills/References/SetUpWolframMCPServer.md
@@ -39,6 +39,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Copilot CLI | `"CopilotCLI"` |
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
+| Junie | `"Junie"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/AgentSkills/Skills/wolfram-alpha/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-alpha/references/SetUpWolframMCPServer.md
@@ -39,6 +39,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Copilot CLI | `"CopilotCLI"` |
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
+| Junie | `"Junie"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/AgentSkills/Skills/wolfram-language/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-language/references/SetUpWolframMCPServer.md
@@ -39,6 +39,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Copilot CLI | `"CopilotCLI"` |
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
+| Junie | `"Junie"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/AgentSkills/Skills/wolfram-notebooks/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-notebooks/references/SetUpWolframMCPServer.md
@@ -39,6 +39,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Copilot CLI | `"CopilotCLI"` |
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
+| Junie | `"Junie"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/AgentSkills/Skills/wolfram-paclets/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-paclets/references/SetUpWolframMCPServer.md
@@ -39,6 +39,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Copilot CLI | `"CopilotCLI"` |
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
+| Junie | `"Junie"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/Kernel/InstallMCPServer.wl
+++ b/Kernel/InstallMCPServer.wl
@@ -493,6 +493,7 @@ guessClientName[ file_? fileQ ] := Enclose[
             { __, ".mcp.json" }, Throw[ "ClaudeCode" ],
             { __, "opencode.json" }, Throw[ "OpenCode" ],
             { __, ".vscode", "settings.json" | "mcp.json" }, Throw[ "VisualStudioCode" ],
+            { __, ".junie", "mcp", "mcp.json" }, Throw[ "Junie" ],
             { __, ".kiro", "settings", "mcp.json" }, Throw[ "Kiro" ],
             { __, ".zed", "settings.json" }, Throw[ "Zed" ]
         ];

--- a/Kernel/SupportedClients.wl
+++ b/Kernel/SupportedClients.wl
@@ -103,6 +103,15 @@ $supportedMCPClients = <|
         "ProjectPath"     -> { ".kiro", "settings", "mcp.json" },
         "InstallLocation" :> { $HomeDirectory, ".kiro", "settings", "mcp.json" }
     |>,
+    "Junie" -> <|
+        "DisplayName"     -> "Junie",
+        "Aliases"         -> { },
+        "ConfigFormat"    -> "JSON",
+        "ConfigKey"       -> { "mcpServers" },
+        "URL"             -> "https://www.jetbrains.com/junie/",
+        "ProjectPath"     -> { ".junie", "mcp", "mcp.json" },
+        "InstallLocation" :> { $HomeDirectory, ".junie", "mcp", "mcp.json" }
+    |>,
     "OpenCode" -> <|
         "DisplayName"     -> "OpenCode",
         "Aliases"         -> { },

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ AgentTools can be installed into the following MCP client applications:
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `"GeminiCLI"` | No |
 | [Goose](https://block.github.io/goose/) | `"Goose"` | No |
 | [Google Antigravity](https://antigravity.google) | `"Antigravity"` | No |
+| [Junie](https://www.jetbrains.com/junie/) | `"Junie"` | Yes |
 | [OpenAI Codex](https://openai.com/codex) | `"Codex"` | Yes |
 | [OpenCode](https://opencode.ai) | `"OpenCode"` | Yes |
 | [Visual Studio Code](https://code.visualstudio.com) | `"VisualStudioCode"` | Yes |

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -1840,26 +1840,181 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
+(*Junie Support*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Install Location for Junie*)
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+VerificationTest[
+    Wolfram`AgentTools`Common`installLocation[ "Junie", "Windows" ],
+    _File,
+    SameTest -> MatchQ,
+    TestID   -> "InstallLocation-Junie-Windows@@Tests/InstallMCPServer.wlt:1852,1-1857,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`installLocation[ "Junie", "MacOSX" ],
+    _File,
+    SameTest -> MatchQ,
+    TestID   -> "InstallLocation-Junie-MacOSX@@Tests/InstallMCPServer.wlt:1859,1-1864,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`installLocation[ "Junie", "Unix" ],
+    _File,
+    SameTest -> MatchQ,
+    TestID   -> "InstallLocation-Junie-Unix@@Tests/InstallMCPServer.wlt:1866,1-1871,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Junie" ],
+    "Junie",
+    SameTest -> Equal,
+    TestID   -> "InstallDisplayName-Junie@@Tests/InstallMCPServer.wlt:1873,1-1878,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`toInstallName[ "Junie" ],
+    "Junie",
+    SameTest -> Equal,
+    TestID   -> "ToInstallName-Junie@@Tests/InstallMCPServer.wlt:1880,1-1885,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Project Install Location*)
+VerificationTest[
+    Module[ { path, result },
+        path = FileNameJoin @ { $TemporaryDirectory, "TestProject" };
+        result = Wolfram`AgentTools`Common`projectInstallLocation[ "Junie", path ];
+        FileNameTake[ First @ result, -3 ]
+    ],
+    FileNameJoin @ { ".junie", "mcp", "mcp.json" },
+    SameTest -> Equal,
+    TestID   -> "ProjectInstallLocation-Junie@@Tests/InstallMCPServer.wlt:1890,1-1899,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Junie Install and Uninstall*)
+VerificationTest[
+    junieConfigFile = testConfigFile[];
+    installResult = InstallMCPServer[ junieConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "Junie" ],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Junie-Basic@@Tests/InstallMCPServer.wlt:1904,1-1910,2"
+]
+
+VerificationTest[
+    FileExistsQ[ junieConfigFile ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Junie-FileExists@@Tests/InstallMCPServer.wlt:1912,1-1917,2"
+]
+
+VerificationTest[
+    Module[ { content },
+        content = Import[ junieConfigFile, "RawJSON" ];
+        KeyExistsQ[ content, "mcpServers" ] && KeyExistsQ[ content[ "mcpServers" ], "Wolfram" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Junie-VerifyContent@@Tests/InstallMCPServer.wlt:1919,1-1927,2"
+]
+
+VerificationTest[
+    Module[ { content, server },
+        content = Import[ junieConfigFile, "RawJSON" ];
+        server = content[ "mcpServers", "Wolfram" ];
+        Sort @ Select[ Keys @ server, MemberQ[ { "disabled", "autoApprove", "alwaysAllow", "tools" }, # ] & ]
+    ],
+    { },
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Junie-NoClientDecoration@@Tests/InstallMCPServer.wlt:1929,1-1938,2"
+]
+
+VerificationTest[
+    uninstallResult = UninstallMCPServer[ junieConfigFile, "WolframLanguage", "ApplicationName" -> "Junie" ],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "UninstallMCPServer-Junie-Basic@@Tests/InstallMCPServer.wlt:1940,1-1945,2"
+]
+
+VerificationTest[
+    Module[ { content },
+        content = Import[ junieConfigFile, "RawJSON" ];
+        KeyExistsQ[ content, "mcpServers" ] && ! KeyExistsQ[ content[ "mcpServers" ], "Wolfram" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "UninstallMCPServer-Junie-VerifyRemoval@@Tests/InstallMCPServer.wlt:1947,1-1955,2"
+]
+
+VerificationTest[
+    cleanupTestFiles[ junieConfigFile ],
+    { Null },
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Junie-Cleanup@@Tests/InstallMCPServer.wlt:1957,1-1962,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Junie Preserves Existing Config*)
+VerificationTest[
+    junieConfigFile = testConfigFile[];
+    Export[ junieConfigFile, <| "customSetting" -> True, "mcpServers" -> <| |> |>, "JSON" ];
+    installResult = InstallMCPServer[ junieConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "Junie" ],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Junie-PreserveExisting@@Tests/InstallMCPServer.wlt:1967,1-1974,2"
+]
+
+VerificationTest[
+    Module[ { content },
+        content = Import[ junieConfigFile, "RawJSON" ];
+        KeyExistsQ[ content, "customSetting" ] && content[ "customSetting" ] === True &&
+        KeyExistsQ[ content[ "mcpServers" ], "Wolfram" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Junie-VerifyPreserved@@Tests/InstallMCPServer.wlt:1976,1-1985,2"
+]
+
+VerificationTest[
+    cleanupTestFiles[ junieConfigFile ],
+    { Null },
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-Junie-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:1987,1-1992,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
 (*$SupportedMCPClients*)
 VerificationTest[
     $SupportedMCPClients,
     _Association? AssociationQ,
     SameTest -> MatchQ,
-    TestID   -> "SupportedMCPClients-ReturnsAssociation@@Tests/InstallMCPServer.wlt:1844,1-1849,2"
+    TestID   -> "SupportedMCPClients-ReturnsAssociation@@Tests/InstallMCPServer.wlt:1999,1-2004,2"
 ]
 
 VerificationTest[
     Length @ $SupportedMCPClients,
-    14,
+    15,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-Has14Clients@@Tests/InstallMCPServer.wlt:1851,1-1856,2"
+    TestID   -> "SupportedMCPClients-Has15Clients@@Tests/InstallMCPServer.wlt:2006,1-2011,2"
 ]
 
 VerificationTest[
     Keys @ $SupportedMCPClients,
-    { "Antigravity", "ClaudeCode", "ClaudeDesktop", "Cline", "Codex", "CopilotCLI", "Cursor", "GeminiCLI", "Goose", "Kiro", "OpenCode", "VisualStudioCode", "Windsurf", "Zed" },
+    { "Antigravity", "ClaudeCode", "ClaudeDesktop", "Cline", "Codex", "CopilotCLI", "Cursor", "GeminiCLI", "Goose", "Junie", "Kiro", "OpenCode", "VisualStudioCode", "Windsurf", "Zed" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-KeysSorted@@Tests/InstallMCPServer.wlt:1858,1-1863,2"
+    TestID   -> "SupportedMCPClients-KeysSorted@@Tests/InstallMCPServer.wlt:2013,1-2018,2"
 ]
 
 VerificationTest[
@@ -1878,70 +2033,70 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AllHaveRequiredKeys@@Tests/InstallMCPServer.wlt:1865,1-1882,2"
+    TestID   -> "SupportedMCPClients-AllHaveRequiredKeys@@Tests/InstallMCPServer.wlt:2020,1-2037,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "ClaudeDesktop", "DisplayName" ],
     "Claude Desktop",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ClaudeDesktopDisplayName@@Tests/InstallMCPServer.wlt:1884,1-1889,2"
+    TestID   -> "SupportedMCPClients-ClaudeDesktopDisplayName@@Tests/InstallMCPServer.wlt:2039,1-2044,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "ClaudeDesktop", "Aliases" ],
     { "Claude" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ClaudeDesktopAliases@@Tests/InstallMCPServer.wlt:1891,1-1896,2"
+    TestID   -> "SupportedMCPClients-ClaudeDesktopAliases@@Tests/InstallMCPServer.wlt:2046,1-2051,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Codex", "ConfigFormat" ],
     "TOML",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-CodexConfigFormat@@Tests/InstallMCPServer.wlt:1898,1-1903,2"
+    TestID   -> "SupportedMCPClients-CodexConfigFormat@@Tests/InstallMCPServer.wlt:2053,1-2058,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Codex", "ProjectSupport" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-CodexProjectSupport@@Tests/InstallMCPServer.wlt:1905,1-1910,2"
+    TestID   -> "SupportedMCPClients-CodexProjectSupport@@Tests/InstallMCPServer.wlt:2060,1-2065,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "ClaudeCode", "ProjectSupport" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ClaudeCodeProjectSupport@@Tests/InstallMCPServer.wlt:1912,1-1917,2"
+    TestID   -> "SupportedMCPClients-ClaudeCodeProjectSupport@@Tests/InstallMCPServer.wlt:2067,1-2072,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Zed", "ConfigKey" ],
     { "context_servers" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ZedConfigKey@@Tests/InstallMCPServer.wlt:1919,1-1924,2"
+    TestID   -> "SupportedMCPClients-ZedConfigKey@@Tests/InstallMCPServer.wlt:2074,1-2079,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "VisualStudioCode", "ConfigKey" ],
     { "servers" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-VSCodeConfigKey@@Tests/InstallMCPServer.wlt:1926,1-1931,2"
+    TestID   -> "SupportedMCPClients-VSCodeConfigKey@@Tests/InstallMCPServer.wlt:2081,1-2086,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "OpenCode", "ConfigKey" ],
     { "mcp" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-OpenCodeConfigKey@@Tests/InstallMCPServer.wlt:1933,1-1938,2"
+    TestID   -> "SupportedMCPClients-OpenCodeConfigKey@@Tests/InstallMCPServer.wlt:2088,1-2093,2"
 ]
 
 VerificationTest[
     AllTrue[ Values @ $SupportedMCPClients, StringQ[ #[ "URL" ] ] && StringStartsQ[ #[ "URL" ], "https://" ] & ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AllHaveValidURLs@@Tests/InstallMCPServer.wlt:1940,1-1945,2"
+    TestID   -> "SupportedMCPClients-AllHaveValidURLs@@Tests/InstallMCPServer.wlt:2095,1-2100,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1981,7 +2136,7 @@ VerificationTest[
     ],
     "Zed",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-Zed@@Tests/InstallMCPServer.wlt:1975,1-1985,2"
+    TestID   -> "GuessClientNameFromJSON-Zed@@Tests/InstallMCPServer.wlt:2130,1-2140,2"
 ]
 
 (* VSCode legacy: has "mcp" with nested "servers" (settings.json format) *)
@@ -1994,7 +2149,7 @@ VerificationTest[
     ],
     "VisualStudioCode",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-VisualStudioCode-Legacy@@Tests/InstallMCPServer.wlt:1988,1-1998,2"
+    TestID   -> "GuessClientNameFromJSON-VisualStudioCode-Legacy@@Tests/InstallMCPServer.wlt:2143,1-2153,2"
 ]
 
 (* VSCode: has "servers" at root level (mcp.json format) *)
@@ -2008,7 +2163,7 @@ VerificationTest[
     ],
     "VisualStudioCode",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-VisualStudioCode@@Tests/InstallMCPServer.wlt:2001,1-2012,2"
+    TestID   -> "GuessClientNameFromJSON-VisualStudioCode@@Tests/InstallMCPServer.wlt:2156,1-2167,2"
 ]
 
 (* Generic "servers" key in non-mcp.json file -> None (avoid false positives) *)
@@ -2021,7 +2176,7 @@ VerificationTest[
     ],
     None,
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-GenericServersKey@@Tests/InstallMCPServer.wlt:2015,1-2025,2"
+    TestID   -> "GuessClientNameFromJSON-GenericServersKey@@Tests/InstallMCPServer.wlt:2170,1-2180,2"
 ]
 
 (* OpenCode: has "mcp" with entries that have "type" and List-valued "command" *)
@@ -2034,7 +2189,7 @@ VerificationTest[
     ],
     "OpenCode",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-OpenCode@@Tests/InstallMCPServer.wlt:2028,1-2038,2"
+    TestID   -> "GuessClientNameFromJSON-OpenCode@@Tests/InstallMCPServer.wlt:2183,1-2193,2"
 ]
 
 (* CopilotCLI: has "mcpServers" with entries that have "tools" *)
@@ -2047,7 +2202,7 @@ VerificationTest[
     ],
     "CopilotCLI",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-CopilotCLI@@Tests/InstallMCPServer.wlt:2041,1-2051,2"
+    TestID   -> "GuessClientNameFromJSON-CopilotCLI@@Tests/InstallMCPServer.wlt:2196,1-2206,2"
 ]
 
 (* Cline: has "mcpServers" with entries that have "disabled" and "autoApprove" *)
@@ -2060,7 +2215,7 @@ VerificationTest[
     ],
     "Cline",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-Cline@@Tests/InstallMCPServer.wlt:2054,1-2064,2"
+    TestID   -> "GuessClientNameFromJSON-Cline@@Tests/InstallMCPServer.wlt:2209,1-2219,2"
 ]
 
 (* Ambiguous: standard mcpServers with only command/args/env -> None *)
@@ -2073,7 +2228,7 @@ VerificationTest[
     ],
     None,
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-Ambiguous@@Tests/InstallMCPServer.wlt:2067,1-2077,2"
+    TestID   -> "GuessClientNameFromJSON-Ambiguous@@Tests/InstallMCPServer.wlt:2222,1-2232,2"
 ]
 
 (* Empty JSON -> None *)
@@ -2086,7 +2241,7 @@ VerificationTest[
     ],
     None,
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-EmptyJSON@@Tests/InstallMCPServer.wlt:2080,1-2090,2"
+    TestID   -> "GuessClientNameFromJSON-EmptyJSON@@Tests/InstallMCPServer.wlt:2235,1-2245,2"
 ]
 
 (* Non-existent file -> None *)
@@ -2095,7 +2250,7 @@ VerificationTest[
         FileNameJoin @ { $TemporaryDirectory, "nonexistent_" <> CreateUUID[] <> ".json" },
     None,
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-NonExistentFile@@Tests/InstallMCPServer.wlt:2093,1-2099,2"
+    TestID   -> "GuessClientNameFromJSON-NonExistentFile@@Tests/InstallMCPServer.wlt:2248,1-2254,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2107,7 +2262,7 @@ VerificationTest[
     ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-ClaudeDesktop@@Tests/InstallMCPServer.wlt:2104,1-2111,2"
+    TestID   -> "ConfigKeyPath-ClaudeDesktop@@Tests/InstallMCPServer.wlt:2259,1-2266,2"
 ]
 
 VerificationTest[
@@ -2116,7 +2271,7 @@ VerificationTest[
     ],
     { "servers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-VSCode@@Tests/InstallMCPServer.wlt:2113,1-2120,2"
+    TestID   -> "ConfigKeyPath-VSCode@@Tests/InstallMCPServer.wlt:2268,1-2275,2"
 ]
 
 (* VS Code with mcp.json file: uses new key path *)
@@ -2127,7 +2282,7 @@ VerificationTest[
     ],
     { "servers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-VSCode-MCPJson@@Tests/InstallMCPServer.wlt:2123,1-2131,2"
+    TestID   -> "ConfigKeyPath-VSCode-MCPJson@@Tests/InstallMCPServer.wlt:2278,1-2286,2"
 ]
 
 (* VS Code with legacy settings.json: uses old nested key path *)
@@ -2138,7 +2293,7 @@ VerificationTest[
     ],
     { "mcp", "servers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-VSCode-LegacySettings@@Tests/InstallMCPServer.wlt:2134,1-2142,2"
+    TestID   -> "ConfigKeyPath-VSCode-LegacySettings@@Tests/InstallMCPServer.wlt:2289,1-2297,2"
 ]
 
 VerificationTest[
@@ -2147,7 +2302,7 @@ VerificationTest[
     ],
     { "context_servers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-Zed@@Tests/InstallMCPServer.wlt:2144,1-2151,2"
+    TestID   -> "ConfigKeyPath-Zed@@Tests/InstallMCPServer.wlt:2299,1-2306,2"
 ]
 
 VerificationTest[
@@ -2156,14 +2311,14 @@ VerificationTest[
     ],
     { "mcp" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-OpenCode@@Tests/InstallMCPServer.wlt:2153,1-2160,2"
+    TestID   -> "ConfigKeyPath-OpenCode@@Tests/InstallMCPServer.wlt:2308,1-2315,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`configKeyPath[ "UnknownClient" ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-UnknownFallback@@Tests/InstallMCPServer.wlt:2162,1-2167,2"
+    TestID   -> "ConfigKeyPath-UnknownFallback@@Tests/InstallMCPServer.wlt:2317,1-2322,2"
 ]
 
 VerificationTest[
@@ -2172,7 +2327,7 @@ VerificationTest[
     ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-NoneFallback@@Tests/InstallMCPServer.wlt:2169,1-2176,2"
+    TestID   -> "ConfigKeyPath-NoneFallback@@Tests/InstallMCPServer.wlt:2324,1-2331,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2182,21 +2337,21 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`emptyConfigForPath @ { "mcpServers" },
     <| "mcpServers" -> <| |> |>,
     SameTest -> Equal,
-    TestID   -> "EmptyConfigForPath-SingleKey@@Tests/InstallMCPServer.wlt:2181,1-2186,2"
+    TestID   -> "EmptyConfigForPath-SingleKey@@Tests/InstallMCPServer.wlt:2336,1-2341,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`emptyConfigForPath @ { "mcp", "servers" },
     <| "mcp" -> <| "servers" -> <| |> |> |>,
     SameTest -> Equal,
-    TestID   -> "EmptyConfigForPath-NestedKeys@@Tests/InstallMCPServer.wlt:2188,1-2193,2"
+    TestID   -> "EmptyConfigForPath-NestedKeys@@Tests/InstallMCPServer.wlt:2343,1-2348,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`emptyConfigForPath @ { },
     <| |>,
     SameTest -> Equal,
-    TestID   -> "EmptyConfigForPath-EmptyPath@@Tests/InstallMCPServer.wlt:2195,1-2200,2"
+    TestID   -> "EmptyConfigForPath-EmptyPath@@Tests/InstallMCPServer.wlt:2350,1-2355,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2206,7 +2361,7 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`ensureNestedKey[ <| "other" -> 1 |>, { "mcpServers" } ],
     <| "other" -> 1, "mcpServers" -> <| |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-AddMissing@@Tests/InstallMCPServer.wlt:2205,1-2210,2"
+    TestID   -> "EnsureNestedKey-AddMissing@@Tests/InstallMCPServer.wlt:2360,1-2365,2"
 ]
 
 VerificationTest[
@@ -2216,7 +2371,7 @@ VerificationTest[
     ],
     <| "mcpServers" -> <| "existing" -> "data" |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-PreserveExisting@@Tests/InstallMCPServer.wlt:2212,1-2220,2"
+    TestID   -> "EnsureNestedKey-PreserveExisting@@Tests/InstallMCPServer.wlt:2367,1-2375,2"
 ]
 
 VerificationTest[
@@ -2226,7 +2381,7 @@ VerificationTest[
     ],
     <| "theme" -> "dark", "mcp" -> <| "servers" -> <| |> |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-DeepNesting@@Tests/InstallMCPServer.wlt:2222,1-2230,2"
+    TestID   -> "EnsureNestedKey-DeepNesting@@Tests/InstallMCPServer.wlt:2377,1-2385,2"
 ]
 
 VerificationTest[
@@ -2236,14 +2391,14 @@ VerificationTest[
     ],
     <| "mcp" -> <| "existing" -> 1, "servers" -> <| |> |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-PartiallyExisting@@Tests/InstallMCPServer.wlt:2232,1-2240,2"
+    TestID   -> "EnsureNestedKey-PartiallyExisting@@Tests/InstallMCPServer.wlt:2387,1-2395,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`ensureNestedKey[ "notAssoc", { "mcpServers" } ],
     <| "mcpServers" -> <| |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-NonAssocInput@@Tests/InstallMCPServer.wlt:2242,1-2247,2"
+    TestID   -> "EnsureNestedKey-NonAssocInput@@Tests/InstallMCPServer.wlt:2397,1-2402,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2253,28 +2408,35 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`serverConverter[ "OpenCode" ],
     Wolfram`AgentTools`SupportedClients`Private`convertToOpenCodeFormat,
     SameTest -> SameQ,
-    TestID   -> "ServerConverter-OpenCode@@Tests/InstallMCPServer.wlt:2252,1-2257,2"
+    TestID   -> "ServerConverter-OpenCode@@Tests/InstallMCPServer.wlt:2407,1-2412,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`serverConverter[ "CopilotCLI" ],
     Wolfram`AgentTools`SupportedClients`Private`convertToCopilotCLIFormat,
     SameTest -> SameQ,
-    TestID   -> "ServerConverter-CopilotCLI@@Tests/InstallMCPServer.wlt:2259,1-2264,2"
+    TestID   -> "ServerConverter-CopilotCLI@@Tests/InstallMCPServer.wlt:2414,1-2419,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`serverConverter[ "Cline" ],
     Wolfram`AgentTools`SupportedClients`Private`convertToClineFormat,
     SameTest -> SameQ,
-    TestID   -> "ServerConverter-Cline@@Tests/InstallMCPServer.wlt:2266,1-2271,2"
+    TestID   -> "ServerConverter-Cline@@Tests/InstallMCPServer.wlt:2421,1-2426,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`InstallMCPServer`Private`serverConverter[ "Junie" ],
+    Identity,
+    SameTest -> SameQ,
+    TestID   -> "ServerConverter-Junie-Identity@@Tests/InstallMCPServer.wlt:2428,1-2433,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`serverConverter[ "ClaudeDesktop" ],
     Identity,
     SameTest -> SameQ,
-    TestID   -> "ServerConverter-Default@@Tests/InstallMCPServer.wlt:2273,1-2278,2"
+    TestID   -> "ServerConverter-Default@@Tests/InstallMCPServer.wlt:2435,1-2440,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2286,7 +2448,7 @@ VerificationTest[
     ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "ResolveMCPServerName-BuiltInServer@@Tests/InstallMCPServer.wlt:2283,1-2290,2"
+    TestID   -> "ResolveMCPServerName-BuiltInServer@@Tests/InstallMCPServer.wlt:2445,1-2452,2"
 ]
 
 VerificationTest[
@@ -2295,7 +2457,7 @@ VerificationTest[
     ],
     "CustomKey",
     SameTest -> Equal,
-    TestID   -> "ResolveMCPServerName-OptionOverride@@Tests/InstallMCPServer.wlt:2292,1-2299,2"
+    TestID   -> "ResolveMCPServerName-OptionOverride@@Tests/InstallMCPServer.wlt:2454,1-2461,2"
 ]
 
 VerificationTest[
@@ -2304,7 +2466,7 @@ VerificationTest[
     ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "ResolveMCPServerName-WolframServer@@Tests/InstallMCPServer.wlt:2301,1-2308,2"
+    TestID   -> "ResolveMCPServerName-WolframServer@@Tests/InstallMCPServer.wlt:2463,1-2470,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)
@@ -2327,7 +2489,7 @@ VerificationTest[
     $mockPaclet[ "Name" ],
     "MockMCPPacletTest",
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-MockPacletSetup@@Tests/InstallMCPServer.wlt:2324,1-2331,2"
+    TestID   -> "InstallPacletServer-MockPacletSetup@@Tests/InstallMCPServer.wlt:2486,1-2493,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2337,7 +2499,7 @@ VerificationTest[
     MCPServerObject[ "MockMCPPacletTest/TestServer" ][ "MCPServerName" ],
     "TestServer",
     SameTest -> Equal,
-    TestID   -> "MCPServerName-PacletServerProperty@@Tests/InstallMCPServer.wlt:2336,1-2341,2"
+    TestID   -> "MCPServerName-PacletServerProperty@@Tests/InstallMCPServer.wlt:2498,1-2503,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2349,7 +2511,7 @@ VerificationTest[
     ],
     "TestServer",
     SameTest -> Equal,
-    TestID   -> "ResolveMCPServerName-PacletServerShortName@@Tests/InstallMCPServer.wlt:2346,1-2353,2"
+    TestID   -> "ResolveMCPServerName-PacletServerShortName@@Tests/InstallMCPServer.wlt:2508,1-2515,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2359,7 +2521,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`ensurePacletForInstall[ "MockMCPPacletTest/TestServer" ],
     _PacletObject,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-EnsurePacletAlreadyInstalled@@Tests/InstallMCPServer.wlt:2358,1-2363,2"
+    TestID   -> "InstallPacletServer-EnsurePacletAlreadyInstalled@@Tests/InstallMCPServer.wlt:2520,1-2525,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2371,7 +2533,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletNotInstalled },
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-EnsurePacletThreeSegment@@Tests/InstallMCPServer.wlt:2368,1-2375,2"
+    TestID   -> "InstallPacletServer-EnsurePacletThreeSegment@@Tests/InstallMCPServer.wlt:2530,1-2537,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2382,7 +2544,7 @@ VerificationTest[
     $pacletInstallResult = InstallMCPServer[ $pacletConfigFile, "MockMCPPacletTest/TestServer", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-Install@@Tests/InstallMCPServer.wlt:2380,1-2386,2"
+    TestID   -> "InstallPacletServer-Install@@Tests/InstallMCPServer.wlt:2542,1-2548,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2392,7 +2554,7 @@ VerificationTest[
     FileExistsQ @ $pacletConfigFile,
     True,
     SameTest -> Equal,
-    TestID   -> "InstallPacletServer-ConfigFileExists@@Tests/InstallMCPServer.wlt:2391,1-2396,2"
+    TestID   -> "InstallPacletServer-ConfigFileExists@@Tests/InstallMCPServer.wlt:2553,1-2558,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2403,7 +2565,7 @@ VerificationTest[
     KeyExistsQ[ $pacletConfigJSON[ "mcpServers" ], "TestServer" ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallPacletServer-ConfigHasServerName@@Tests/InstallMCPServer.wlt:2401,1-2407,2"
+    TestID   -> "InstallPacletServer-ConfigHasServerName@@Tests/InstallMCPServer.wlt:2563,1-2569,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2413,7 +2575,7 @@ VerificationTest[
     $pacletConfigJSON[ "mcpServers", "TestServer", "env", "MCP_SERVER_NAME" ],
     "MockMCPPacletTest/TestServer",
     SameTest -> Equal,
-    TestID   -> "InstallPacletServer-ConfigEnvServerName@@Tests/InstallMCPServer.wlt:2412,1-2417,2"
+    TestID   -> "InstallPacletServer-ConfigEnvServerName@@Tests/InstallMCPServer.wlt:2574,1-2579,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2423,7 +2585,7 @@ VerificationTest[
     UninstallMCPServer[ $pacletConfigFile, MCPServerObject[ "MockMCPPacletTest/TestServer" ] ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-Uninstall@@Tests/InstallMCPServer.wlt:2422,1-2427,2"
+    TestID   -> "InstallPacletServer-Uninstall@@Tests/InstallMCPServer.wlt:2584,1-2589,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2434,7 +2596,7 @@ VerificationTest[
     KeyExistsQ[ updatedJSON[ "mcpServers" ], "TestServer" ],
     False,
     SameTest -> Equal,
-    TestID   -> "InstallPacletServer-VerifyUninstall@@Tests/InstallMCPServer.wlt:2432,1-2438,2"
+    TestID   -> "InstallPacletServer-VerifyUninstall@@Tests/InstallMCPServer.wlt:2594,1-2600,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2445,7 +2607,7 @@ VerificationTest[
     $pacletInstallResult2[ "MCPServerObject" ],
     _MCPServerObject? MCPServerObjectQ,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ResultHasMCPServerObject@@Tests/InstallMCPServer.wlt:2443,1-2449,2"
+    TestID   -> "InstallPacletServer-ResultHasMCPServerObject@@Tests/InstallMCPServer.wlt:2605,1-2611,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2456,7 +2618,7 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`validatePacletServerDefinitions @ obj,
     Null,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ValidateDefinitionsValid@@Tests/InstallMCPServer.wlt:2454,1-2460,2"
+    TestID   -> "InstallPacletServer-ValidateDefinitionsValid@@Tests/InstallMCPServer.wlt:2616,1-2622,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2472,7 +2634,7 @@ VerificationTest[
     result,
     Null,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ValidateDefinitionsNoOp@@Tests/InstallMCPServer.wlt:2465,1-2476,2"
+    TestID   -> "InstallPacletServer-ValidateDefinitionsNoOp@@Tests/InstallMCPServer.wlt:2627,1-2638,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2492,7 +2654,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletNotInstalled },
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ValidateToolError@@Tests/InstallMCPServer.wlt:2481,1-2496,2"
+    TestID   -> "InstallPacletServer-ValidateToolError@@Tests/InstallMCPServer.wlt:2643,1-2658,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2512,7 +2674,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletNotInstalled },
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ValidatePromptError@@Tests/InstallMCPServer.wlt:2501,1-2516,2"
+    TestID   -> "InstallPacletServer-ValidatePromptError@@Tests/InstallMCPServer.wlt:2663,1-2678,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2523,7 +2685,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`clearPacletDefinitionCache[ ],
     <| |>,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-Cleanup@@Tests/InstallMCPServer.wlt:2521,1-2527,2"
+    TestID   -> "InstallPacletServer-Cleanup@@Tests/InstallMCPServer.wlt:2683,1-2689,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)
@@ -2540,7 +2702,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile, "WolframLanguage", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-BuiltInUsesWolframKey-Install@@Tests/InstallMCPServer.wlt:2538,1-2544,2"
+    TestID   -> "MCPServerName-BuiltInUsesWolframKey-Install@@Tests/InstallMCPServer.wlt:2700,1-2706,2"
 ]
 
 VerificationTest[
@@ -2549,7 +2711,7 @@ VerificationTest[
     ! KeyExistsQ[ jsonContent[ "mcpServers" ], "WolframLanguage" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-BuiltInUsesWolframKey-Verify@@Tests/InstallMCPServer.wlt:2546,1-2553,2"
+    TestID   -> "MCPServerName-BuiltInUsesWolframKey-Verify@@Tests/InstallMCPServer.wlt:2708,1-2715,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2559,7 +2721,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile, "WolframAlpha", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-SecondBuiltInOverwrites-Install@@Tests/InstallMCPServer.wlt:2558,1-2563,2"
+    TestID   -> "MCPServerName-SecondBuiltInOverwrites-Install@@Tests/InstallMCPServer.wlt:2720,1-2725,2"
 ]
 
 VerificationTest[
@@ -2568,7 +2730,7 @@ VerificationTest[
     KeyExistsQ[ jsonContent[ "mcpServers" ], "Wolfram" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-SecondBuiltInOverwrites-Verify@@Tests/InstallMCPServer.wlt:2565,1-2572,2"
+    TestID   -> "MCPServerName-SecondBuiltInOverwrites-Verify@@Tests/InstallMCPServer.wlt:2727,1-2734,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2578,7 +2740,7 @@ VerificationTest[
     UninstallMCPServer[ mcpNameConfigFile, "WolframAlpha" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-UninstallBuiltIn@@Tests/InstallMCPServer.wlt:2577,1-2582,2"
+    TestID   -> "MCPServerName-UninstallBuiltIn@@Tests/InstallMCPServer.wlt:2739,1-2744,2"
 ]
 
 VerificationTest[
@@ -2586,7 +2748,7 @@ VerificationTest[
     ! KeyExistsQ[ jsonContent[ "mcpServers" ], "Wolfram" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-UninstallBuiltIn-Verify@@Tests/InstallMCPServer.wlt:2584,1-2590,2"
+    TestID   -> "MCPServerName-UninstallBuiltIn-Verify@@Tests/InstallMCPServer.wlt:2746,1-2752,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2601,7 +2763,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile, mcpNameCustomServer, "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-CustomServerUsesName-Install@@Tests/InstallMCPServer.wlt:2595,1-2605,2"
+    TestID   -> "MCPServerName-CustomServerUsesName-Install@@Tests/InstallMCPServer.wlt:2757,1-2767,2"
 ]
 
 VerificationTest[
@@ -2609,7 +2771,7 @@ VerificationTest[
     KeyExistsQ[ jsonContent[ "mcpServers" ], mcpNameCustomName ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-CustomServerUsesName-Verify@@Tests/InstallMCPServer.wlt:2607,1-2613,2"
+    TestID   -> "MCPServerName-CustomServerUsesName-Verify@@Tests/InstallMCPServer.wlt:2769,1-2775,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2619,7 +2781,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile, "WolframLanguage", "MCPServerName" -> "WolframDev", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-OptionOverride-Install@@Tests/InstallMCPServer.wlt:2618,1-2623,2"
+    TestID   -> "MCPServerName-OptionOverride-Install@@Tests/InstallMCPServer.wlt:2780,1-2785,2"
 ]
 
 VerificationTest[
@@ -2627,7 +2789,7 @@ VerificationTest[
     KeyExistsQ[ jsonContent[ "mcpServers" ], "WolframDev" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-OptionOverride-Verify@@Tests/InstallMCPServer.wlt:2625,1-2631,2"
+    TestID   -> "MCPServerName-OptionOverride-Verify@@Tests/InstallMCPServer.wlt:2787,1-2793,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2639,7 +2801,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile2, "WolframLanguage", "MCPServerName" -> "WolframDev2", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-TwoBuiltInWithOverrides-Install@@Tests/InstallMCPServer.wlt:2636,1-2643,2"
+    TestID   -> "MCPServerName-TwoBuiltInWithOverrides-Install@@Tests/InstallMCPServer.wlt:2798,1-2805,2"
 ]
 
 VerificationTest[
@@ -2648,7 +2810,7 @@ VerificationTest[
     KeyExistsQ[ jsonContent[ "mcpServers" ], "WolframDev2" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-TwoBuiltInWithOverrides-Verify@@Tests/InstallMCPServer.wlt:2645,1-2652,2"
+    TestID   -> "MCPServerName-TwoBuiltInWithOverrides-Verify@@Tests/InstallMCPServer.wlt:2807,1-2814,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2661,7 +2823,7 @@ VerificationTest[
     MemberQ[ wolframInstalls, KeyValuePattern[ "ConfigurationFile" -> mcpNameConfigFile3 ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-StaleRecordClearing-Setup@@Tests/InstallMCPServer.wlt:2657,1-2665,2"
+    TestID   -> "MCPServerName-StaleRecordClearing-Setup@@Tests/InstallMCPServer.wlt:2819,1-2827,2"
 ]
 
 VerificationTest[
@@ -2673,7 +2835,7 @@ VerificationTest[
     MemberQ[ wlInstalls, KeyValuePattern[ "ConfigurationFile" -> mcpNameConfigFile3 ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-StaleRecordClearing-Verify@@Tests/InstallMCPServer.wlt:2667,1-2677,2"
+    TestID   -> "MCPServerName-StaleRecordClearing-Verify@@Tests/InstallMCPServer.wlt:2829,1-2839,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2687,5 +2849,5 @@ VerificationTest[
     cleanupTestFiles[ { mcpNameConfigFile, mcpNameConfigFile2, mcpNameConfigFile3 } ],
     { Null.. },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-Cleanup@@Tests/InstallMCPServer.wlt:2682,1-2691,2"
+    TestID   -> "MCPServerName-Cleanup@@Tests/InstallMCPServer.wlt:2844,1-2853,2"
 ]

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -22,6 +22,7 @@ The following clients have built-in support for automatic configuration via `Ins
 | Gemini CLI | `"GeminiCLI"` | `"Gemini"` | JSON | No |
 | Goose | `"Goose"` | — | YAML | No |
 | Antigravity | `"Antigravity"` | `"GoogleAntigravity"` | JSON | No |
+| Junie | `"Junie"` | — | JSON | Yes |
 | Kiro | `"Kiro"` | — | JSON | Yes |
 | Codex CLI | `"Codex"` | `"OpenAICodex"` | TOML | Yes |
 | OpenCode | `"OpenCode"` | — | JSON | Yes |
@@ -200,6 +201,17 @@ extensions:
 ```
 
 Note: Goose uses YAML with an `extensions` key (not `mcpServers`) and renames several fields: `command` → `cmd`, `env` → `envs`. `InstallMCPServer` automatically adds the required `name`, `enabled: true`, `type: stdio`, and `timeout: 300` fields. Goose has no project-level configuration.
+
+### Junie
+
+| Scope | Config Location |
+|-------|----------------|
+| Global | `~/.junie/mcp/mcp.json` |
+| Project | `.junie/mcp/mcp.json` (in project root) |
+
+**Format:** Same as Claude Desktop (`mcpServers` key).
+
+Note: Junie is JetBrains' AI coding agent for IntelliJ-family IDEs (IntelliJ IDEA, PyCharm, WebStorm, GoLand, PhpStorm, RubyMine, RustRover, Rider) and the Junie CLI. The same configuration file is shared across all JetBrains IDEs and the standalone CLI.
 
 ### Kiro
 


### PR DESCRIPTION
## Summary

- Adds [Junie](https://www.jetbrains.com/junie/) (JetBrains' AI coding agent) as a supported MCP client in `InstallMCPServer`. A single entry covers the entire IntelliJ family (IntelliJ IDEA, PyCharm, WebStorm, GoLand, PhpStorm, RubyMine, RustRover, Rider) and the standalone `junie` CLI — they all read the same config file.
- Global config: `~/.junie/mcp/mcp.json`; project config: `.junie/mcp/mcp.json` (same relative path on every OS).
- Standard `mcpServers` JSON shape with plain `{command, args, env}` server entries — no `ServerConverter` required.
- Path-based client detection via `guessClientName` for project-scope files; user-scope files auto-match via the registered `installLocation`.
- Client count increases from 14 to 15; documentation and tests updated accordingly.

## Test plan

- [x] `TestReport` on `Tests/InstallMCPServer.wlt` — all 272 tests pass (adds 16 new Junie tests: install-location per OS, display/install name, project path, install/uninstall, preserve-existing, server-converter-identity, and a negative assertion that no Cline/Copilot/OpenCode-style decoration leaks into Junie's server entry).
- [x] `CodeInspector` on `Kernel/SupportedClients.wl`, `Kernel/InstallMCPServer.wl`, `Tests/InstallMCPServer.wlt` — no new issues.
- [ ] Manual verification: `InstallMCPServer[File["/tmp/junie-test.json"], "WolframLanguage", "ApplicationName" -> "Junie"]` produces a valid JSON config with `mcpServers.Wolfram` and no client-specific decoration.
- [ ] Manual verification: `InstallMCPServer[{"Junie", "/path/to/project"}, "WolframLanguage"]` writes to `.junie/mcp/mcp.json` under the project root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)