### PR TITLE
Bugfix: Fall back when AppearanceElements option is unsupported

### DIFF
--- a/Kernel/UIResources.wl
+++ b/Kernel/UIResources.wl
@@ -48,13 +48,10 @@ deployCloudNotebookForMCPApp[ nb_Notebook, identifier_ ] := Enclose[
             "Target"
         ];
 
-        deployed = CloudDeploy[
-            nb,
-            target,
-            AppearanceElements -> None,
-            AutoRemove         -> True,
-            IconRules          -> { },
-            Permissions        -> { "All" -> { "Read", "Interact" } }
+        deployed = ConfirmMatch[
+            cloudDeployTryAppearanceElements[ nb, target ],
+            _CloudObject | _? FailureQ,
+            "Deployed"
         ];
 
         If[ MatchQ[ deployed, _CloudObject ],
@@ -68,6 +65,38 @@ deployCloudNotebookForMCPApp[ nb_Notebook, identifier_ ] := Enclose[
 ];
 
 deployCloudNotebookForMCPApp // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*cloudDeployTryAppearanceElements*)
+(* This tries to CloudDeploy with AppearanceElements -> None, since the footer links will not be clickable in the app.
+   However, some cloud accounts do not support this option, which causes CloudDeploy to fail with a message.
+   In that case, we retry without the AppearanceElements option. *)
+cloudDeployTryAppearanceElements // beginDefinition;
+
+cloudDeployTryAppearanceElements[ expr_, target_ ] := Quiet[
+    Check[
+        CloudDeploy[
+            expr,
+            target,
+            AppearanceElements -> None,
+            AutoRemove         -> True,
+            IconRules          -> { },
+            Permissions        -> { "All" -> { "Read", "Interact" } }
+        ],
+        CloudDeploy[
+            expr,
+            target,
+            AutoRemove  -> True,
+            IconRules   -> { },
+            Permissions -> { "All" -> { "Read", "Interact" } }
+        ],
+        { CloudDeploy::appearancenotsup }
+    ],
+    { CloudDeploy::appearancenotsup }
+];
+
+cloudDeployTryAppearanceElements // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Kernel/UIResources.wl
+++ b/Kernel/UIResources.wl
@@ -19,8 +19,9 @@ $toolUIAssociations = <|
     "WolframAlpha" :> If[ $deployCloudNotebooks, "ui://wolfram/wolframalpha-viewer", None ]
 |>;
 
-$deployedNotebookRoot  = "AgentTools/Notebooks";
-$deployCloudNotebooks := $deployCloudNotebooks = $CloudConnected; (* must be connected to deploy notebooks *)
+$includeAppearanceElements = False;
+$deployedNotebookRoot      = "AgentTools/Notebooks";
+$deployCloudNotebooks     := $deployCloudNotebooks = $CloudConnected; (* must be connected to deploy notebooks *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -69,11 +70,14 @@ deployCloudNotebookForMCPApp // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*cloudDeployTryAppearanceElements*)
+cloudDeployTryAppearanceElements // beginDefinition;
+
+cloudDeployTryAppearanceElements[ expr_, target_ ] /; $includeAppearanceElements :=
+    cloudDeployWithAppearanceElements[ expr, target ];
+
 (* This tries to CloudDeploy with AppearanceElements -> None, since the footer links will not be clickable in the app.
    However, some cloud accounts do not support this option, which causes CloudDeploy to fail with a message.
    In that case, we retry without the AppearanceElements option. *)
-cloudDeployTryAppearanceElements // beginDefinition;
-
 cloudDeployTryAppearanceElements[ expr_, target_ ] := Quiet[
     Check[
         CloudDeploy[
@@ -84,19 +88,30 @@ cloudDeployTryAppearanceElements[ expr_, target_ ] := Quiet[
             IconRules          -> { },
             Permissions        -> { "All" -> { "Read", "Interact" } }
         ],
-        CloudDeploy[
-            expr,
-            target,
-            AutoRemove  -> True,
-            IconRules   -> { },
-            Permissions -> { "All" -> { "Read", "Interact" } }
-        ],
+        (* Disable this check for the remainder of the session: *)
+        $includeAppearanceElements = True;
+        cloudDeployWithAppearanceElements[ expr, target ],
         { CloudDeploy::appearancenotsup }
     ],
     { CloudDeploy::appearancenotsup }
 ];
 
 cloudDeployTryAppearanceElements // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*cloudDeployWithAppearanceElements*)
+cloudDeployWithAppearanceElements // beginDefinition;
+
+cloudDeployWithAppearanceElements[ expr_, target_ ] := CloudDeploy[
+    expr,
+    target,
+    AutoRemove  -> True,
+    IconRules   -> { },
+    Permissions -> { "All" -> { "Read", "Interact" } }
+];
+
+cloudDeployWithAppearanceElements // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -2,7 +2,7 @@ PacletObject[ <|
     "Name"             -> "Wolfram/AgentTools",
     "Description"      -> "Provides tools and integrations for connecting Wolfram Language to AI agents and LLMs",
     "Creator"          -> "Richard Hennigan (Wolfram Research)",
-    "Version"          -> "2.1.0",
+    "Version"          -> "2.1.1",
     "WolframVersion"   -> "14.3+",
     "PublisherID"      -> "Wolfram",
     "License"          -> "MIT",

--- a/docs/mcp-apps.md
+++ b/docs/mcp-apps.md
@@ -75,6 +75,8 @@ Tools with UI-enhanced behavior:
 
 These enhancements require both MCP Apps support and an active Wolfram Cloud connection. The session flag `$deployCloudNotebooks` (initialized from `$CloudConnected`) gates deployment: if a `CloudDeploy` call fails at runtime, the helper `deployCloudNotebookForMCPApp` sets the flag to `False` and the tools fall back to their standard (non-UI) results for the rest of the session rather than surfacing an internal failure.
 
+Cloud notebooks are deployed with `AppearanceElements -> None` by default, which hides the footer links that would not be clickable inside the MCP App iframe. Some cloud accounts reject this option with `CloudDeploy::appearancenotsup`; in that case the deployment is transparently retried without `AppearanceElements`, and the unsupported status is cached in a session flag (`$includeAppearanceElements`) so subsequent deployments skip the failing attempt.
+
 The fallback is per-tool:
 
 - `WolframLanguageEvaluator` always has a text/image result it can return, so it degrades in place.


### PR DESCRIPTION
## Summary

- Fix `MCP Apps` cloud notebook deployment failing on accounts that do not support `AppearanceElements -> None` by transparently retrying `CloudDeploy` without the option on `CloudDeploy::appearancenotsup`.
- Cache the unsupported status in a session flag (`$includeAppearanceElements`) so subsequent deployments skip the failing attempt instead of retrying and emitting a message every time.
- Bump paclet version to 2.1.1 and document the new fallback behavior in `docs/mcp-apps.md`.

Fixes #155.

## Test plan

- [x] On an account that supports `AppearanceElements -> None`: call `WolframLanguageEvaluator` / `WolframAlpha` via an MCP Apps client and confirm the deployed notebook has no footer links.
- [x] On an account that does NOT support `AppearanceElements -> None`: call the same tools and confirm deployment succeeds (with footer links visible) rather than failing.
- [x] After a first unsupported failure, confirm that `$includeAppearanceElements` is `True` and subsequent deployments do not emit `CloudDeploy::appearancenotsup`.
- [ ] Run `Tests/MCPApps.wlt` and related MCP Apps tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)