### PR TITLE
Per-client default toolset for Automatic resolution

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
         "alnum",
         "AmazonQ",
         "amzq",
+        "appname",
         "Auggie",
         "BUILDKIT",
         "buildx",

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/settings.local.json
 .claude/worktrees/
+.mcp.json
 
 # Git merge-conflict artifacts (created by 3-way mergetools)
 *_BACKUP_*

--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -79,6 +79,7 @@ BeginPackage[ "Wolfram`AgentTools`Common`" ];
 `exportMarkdownString;
 
 (* Shared symbols with DeployAgentTools: *)
+`defaultToolsetForTarget;
 `guessClientName;
 `installLocation;
 `projectInstallLocation;

--- a/Kernel/DeployAgentTools.wl
+++ b/Kernel/DeployAgentTools.wl
@@ -265,7 +265,18 @@ DeployAgentTools[ target_, opts: $$deployAgentToolsOptions ] :=
     catchMine @ DeployAgentTools[ target, Automatic, opts ];
 
 DeployAgentTools[ target_, Automatic, opts: $$deployAgentToolsOptions ] :=
-    catchMine @ DeployAgentTools[ target, defaultToolsetForTarget @ target, opts ];
+    catchMine @ DeployAgentTools[
+        target,
+        defaultToolsetForTarget[
+            target,
+            OptionValue[
+                InstallMCPServer,
+                FilterRules[ { opts }, Options @ InstallMCPServer ],
+                "ApplicationName"
+            ]
+        ],
+        opts
+    ];
 
 DeployAgentTools[ target_, server_, opts: $$deployAgentToolsOptions ] :=
     catchMine @ deployAgentTools[ target, ensureMCPServerExists @ MCPServerObject @ server, opts ];

--- a/Kernel/DeployAgentTools.wl
+++ b/Kernel/DeployAgentTools.wl
@@ -265,7 +265,7 @@ DeployAgentTools[ target_, opts: $$deployAgentToolsOptions ] :=
     catchMine @ DeployAgentTools[ target, Automatic, opts ];
 
 DeployAgentTools[ target_, Automatic, opts: $$deployAgentToolsOptions ] :=
-    catchMine @ DeployAgentTools[ target, $defaultMCPServer, opts ];
+    catchMine @ DeployAgentTools[ target, defaultToolsetForTarget @ target, opts ];
 
 DeployAgentTools[ target_, server_, opts: $$deployAgentToolsOptions ] :=
     catchMine @ deployAgentTools[ target, ensureMCPServerExists @ MCPServerObject @ server, opts ];

--- a/Kernel/InstallMCPServer.wl
+++ b/Kernel/InstallMCPServer.wl
@@ -38,7 +38,11 @@ InstallMCPServer[ target_, opts: OptionsPattern[ ] ] :=
     catchMine @ InstallMCPServer[ target, Automatic, opts ];
 
 InstallMCPServer[ target_, Automatic, opts: OptionsPattern[ ] ] :=
-    catchMine @ InstallMCPServer[ target, defaultToolsetForTarget @ target, opts ];
+    catchMine @ InstallMCPServer[
+        target,
+        defaultToolsetForTarget[ target, OptionValue[ "ApplicationName" ] ],
+        opts
+    ];
 
 InstallMCPServer[ target_File? fileQ, server0_String? pacletQualifiedNameQ, opts: OptionsPattern[ ] ] :=
     catchMine @ (

--- a/Kernel/InstallMCPServer.wl
+++ b/Kernel/InstallMCPServer.wl
@@ -38,7 +38,7 @@ InstallMCPServer[ target_, opts: OptionsPattern[ ] ] :=
     catchMine @ InstallMCPServer[ target, Automatic, opts ];
 
 InstallMCPServer[ target_, Automatic, opts: OptionsPattern[ ] ] :=
-    catchMine @ InstallMCPServer[ target, $defaultMCPServer, opts ];
+    catchMine @ InstallMCPServer[ target, defaultToolsetForTarget @ target, opts ];
 
 InstallMCPServer[ target_File? fileQ, server0_String? pacletQualifiedNameQ, opts: OptionsPattern[ ] ] :=
     catchMine @ (

--- a/Kernel/SupportedClients.wl
+++ b/Kernel/SupportedClients.wl
@@ -271,6 +271,13 @@ defaultToolsetForTarget[ file_? fileQ ] := Enclose[
 
 defaultToolsetForTarget[ _ ] := $defaultMCPServer;
 
+(* 2-arg form: an explicit ApplicationName takes precedence over target-based
+   resolution.  This lets callers like `InstallMCPServer[File[...], Automatic,
+   "ApplicationName" -> "Cline"]` pick up Cline's `DefaultToolset` even when the
+   file path doesn't reveal the client. *)
+defaultToolsetForTarget[ _, name_String ] := defaultToolsetForTarget @ name;
+defaultToolsetForTarget[ target_, _ ]     := defaultToolsetForTarget @ target;
+
 defaultToolsetForTarget // endDefinition;
 
 (* ::**************************************************************************************************************:: *)

--- a/Kernel/SupportedClients.wl
+++ b/Kernel/SupportedClients.wl
@@ -21,6 +21,7 @@ $SupportedMCPClients := WithCleanup[
 $supportedMCPClients = <|
     "ClaudeDesktop" -> <|
         "DisplayName"     -> "Claude Desktop",
+        "DefaultToolset"  -> "Wolfram",
         "Aliases"         -> { "Claude" },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -32,6 +33,7 @@ $supportedMCPClients = <|
     |>,
     "ClaudeCode" -> <|
         "DisplayName"     -> "Claude Code",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -41,6 +43,7 @@ $supportedMCPClients = <|
     |>,
     "Cursor" -> <|
         "DisplayName"     -> "Cursor",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -49,6 +52,7 @@ $supportedMCPClients = <|
     |>,
     "GeminiCLI" -> <|
         "DisplayName"     -> "Gemini CLI",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { "Gemini" },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -57,6 +61,7 @@ $supportedMCPClients = <|
     |>,
     "Goose" -> <|
         "DisplayName"     -> "Goose",
+        "DefaultToolset"  -> "Wolfram",
         "Aliases"         -> { },
         "ConfigFormat"    -> "YAML",
         "ConfigKey"       -> { "extensions" },
@@ -69,6 +74,7 @@ $supportedMCPClients = <|
     |>,
     "Antigravity" -> <|
         "DisplayName"     -> "Antigravity",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { "GoogleAntigravity" },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -77,6 +83,7 @@ $supportedMCPClients = <|
     |>,
     "AugmentCode" -> <|
         "DisplayName"     -> "Augment Code",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { "Auggie", "Augment" },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -86,6 +93,7 @@ $supportedMCPClients = <|
     |>,
     "AugmentCodeIDE" -> <|
         "DisplayName"     -> "Augment Code IDE",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { "AugmentIDE", "AuggieIDE" },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { },
@@ -102,6 +110,7 @@ $supportedMCPClients = <|
     |>,
     "Codex" -> <|
         "DisplayName"     -> "Codex CLI",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { "OpenAICodex" },
         "ConfigFormat"    -> "TOML",
         "ConfigKey"       -> { "mcp_servers" },
@@ -111,6 +120,7 @@ $supportedMCPClients = <|
     |>,
     "CopilotCLI" -> <|
         "DisplayName"     -> "Copilot CLI",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { "Copilot" },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -120,6 +130,7 @@ $supportedMCPClients = <|
     |>,
     "Kiro" -> <|
         "DisplayName"     -> "Kiro",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -130,6 +141,7 @@ $supportedMCPClients = <|
     |>,
     "OpenCode" -> <|
         "DisplayName"     -> "OpenCode",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcp" },
@@ -140,6 +152,7 @@ $supportedMCPClients = <|
     |>,
     "VisualStudioCode" -> <|
         "DisplayName"     -> "Visual Studio Code",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { "VSCode" },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "servers" },
@@ -153,6 +166,7 @@ $supportedMCPClients = <|
     |>,
     "Windsurf" -> <|
         "DisplayName"     -> "Windsurf",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { "Codeium" },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -161,6 +175,7 @@ $supportedMCPClients = <|
     |>,
     "AmazonQ" -> <|
         "DisplayName"     -> "Amazon Q Developer",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { "AmazonQDeveloper", "Q", "QDeveloper" },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -170,6 +185,7 @@ $supportedMCPClients = <|
     |>,
     "Cline" -> <|
         "DisplayName"     -> "Cline",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "mcpServers" },
@@ -186,6 +202,7 @@ $supportedMCPClients = <|
     |>,
     "Zed" -> <|
         "DisplayName"     -> "Zed",
+        "DefaultToolset"  -> "WolframLanguage",
         "Aliases"         -> { },
         "ConfigFormat"    -> "JSON",
         "ConfigKey"       -> { "context_servers" },
@@ -228,6 +245,33 @@ $aliasToCanonicalName := $aliasToCanonicalName = Association @ Flatten @ KeyValu
     Function[ { name, meta }, Thread[ meta[ "Aliases" ] -> name ] ],
     $supportedMCPClients
 ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*defaultToolsetForTarget*)
+defaultToolsetForTarget // beginDefinition;
+
+defaultToolsetForTarget[ name_String ] :=
+    Replace[
+        Lookup[
+            Lookup[ $supportedMCPClients, toInstallName @ name, <| |> ],
+            "DefaultToolset",
+            $defaultMCPServer
+        ],
+        Except[ _String ] :> $defaultMCPServer
+    ];
+
+defaultToolsetForTarget[ { name_String, _ } ] :=
+    defaultToolsetForTarget @ name;
+
+defaultToolsetForTarget[ file_? fileQ ] := Enclose[
+    defaultToolsetForTarget @ ConfirmBy[ guessClientName @ file, StringQ, "Guess" ],
+    $defaultMCPServer &
+];
+
+defaultToolsetForTarget[ _ ] := $defaultMCPServer;
+
+defaultToolsetForTarget // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Kernel/Tools/Context.wl
+++ b/Kernel/Tools/Context.wl
@@ -262,11 +262,14 @@ relatedWolframAlphaResults[ context_String ] := Enclose[
         includeWLResults = Replace[ $waIncludeWLResults, Except[ True|False ] :> Automatic ];
 
         prompt = ConfirmBy[
-            cb`RelatedWolframAlphaResults[
-                context,
-                "Prompt",
-                "MaxItems"         -> maxItems,
-                "IncludeWLResults" -> includeWLResults
+            Quiet[
+                cb`RelatedWolframAlphaResults[
+                    context,
+                    "Prompt",
+                    "MaxItems"         -> maxItems,
+                    "IncludeWLResults" -> includeWLResults
+                ],
+                { WolframAlpha::kbserr }
             ],
             StringQ,
             "Prompt"

--- a/Kernel/Tools/WolframAlpha.wl
+++ b/Kernel/Tools/WolframAlpha.wl
@@ -59,11 +59,13 @@ $defaultMCPTools[ "WolframAlpha" ] := LLMTool @ <|
 (*wolframAlphaToolEvaluate*)
 wolframAlphaToolEvaluate // beginDefinition;
 
-wolframAlphaToolEvaluate[ as_ ] :=
+wolframAlphaToolEvaluate[ as_ ] := Quiet[
     If[ TrueQ @ $clientSupportsUI && TrueQ @ $deployCloudNotebooks,
         wolframAlphaToolEvaluateUI @ as,
         wolframAlphaToolEvaluate[ as, cb`$DefaultTools[ "WolframAlpha" ][ as ] ]
-    ];
+    ],
+    { WolframAlpha::kbserr }
+];
 
 wolframAlphaToolEvaluate[ as_, result_String ] := extractWolframAlphaImages @ result;
 wolframAlphaToolEvaluate[ as_, KeyValuePattern[ "String" -> result_String ] ] := extractWolframAlphaImages @ result;

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ InstallMCPServer["ClaudeDesktop"]
 (* Out: Success["InstallMCPServer", <|...|>] *)
 ```
 
+When no server is specified, each client gets a sensible default — chat clients (Claude Desktop, Goose) get the general-purpose `"Wolfram"` server, while coding clients (Claude Code, Cursor, VS Code, etc.) get `"WolframLanguage"`. Pass an explicit server name as the second argument to override.
+
 After restarting Claude Desktop, it will have access to Wolfram knowledge and tools:
 
 ![Claude Desktop Screenshot](.github/images/sk6raevruc0q.png)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ InstallMCPServer["ClaudeDesktop"]
 (* Out: Success["InstallMCPServer", <|...|>] *)
 ```
 
