### PR TITLE
Bugfix: Override ENTRYPOINT in Docker image test step

### DIFF
--- a/.github/workflows/Docker.yml
+++ b/.github/workflows/Docker.yml
@@ -92,4 +92,5 @@ jobs:
         echo "Image pulled successfully"
         # Basic sanity check: verify that the container can start.
         # Note: Full runtime test requires Wolfram Engine license.
-        docker run --rm --env WOLFRAMSCRIPT_ENTITLEMENTID "$IMAGE_TAG" wolframscript -code '$Version'
+        # Override ENTRYPOINT since the default starts the MCP server on stdin.
+        docker run --rm --entrypoint wolframscript --env WOLFRAMSCRIPT_ENTITLEMENTID "$IMAGE_TAG" -code '$Version'


### PR DESCRIPTION
## Summary
- The Docker workflow's test step was hanging after the Dockerfile switched from `CMD` to `ENTRYPOINT`: trailing args (`wolframscript -code '\$Version'`) were appended to the MCP server entrypoint instead of replacing it, so the container started the server and blocked on stdin.
- Fix by passing `--entrypoint wolframscript` to `docker run`, with `-code '\$Version'` as args to that entrypoint.

## Test plan
- [ ] Trigger the Docker workflow (via `workflow_dispatch` or a push to `release/paclet`) and confirm the "Test Docker image" step completes and prints a version string instead of hanging until timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)