### PR TITLE
Fix stdio handling in Docker image entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,4 +79,4 @@ USER wolframengine
 WORKDIR /workspace
 
 # Entry point - MCP servers communicate via stdin/stdout
-CMD ["wolframscript", "-f", "/opt/AgentTools/Scripts/StartMCPServer.wls"]
+ENTRYPOINT ["/bin/bash", "-c", "exec wolframscript -script /opt/AgentTools/Scripts/StartMCPServer.wls"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -37,10 +37,9 @@ Use a free [Wolfram Engine Developer License](https://www.wolfram.com/developer-
 1. Get a free license at https://www.wolfram.com/developer-license/
 2. Activate once interactively:
    ```bash
-   docker run -it \
+   docker run -it --entrypoint wolframscript \
      -v ./Licensing:/root/.WolframEngine/Licensing \
-     ghcr.io/wolframresearch/mcpserver:latest \
-     wolframscript
+     ghcr.io/wolframresearch/mcpserver:latest
    ```
 3. Enter your Wolfram ID credentials when prompted
 4. For subsequent runs, mount the same licensing directory:


### PR DESCRIPTION
## Summary
- Wrap `wolframscript` in `bash -c` with `exec` so stdin/stdout are correctly wired for MCP JSON-RPC communication when the container runs
- Switch from `CMD` to `ENTRYPOINT` and use the `-script` flag instead of `-f`

## Test plan
- [ ] Build the Docker image and run it as an MCP server via an MCP client (e.g. Claude Code) and confirm the server initializes and handles requests over stdio
- [ ] Verify the container still exits cleanly when the client disconnects (no orphaned `wolframscript` process from the bash wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)