-When no server is specified, each client gets a sensible default — chat clients (Claude Desktop, Goose) get the general-purpose `"Wolfram"` server, while coding clients (Claude Code, Cursor, VS Code, etc.) get `"WolframLanguage"`. Pass an explicit server name as the second argument to override.
+When no server is specified, each named client gets a sensible default — chat clients (Claude Desktop, Goose) get the general-purpose `"Wolfram"` server, while coding clients (Claude Code, Cursor, VS Code, etc.) get `"WolframLanguage"`. For `File[...]` targets, the same per-client default applies when the path or content identifies a known client (or `"ApplicationName"` is supplied); otherwise it falls back to `"Wolfram"`. Pass an explicit server name as the second argument to override.
 
 After restarting Claude Desktop, it will have access to Wolfram knowledge and tools:
 

--- a/Tests/DeployAgentTools.wlt
+++ b/Tests/DeployAgentTools.wlt
@@ -1081,13 +1081,52 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
-(*Cleanup*)
+(*DeployAgentTools Automatic with File target + ApplicationName*)
+(* For arbitrary File[...] targets, an explicit ApplicationName option must
+   drive the Automatic toolset choice instead of falling through to "Wolfram". *)
 VerificationTest[
     Quiet @ catchAlways @ DeleteObject @ autoDeploy1Arg;
     Quiet @ DeleteDirectory[ autoDeployDir, DeleteContents -> True ];
+    autoDeployDir = CreateDirectory[ ];
+    autoDeployFile = File @ FileNameJoin @ { autoDeployDir, "custom_config_" <> CreateUUID[ ] <> ".json" };
+    autoDeployFileApp = DeployAgentTools[
+        autoDeployFile,
+        Automatic,
+        "ApplicationName" -> "Cline",
+        "VerifyLLMKit"    -> False
+    ];
+    autoDeployFileApp[ "Toolset" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DeployAgentTools-Automatic-File-AppName-Cline@@Tests/DeployAgentTools.wlt:1087,1-1102,2"
+]
+
+VerificationTest[
+    Quiet @ catchAlways @ DeleteObject @ autoDeployFileApp;
+    Quiet @ DeleteDirectory[ autoDeployDir, DeleteContents -> True ];
+    autoDeployDir = CreateDirectory[ ];
+    autoDeployFile = File @ FileNameJoin @ { autoDeployDir, "custom_config_" <> CreateUUID[ ] <> ".json" };
+    autoDeployFileChat = DeployAgentTools[
+        autoDeployFile,
+        Automatic,
+        "ApplicationName" -> "ClaudeDesktop",
+        "VerifyLLMKit"    -> False
+    ];
+    autoDeployFileChat[ "Toolset" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DeployAgentTools-Automatic-File-AppName-ClaudeDesktop@@Tests/DeployAgentTools.wlt:1104,1-1119,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Cleanup*)
+VerificationTest[
+    Quiet @ catchAlways @ DeleteObject @ autoDeployFileChat;
+    Quiet @ DeleteDirectory[ autoDeployDir, DeleteContents -> True ];
     True,
     True,
-    TestID -> "DeployAgentTools-Automatic-Cleanup@@Tests/DeployAgentTools.wlt:1085,1-1091,2"
+    TestID -> "DeployAgentTools-Automatic-Cleanup@@Tests/DeployAgentTools.wlt:1124,1-1130,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/DeployAgentTools.wlt
+++ b/Tests/DeployAgentTools.wlt
@@ -1120,13 +1120,56 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
-(*Cleanup*)
+(*DeployAgentTools Automatic with recognizable File target (no ApplicationName)*)
+(* When the File[...] path itself identifies a known client, Automatic must
+   pick up that client's DefaultToolset without needing an explicit
+   "ApplicationName" option.  These guard against regressions where
+   path-based detection silently drops back to "Wolfram". *)
+
+(* .mcp.json -> ClaudeCode -> "WolframLanguage" *)
 VerificationTest[
     Quiet @ catchAlways @ DeleteObject @ autoDeployFileChat;
     Quiet @ DeleteDirectory[ autoDeployDir, DeleteContents -> True ];
+    autoDeployDir = CreateDirectory[ ];
+    autoDeployFile = File @ FileNameJoin @ { autoDeployDir, ".mcp.json" };
+    autoDeployFilePath = DeployAgentTools[
+        autoDeployFile,
+        Automatic,
+        "VerifyLLMKit" -> False
+    ];
+    autoDeployFilePath[ "Toolset" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DeployAgentTools-Automatic-File-ClaudeCodeProject@@Tests/DeployAgentTools.wlt:1130,1-1144,2"
+]
+
+(* .vscode/mcp.json -> VisualStudioCode -> "WolframLanguage" *)
+VerificationTest[
+    Quiet @ catchAlways @ DeleteObject @ autoDeployFilePath;
+    Quiet @ DeleteDirectory[ autoDeployDir, DeleteContents -> True ];
+    autoDeployDir = CreateDirectory[ ];
+    CreateDirectory @ FileNameJoin @ { autoDeployDir, ".vscode" };
+    autoDeployFile = File @ FileNameJoin @ { autoDeployDir, ".vscode", "mcp.json" };
+    autoDeployFileVSCode = DeployAgentTools[
+        autoDeployFile,
+        Automatic,
+        "VerifyLLMKit" -> False
+    ];
+    autoDeployFileVSCode[ "Toolset" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DeployAgentTools-Automatic-File-VSCodeProject@@Tests/DeployAgentTools.wlt:1147,1-1162,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Cleanup*)
+VerificationTest[
+    Quiet @ catchAlways @ DeleteObject @ autoDeployFileVSCode;
+    Quiet @ DeleteDirectory[ autoDeployDir, DeleteContents -> True ];
     True,
     True,
-    TestID -> "DeployAgentTools-Automatic-Cleanup@@Tests/DeployAgentTools.wlt:1124,1-1130,2"
+    TestID -> "DeployAgentTools-Automatic-Cleanup@@Tests/DeployAgentTools.wlt:1167,1-1173,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/DeployAgentTools.wlt
+++ b/Tests/DeployAgentTools.wlt
@@ -1044,4 +1044,50 @@ VerificationTest[
     TestID -> "DeployAgentTools-Cleanup@@Tests/DeployAgentTools.wlt:1035,1-1045,2"
 ]
 
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Automatic toolset resolution (per-client DefaultToolset)*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*DeployAgentTools with Automatic resolution*)
+VerificationTest[
+    autoDeployDir = CreateDirectory[ ];
+    autoDeployAuto = DeployAgentTools[
+        { "ClaudeCode", autoDeployDir },
+        Automatic,
+        "VerifyLLMKit" -> False
+    ];
+    autoDeployAuto[ "Toolset" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DeployAgentTools-Automatic-ClaudeCode@@Tests/DeployAgentTools.wlt:1054,1-1065,2"
+]
+
+VerificationTest[
+    autoDeployAutoUUID = autoDeployAuto[ "UUID" ];
+    Quiet @ catchAlways @ DeleteObject @ autoDeployAuto;
+    Quiet @ DeleteDirectory[ autoDeployDir, DeleteContents -> True ];
+    autoDeployDir = CreateDirectory[ ];
+    autoDeploy1Arg = DeployAgentTools[
+        { "ClaudeCode", autoDeployDir },
+        "VerifyLLMKit" -> False
+    ];
+    autoDeploy1Arg[ "Toolset" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DeployAgentTools-1Arg-ClaudeCode@@Tests/DeployAgentTools.wlt:1067,1-1080,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Cleanup*)
+VerificationTest[
+    Quiet @ catchAlways @ DeleteObject @ autoDeploy1Arg;
+    Quiet @ DeleteDirectory[ autoDeployDir, DeleteContents -> True ];
+    True,
+    True,
+    TestID -> "DeployAgentTools-Automatic-Cleanup@@Tests/DeployAgentTools.wlt:1085,1-1091,2"
+]
+
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -3591,4 +3591,134 @@ VerificationTest[
     TestID   -> "MCPServerName-Cleanup@@Tests/InstallMCPServer.wlt:3583,1-3592,2"
 ]
 
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Automatic toolset resolution (per-client DefaultToolset)*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*defaultToolsetForTarget helper*)
+VerificationTest[
+    defaultToolsetForTarget = Wolfram`AgentTools`Common`defaultToolsetForTarget;
+    defaultToolsetForTarget[ "ClaudeCode" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-ClaudeCode@@Tests/InstallMCPServer.wlt:3601,1-3607,2"
+]
+
+VerificationTest[
+    defaultToolsetForTarget[ "ClaudeDesktop" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-ClaudeDesktop@@Tests/InstallMCPServer.wlt:3609,1-3614,2"
+]
+
+VerificationTest[
+    defaultToolsetForTarget[ "Goose" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-Goose@@Tests/InstallMCPServer.wlt:3616,1-3621,2"
+]
+
+VerificationTest[
+    defaultToolsetForTarget[ "Cursor" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-Cursor@@Tests/InstallMCPServer.wlt:3623,1-3628,2"
+]
+
+(* Aliases resolve to their canonical client's default *)
+VerificationTest[
+    defaultToolsetForTarget[ "Claude" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-Alias-Claude@@Tests/InstallMCPServer.wlt:3631,1-3636,2"
+]
+
+VerificationTest[
+    defaultToolsetForTarget[ "VSCode" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-Alias-VSCode@@Tests/InstallMCPServer.wlt:3638,1-3643,2"
+]
+
+(* Unknown client falls back to $defaultMCPServer *)
+VerificationTest[
+    defaultToolsetForTarget[ "TotallyMadeUpClient" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-Unknown@@Tests/InstallMCPServer.wlt:3646,1-3651,2"
+]
+
+(* {name, dir} project-install form dispatches on the name *)
+VerificationTest[
+    defaultToolsetForTarget[ { "ClaudeCode", "/some/dir" } ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-NameDir-ClaudeCode@@Tests/InstallMCPServer.wlt:3654,1-3659,2"
+]
+
+VerificationTest[
+    defaultToolsetForTarget[ { "ClaudeDesktop", "/some/dir" } ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-NameDir-ClaudeDesktop@@Tests/InstallMCPServer.wlt:3661,1-3666,2"
+]
+
+(* File target with no client match falls back *)
+VerificationTest[
+    defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ] ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-File-Unknown@@Tests/InstallMCPServer.wlt:3669,1-3674,2"
+]
+
+(* Non-target argument falls back *)
+VerificationTest[
+    defaultToolsetForTarget[ 42 ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-NonTarget@@Tests/InstallMCPServer.wlt:3677,1-3682,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*InstallMCPServer with Automatic resolution*)
+VerificationTest[
+    autoTestDir = CreateDirectory[ ];
+    autoInstallResultAuto = InstallMCPServer[
+        { "ClaudeCode", autoTestDir },
+        Automatic,
+        "VerifyLLMKit" -> False
+    ];
+    autoInstallResultAuto[[ 2 ]][ "MCPServerObject" ][ "Name" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Automatic-ClaudeCode@@Tests/InstallMCPServer.wlt:3687,1-3698,2"
+]
+
+(* 1-arg form should give the same result as Automatic *)
+VerificationTest[
+    Quiet @ DeleteDirectory[ autoTestDir, DeleteContents -> True ];
+    autoTestDir = CreateDirectory[ ];
+    autoInstallResult1Arg = InstallMCPServer[
+        { "ClaudeCode", autoTestDir },
+        "VerifyLLMKit" -> False
+    ];
+    autoInstallResult1Arg[[ 2 ]][ "MCPServerObject" ][ "Name" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-1Arg-ClaudeCode@@Tests/InstallMCPServer.wlt:3701,1-3712,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Cleanup*)
+VerificationTest[
+    Quiet @ DeleteDirectory[ autoTestDir, DeleteContents -> True ];
+    True,
+    True,
+    TestID -> "Automatic-Cleanup@@Tests/InstallMCPServer.wlt:3717,1-3722,2"
+]
+
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -3673,12 +3673,41 @@ VerificationTest[
     TestID   -> "DefaultToolsetForTarget-File-Unknown@@Tests/InstallMCPServer.wlt:3669,1-3674,2"
 ]
 
+(* Recognizable File[...] targets resolve via path-based client detection
+   (no ApplicationName needed). These guard against regressions where
+   defaultToolsetForTarget would silently fall back to "Wolfram" for files
+   that guessClientName already identifies. *)
+
+(* .mcp.json -> ClaudeCode (coding client, "WolframLanguage") *)
+VerificationTest[
+    defaultToolsetForTarget[ File[ "/some/project/.mcp.json" ] ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-File-ClaudeCodeProject@@Tests/InstallMCPServer.wlt:3682,1-3687,2"
+]
+
+(* .vscode/mcp.json -> VisualStudioCode (coding client, "WolframLanguage") *)
+VerificationTest[
+    defaultToolsetForTarget[ File[ "/some/project/.vscode/mcp.json" ] ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-File-VSCodeProject@@Tests/InstallMCPServer.wlt:3690,1-3695,2"
+]
+
+(* opencode.json -> OpenCode (coding client, "WolframLanguage") *)
+VerificationTest[
+    defaultToolsetForTarget[ File[ "/some/project/opencode.json" ] ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-File-OpenCodeProject@@Tests/InstallMCPServer.wlt:3698,1-3703,2"
+]
+
 (* Non-target argument falls back *)
 VerificationTest[
     defaultToolsetForTarget[ 42 ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-NonTarget@@Tests/InstallMCPServer.wlt:3677,1-3682,2"
+    TestID   -> "DefaultToolsetForTarget-NonTarget@@Tests/InstallMCPServer.wlt:3706,1-3711,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3690,14 +3719,14 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], "Cline" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-AppName-Cline@@Tests/InstallMCPServer.wlt:3689,1-3694,2"
+    TestID   -> "DefaultToolsetForTarget-File-AppName-Cline@@Tests/InstallMCPServer.wlt:3718,1-3723,2"
 ]
 
 VerificationTest[
     defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], "ClaudeDesktop" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:3696,1-3701,2"
+    TestID   -> "DefaultToolsetForTarget-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:3725,1-3730,2"
 ]
 
 (* Aliases route through toInstallName, so an alias picks up the canonical client's default *)
@@ -3705,7 +3734,7 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], "VSCode" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-AppName-Alias@@Tests/InstallMCPServer.wlt:3704,1-3709,2"
+    TestID   -> "DefaultToolsetForTarget-File-AppName-Alias@@Tests/InstallMCPServer.wlt:3733,1-3738,2"
 ]
 
 (* Automatic in the 2-arg form falls back to the existing target-based resolution *)
@@ -3713,7 +3742,7 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], Automatic ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-AppName-Automatic@@Tests/InstallMCPServer.wlt:3712,1-3717,2"
+    TestID   -> "DefaultToolsetForTarget-File-AppName-Automatic@@Tests/InstallMCPServer.wlt:3741,1-3746,2"
 ]
 
 (* String target is also overridden by an explicit ApplicationName *)
@@ -3721,7 +3750,7 @@ VerificationTest[
     defaultToolsetForTarget[ "ClaudeCode", "ClaudeDesktop" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-StringTarget-AppName@@Tests/InstallMCPServer.wlt:3720,1-3725,2"
+    TestID   -> "DefaultToolsetForTarget-StringTarget-AppName@@Tests/InstallMCPServer.wlt:3749,1-3754,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3737,7 +3766,7 @@ VerificationTest[
     autoInstallResultAuto[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Automatic-ClaudeCode@@Tests/InstallMCPServer.wlt:3730,1-3741,2"
+    TestID   -> "InstallMCPServer-Automatic-ClaudeCode@@Tests/InstallMCPServer.wlt:3759,1-3770,2"
 ]
 
 (* 1-arg form should give the same result as Automatic *)
@@ -3751,7 +3780,7 @@ VerificationTest[
     autoInstallResult1Arg[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-1Arg-ClaudeCode@@Tests/InstallMCPServer.wlt:3744,1-3755,2"
+    TestID   -> "InstallMCPServer-1Arg-ClaudeCode@@Tests/InstallMCPServer.wlt:3773,1-3784,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3770,7 +3799,7 @@ VerificationTest[
     autoInstallResultFileApp[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Automatic-File-AppName-Cline@@Tests/InstallMCPServer.wlt:3762,1-3774,2"
+    TestID   -> "InstallMCPServer-Automatic-File-AppName-Cline@@Tests/InstallMCPServer.wlt:3791,1-3803,2"
 ]
 
 VerificationTest[
@@ -3785,7 +3814,68 @@ VerificationTest[
     autoInstallResultFileChat[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Automatic-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:3776,1-3789,2"
+    TestID   -> "InstallMCPServer-Automatic-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:3805,1-3818,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*InstallMCPServer Automatic with recognizable File targets (no ApplicationName)*)
+(* When the File[...] path itself identifies a known client, Automatic must
+   resolve to that client's DefaultToolset without any "ApplicationName"
+   override.  These guard against regressions where path-based detection
+   silently drops back to the global default. *)
+
+(* .mcp.json -> ClaudeCode -> "WolframLanguage" *)
+VerificationTest[
+    autoRecognizableDir = CreateDirectory[ ];
+    autoRecognizableFile = File @ FileNameJoin @ { autoRecognizableDir, ".mcp.json" };
+    autoInstallResultFileClaudeCode = InstallMCPServer[
+        autoRecognizableFile,
+        Automatic,
+        "VerifyLLMKit" -> False
+    ];
+    autoInstallResultFileClaudeCode[[ 2 ]][ "MCPServerObject" ][ "Name" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Automatic-File-ClaudeCodeProject@@Tests/InstallMCPServer.wlt:3829,1-3841,2"
+]
+
+(* .vscode/mcp.json -> VisualStudioCode -> "WolframLanguage" *)
+VerificationTest[
+    Quiet @ DeleteDirectory[ autoRecognizableDir, DeleteContents -> True ];
+    autoRecognizableDir = CreateDirectory[ ];
+    CreateDirectory @ FileNameJoin @ { autoRecognizableDir, ".vscode" };
+    autoRecognizableFile = File @ FileNameJoin @ { autoRecognizableDir, ".vscode", "mcp.json" };
+    autoInstallResultFileVSCode = InstallMCPServer[
+        autoRecognizableFile,
+        Automatic,
+        "VerifyLLMKit" -> False
+    ];
+    autoInstallResultFileVSCode[[ 2 ]][ "MCPServerObject" ][ "Name" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Automatic-File-VSCodeProject@@Tests/InstallMCPServer.wlt:3844,1-3858,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*$SupportedMCPClients DefaultToolset coverage*)
+(* Every $SupportedMCPClients entry must expose a string DefaultToolset that
+   names a real predefined server.  This catches typos or missing metadata in
+   any client whose toolset isn't covered by an individual VerificationTest. *)
+VerificationTest[
+    Module[ { knownServers, validQ },
+        knownServers = Keys @ $DefaultMCPServers;
+        validQ = Function[ meta,
+            With[ { toolset = Lookup[ meta, "DefaultToolset" ] },
+                StringQ @ toolset && MemberQ[ knownServers, toolset ]
+            ]
+        ];
+        Keys @ Select[ $SupportedMCPClients, ! validQ[ # ] & ]
+    ],
+    { },
+    SameTest -> Equal,
+    TestID   -> "SupportedMCPClients-DefaultToolset-Coverage@@Tests/InstallMCPServer.wlt:3866,1-3879,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3793,10 +3883,11 @@ VerificationTest[
 (*Cleanup*)
 VerificationTest[
     Quiet @ DeleteDirectory[ autoTestDir, DeleteContents -> True ];
+    Quiet @ DeleteDirectory[ autoRecognizableDir, DeleteContents -> True ];
     cleanupTestFiles @ autoCustomFile;
     True,
     True,
-    TestID -> "Automatic-Cleanup@@Tests/InstallMCPServer.wlt:3794,1-3800,2"
+    TestID -> "Automatic-Cleanup@@Tests/InstallMCPServer.wlt:3884,1-3891,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -3683,6 +3683,49 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*defaultToolsetForTarget with explicit ApplicationName*)
+(* The 2-arg form lets callers override path-based resolution by passing an
+   explicit application name (the same string accepted by "ApplicationName"). *)
+VerificationTest[
+    defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], "Cline" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-File-AppName-Cline@@Tests/InstallMCPServer.wlt:3689,1-3694,2"
+]
+
+VerificationTest[
+    defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], "ClaudeDesktop" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:3696,1-3701,2"
+]
+
+(* Aliases route through toInstallName, so an alias picks up the canonical client's default *)
+VerificationTest[
+    defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], "VSCode" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-File-AppName-Alias@@Tests/InstallMCPServer.wlt:3704,1-3709,2"
+]
+
+(* Automatic in the 2-arg form falls back to the existing target-based resolution *)
+VerificationTest[
+    defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], Automatic ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-File-AppName-Automatic@@Tests/InstallMCPServer.wlt:3712,1-3717,2"
+]
+
+(* String target is also overridden by an explicit ApplicationName *)
+VerificationTest[
+    defaultToolsetForTarget[ "ClaudeCode", "ClaudeDesktop" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-StringTarget-AppName@@Tests/InstallMCPServer.wlt:3720,1-3725,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*InstallMCPServer with Automatic resolution*)
 VerificationTest[
     autoTestDir = CreateDirectory[ ];
@@ -3694,7 +3737,7 @@ VerificationTest[
     autoInstallResultAuto[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Automatic-ClaudeCode@@Tests/InstallMCPServer.wlt:3687,1-3698,2"
+    TestID   -> "InstallMCPServer-Automatic-ClaudeCode@@Tests/InstallMCPServer.wlt:3730,1-3741,2"
 ]
 
 (* 1-arg form should give the same result as Automatic *)
@@ -3708,7 +3751,41 @@ VerificationTest[
     autoInstallResult1Arg[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-1Arg-ClaudeCode@@Tests/InstallMCPServer.wlt:3701,1-3712,2"
+    TestID   -> "InstallMCPServer-1Arg-ClaudeCode@@Tests/InstallMCPServer.wlt:3744,1-3755,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*InstallMCPServer Automatic with File target + ApplicationName*)
+(* For arbitrary File[...] targets whose path doesn't reveal the client, an
+   explicit "ApplicationName" must drive the Automatic toolset choice. *)
+VerificationTest[
+    autoCustomFile = testConfigFile[ ];
+    autoInstallResultFileApp = InstallMCPServer[
+        autoCustomFile,
+        Automatic,
+        "ApplicationName" -> "Cline",
+        "VerifyLLMKit"    -> False
+    ];
+    autoInstallResultFileApp[[ 2 ]][ "MCPServerObject" ][ "Name" ],
+    "WolframLanguage",
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Automatic-File-AppName-Cline@@Tests/InstallMCPServer.wlt:3762,1-3774,2"
+]
+
+VerificationTest[
+    cleanupTestFiles @ autoCustomFile;
+    autoCustomFile = testConfigFile[ ];
+    autoInstallResultFileChat = InstallMCPServer[
+        autoCustomFile,
+        Automatic,
+        "ApplicationName" -> "ClaudeDesktop",
+        "VerifyLLMKit"    -> False
+    ];
+    autoInstallResultFileChat[[ 2 ]][ "MCPServerObject" ][ "Name" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-Automatic-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:3776,1-3789,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3716,9 +3793,10 @@ VerificationTest[
 (*Cleanup*)
 VerificationTest[
     Quiet @ DeleteDirectory[ autoTestDir, DeleteContents -> True ];
+    cleanupTestFiles @ autoCustomFile;
     True,
     True,
-    TestID -> "Automatic-Cleanup@@Tests/InstallMCPServer.wlt:3717,1-3722,2"
+    TestID -> "Automatic-Cleanup@@Tests/InstallMCPServer.wlt:3794,1-3800,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/docs/deploy-agent-tools.md
+++ b/docs/deploy-agent-tools.md
@@ -31,7 +31,7 @@ DeployAgentTools[target, server, opts]
 | Argument | Type | Description |
 |----------|------|-------------|
 | `target` | `String`, `File[...]`, or `{String, dir}` | The client to deploy to (same target formats as `InstallMCPServer`) |
-| `server` | `MCPServerObject`, `String`, or `Automatic` | The MCP server to deploy (defaults to `Automatic`, which resolves to the default `"Wolfram"` server) |
+| `server` | `MCPServerObject`, `String`, or `Automatic` | The MCP server to deploy. Defaults to `Automatic`, which resolves to the target client's default toolset (see [mcp-clients.md](mcp-clients.md#clients-with-installmcpserver-support)) — `"WolframLanguage"` for coding clients and `"Wolfram"` for chat clients. |
 
 ### Options
 

--- a/docs/deploy-agent-tools.md
+++ b/docs/deploy-agent-tools.md
@@ -31,7 +31,7 @@ DeployAgentTools[target, server, opts]
 | Argument | Type | Description |
 |----------|------|-------------|
 | `target` | `String`, `File[...]`, or `{String, dir}` | The client to deploy to (same target formats as `InstallMCPServer`) |
-| `server` | `MCPServerObject`, `String`, or `Automatic` | The MCP server to deploy. Defaults to `Automatic`, which resolves to the target client's default toolset (see [mcp-clients.md](mcp-clients.md#clients-with-installmcpserver-support)) — `"WolframLanguage"` for coding clients and `"Wolfram"` for chat clients. |
+| `server` | `MCPServerObject`, `String`, or `Automatic` | The MCP server to deploy. Defaults to `Automatic`, which resolves to the target client's default toolset (see [mcp-clients.md](mcp-clients.md#clients-with-installmcpserver-support)) — `"WolframLanguage"` for coding clients and `"Wolfram"` for chat clients. For `File[...]` targets the per-client default only applies when the path or content identifies a known client (or `"ApplicationName"` is supplied); otherwise it falls back to `"Wolfram"`. |
 
 ### Options
 

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -578,7 +578,7 @@ Each entry is keyed by the canonical client name and contains an association wit
 | `"ConfigKey"` | Yes | Key path to the servers section (e.g. `{"mcpServers"}` or `{"servers"}`) |
 | `"URL"` | Yes | Client's website or download page |
 | `"InstallLocation"` | Yes | Config file path(s) per OS (see below) |
-| `"DefaultToolset"` | No | Predefined server name to use when `InstallMCPServer`/`DeployAgentTools` is called with `Automatic`. Falls back to `"Wolfram"` if omitted. Use `"WolframLanguage"` for coding-oriented clients and `"Wolfram"` for general-purpose chat clients. |
+| `"DefaultToolset"` | Yes | Predefined server name to use when `InstallMCPServer`/`DeployAgentTools` is called with `Automatic`. Use `"WolframLanguage"` for coding-oriented clients and `"Wolfram"` for general-purpose chat clients. |
 | `"ProjectPath"` | No | Relative path components for project-level config |
 | `"ServerConverter"` | No | Function to transform the standard server entry into a client-specific format |
 

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -12,25 +12,27 @@ For convenience, `InstallMCPServer` and `UninstallMCPServer` functions are provi
 
 The following clients have built-in support for automatic configuration via `InstallMCPServer`:
 
-| Client | Canonical Name | Aliases | Config Format | Project Support |
-|--------|---------------|---------|---------------|-----------------|
-| Amazon Q Developer | `"AmazonQ"` | `"AmazonQDeveloper"`, `"Q"`, `"QDeveloper"` | JSON | Yes |
-| Augment Code | `"AugmentCode"` | `"Auggie"`, `"Augment"` | JSON | No |
-| Augment Code IDE | `"AugmentCodeIDE"` | `"AugmentIDE"`, `"AuggieIDE"` | JSON (array) | No |
-| Claude Code | `"ClaudeCode"` | — | JSON | Yes |
-| Claude Desktop | `"ClaudeDesktop"` | `"Claude"` | JSON | No |
-| Cline | `"Cline"` | — | JSON | No |
-| Copilot CLI | `"CopilotCLI"` | `"Copilot"` | JSON | No |
-| Cursor | `"Cursor"` | — | JSON | No |
-| Gemini CLI | `"GeminiCLI"` | `"Gemini"` | JSON | No |
-| Goose | `"Goose"` | — | YAML | No |
-| Antigravity | `"Antigravity"` | `"GoogleAntigravity"` | JSON | No |
-| Kiro | `"Kiro"` | — | JSON | Yes |
-| Codex CLI | `"Codex"` | `"OpenAICodex"` | TOML | Yes |
-| OpenCode | `"OpenCode"` | — | JSON | Yes |
-| Visual Studio Code | `"VisualStudioCode"` | `"VSCode"` | JSON | Yes |
-| Windsurf | `"Windsurf"` | `"Codeium"` | JSON | No |
-| Zed | `"Zed"` | — | JSON | Yes |
+| Client | Canonical Name | Aliases | Config Format | Project Support | Default Toolset |
+|--------|---------------|---------|---------------|-----------------|-----------------|
+| Amazon Q Developer | `"AmazonQ"` | `"AmazonQDeveloper"`, `"Q"`, `"QDeveloper"` | JSON | Yes | `"WolframLanguage"` |
+| Augment Code | `"AugmentCode"` | `"Auggie"`, `"Augment"` | JSON | No | `"WolframLanguage"` |
+| Augment Code IDE | `"AugmentCodeIDE"` | `"AugmentIDE"`, `"AuggieIDE"` | JSON (array) | No | `"WolframLanguage"` |
+| Claude Code | `"ClaudeCode"` | — | JSON | Yes | `"WolframLanguage"` |
+| Claude Desktop | `"ClaudeDesktop"` | `"Claude"` | JSON | No | `"Wolfram"` |
+| Cline | `"Cline"` | — | JSON | No | `"WolframLanguage"` |
+| Copilot CLI | `"CopilotCLI"` | `"Copilot"` | JSON | No | `"WolframLanguage"` |
+| Cursor | `"Cursor"` | — | JSON | No | `"WolframLanguage"` |
+| Gemini CLI | `"GeminiCLI"` | `"Gemini"` | JSON | No | `"WolframLanguage"` |
+| Goose | `"Goose"` | — | YAML | No | `"Wolfram"` |
+| Antigravity | `"Antigravity"` | `"GoogleAntigravity"` | JSON | No | `"WolframLanguage"` |
+| Kiro | `"Kiro"` | — | JSON | Yes | `"WolframLanguage"` |
+| Codex CLI | `"Codex"` | `"OpenAICodex"` | TOML | Yes | `"WolframLanguage"` |
+| OpenCode | `"OpenCode"` | — | JSON | Yes | `"WolframLanguage"` |
+| Visual Studio Code | `"VisualStudioCode"` | `"VSCode"` | JSON | Yes | `"WolframLanguage"` |
+| Windsurf | `"Windsurf"` | `"Codeium"` | JSON | No | `"WolframLanguage"` |
+| Zed | `"Zed"` | — | JSON | Yes | `"WolframLanguage"` |
+
+The **Default Toolset** is the [predefined server](servers.md) used when `InstallMCPServer`/`DeployAgentTools` is called without an explicit server (or with `Automatic`). Coding clients default to `"WolframLanguage"`; chat clients (Claude Desktop, Goose) default to `"Wolfram"`.
 
 ## Usage
 
@@ -42,7 +44,7 @@ Install an MCP server into a client application:
 InstallMCPServer["ClaudeDesktop"]
 ```
 
-This installs the default MCP server into Claude Desktop's configuration file.
+This installs the client's default toolset into Claude Desktop's configuration file. Each client has its own default — Claude Desktop and Goose default to `"Wolfram"`; coding clients (Claude Code, Cursor, VS Code, etc.) default to `"WolframLanguage"`. Pass `Automatic` explicitly for the same behavior, or pass a server name to override (see the table above for each client's default).
 
 ### Installing a Specific Server
 
@@ -576,6 +578,7 @@ Each entry is keyed by the canonical client name and contains an association wit
 | `"ConfigKey"` | Yes | Key path to the servers section (e.g. `{"mcpServers"}` or `{"servers"}`) |
 | `"URL"` | Yes | Client's website or download page |
 | `"InstallLocation"` | Yes | Config file path(s) per OS (see below) |
+| `"DefaultToolset"` | No | Predefined server name to use when `InstallMCPServer`/`DeployAgentTools` is called with `Automatic`. Falls back to `"Wolfram"` if omitted. Use `"WolframLanguage"` for coding-oriented clients and `"Wolfram"` for general-purpose chat clients. |
 | `"ProjectPath"` | No | Relative path components for project-level config |
 | `"ServerConverter"` | No | Function to transform the standard server entry into a client-specific format |
 
@@ -584,6 +587,7 @@ Each entry is keyed by the canonical client name and contains an association wit
 ```wl
 "NewClient" -> <|
     "DisplayName"     -> "New Client",
+    "DefaultToolset"  -> "WolframLanguage",
     "Aliases"         -> { "NC" },
     "ConfigFormat"    -> "JSON",
     "ConfigKey"       -> { "mcpServers" },

--- a/docs/servers.md
+++ b/docs/servers.md
@@ -15,7 +15,7 @@ AgentTools provides four predefined server configurations, each tailored for dif
 
 ## Choosing a Server
 
-### Wolfram (Default)
+### Wolfram
 
 **Best for:** General-purpose use combining computational power with natural language understanding.
 
@@ -23,7 +23,7 @@ AgentTools provides four predefined server configurations, each tailored for dif
 InstallMCPServer["ClaudeDesktop", "Wolfram"]
 ```
 
-This is the default server when no server name is specified. It provides:
+This is the default server for chat clients (`ClaudeDesktop`, `Goose`) when no server name is specified. Coding clients default to `"WolframLanguage"` instead — see [mcp-clients.md](mcp-clients.md#clients-with-installmcpserver-support) for each client's default. It provides:
 
 | Component | Name | Description |
 |-----------|------|-------------|


### PR DESCRIPTION
## Summary
- Add a `DefaultToolset` field to each entry in `$supportedMCPClients` so different clients can advertise different default toolsets.
- Introduce `defaultToolsetForTarget` to look up that field for a client name, alias, `{name, dir}` pair, or file target — falling back to `$defaultMCPServer` for unknown inputs.
- Route `InstallMCPServer[target, Automatic]` and `DeployAgentTools[target, Automatic]` through the helper so coding-focused clients (Claude Code, Cursor, Codex, Copilot CLI, Augment, Antigravity, Kiro, OpenCode, VS Code, Windsurf, Amazon Q, Cline, Zed) default to `"WolframLanguage"`, while desktop clients (Claude Desktop, Goose) keep `"Wolfram"`.
- Add `appname` to the cspell dictionary (matches existing `appname_test.json` test fixture filenames).
- Ignore local `.mcp.json` Claude Code project config.

## Test plan
- [ ] `TestReport` on `Tests/InstallMCPServer.wlt` — covers `defaultToolsetForTarget` for canonical names, aliases, `{name, dir}` pairs, file targets, and unknown inputs, plus end-to-end `InstallMCPServer[..., Automatic]` and the 1-arg form.
- [ ] `TestReport` on `Tests/DeployAgentTools.wlt` — covers `DeployAgentTools[..., Automatic]` and the 1-arg form for `ClaudeCode`.
- [ ] Spot-check `InstallMCPServer[{"ClaudeCode", dir}]` produces a `WolframLanguage` server, and `InstallMCPServer[{"ClaudeDesktop", dir}]` still produces `Wolfram`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)