### PR TITLE
Support DeployAgentTools[All] for deploying to every supported client

### DIFF
--- a/Kernel/DeployAgentTools.wl
+++ b/Kernel/DeployAgentTools.wl
@@ -261,9 +261,15 @@ $$deployAgentToolsOptions = OptionsPattern @ { DeployAgentTools, InstallMCPServe
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Main Definition*)
+(* Default server is `Automatic` *)
 DeployAgentTools[ target_, opts: $$deployAgentToolsOptions ] :=
     catchMine @ DeployAgentTools[ target, Automatic, opts ];
 
+(* Deploy for all clients *)
+DeployAgentTools[ All, server_, opts: $$deployAgentToolsOptions ] :=
+    catchMine @ deployAllAgentTools[ server, opts ];
+
+(* Resolve automatic server *)
 DeployAgentTools[ target_, Automatic, opts: $$deployAgentToolsOptions ] :=
     catchMine @ DeployAgentTools[
         target,
@@ -278,10 +284,57 @@ DeployAgentTools[ target_, Automatic, opts: $$deployAgentToolsOptions ] :=
         opts
     ];
 
+(* Proceed with deployment *)
 DeployAgentTools[ target_, server_, opts: $$deployAgentToolsOptions ] :=
     catchMine @ deployAgentTools[ target, ensureMCPServerExists @ MCPServerObject @ server, opts ];
 
 DeployAgentTools // endExportedDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*deployAllAgentTools*)
+deployAllAgentTools // beginDefinition;
+
+deployAllAgentTools[ server0_, opts: $$deployAgentToolsOptions ] := Enclose[
+    Module[ { clients, server, results },
+        clients = ConfirmMatch[ Keys @ $SupportedMCPClients, { __String }, "Clients" ];
+
+        server = If[ server0 === Automatic,
+                     Automatic,
+                     ConfirmBy[ ensureMCPServerExists @ MCPServerObject @ server0, MCPServerObjectQ, "Server" ]
+                 ];
+
+        results = ConfirmMatch[
+            Map[ deployAgentToolsQuietly[ #, server, opts ] &, clients ],
+            { (_AgentToolsDeployment | Missing[ "DeploymentExists", _ ]).. },
+            "Results"
+        ];
+
+        If[ AnyTrue[ results, MissingQ ], messagePrint[ "DeploymentsExistWarning" ] ];
+
+        results
+    ],
+    throwInternalFailure
+];
+
+deployAllAgentTools // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*deployAgentToolsQuietly*)
+deployAgentToolsQuietly // beginDefinition;
+
+deployAgentToolsQuietly[ target_, server_, opts: $$deployAgentToolsOptions ] :=
+    Quiet[
+        Replace[
+            catchAlways @ DeployAgentTools[ target, server, opts ],
+            Failure[ "DeployAgentTools::DeploymentExists", _ ] :>
+                Missing[ "DeploymentExists", target ]
+        ],
+        { DeployAgentTools::DeploymentExists }
+    ];
+
+deployAgentToolsQuietly // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)

--- a/Kernel/DeployAgentTools.wl
+++ b/Kernel/DeployAgentTools.wl
@@ -306,11 +306,13 @@ deployAllAgentTools[ server0_, opts: $$deployAgentToolsOptions ] := Enclose[
 
         results = ConfirmMatch[
             Map[ deployAgentToolsQuietly[ #, server, opts ] &, clients ],
-            { (_AgentToolsDeployment | Missing[ "DeploymentExists", _ ]).. },
+            { (_AgentToolsDeployment | Missing[ "DeploymentExists", _ ] | Missing[ "Unsupported", _ ]).. },
             "Results"
         ];
 
-        If[ AnyTrue[ results, MissingQ ], messagePrint[ "DeploymentsExistWarning" ] ];
+        If[ MemberQ[ results, Missing[ "DeploymentExists", _ ] ],
+            messagePrint[ "DeploymentsExistWarning" ]
+        ];
 
         results
     ],

--- a/Kernel/DeployAgentTools.wl
+++ b/Kernel/DeployAgentTools.wl
@@ -329,11 +329,19 @@ deployAgentToolsQuietly[ target_, server_, opts: $$deployAgentToolsOptions ] :=
         Replace[
             catchAlways @ DeployAgentTools[ target, server, opts ],
             {
-                Failure[ "DeployAgentTools::DeploymentExists", _ ] :> Missing[ "DeploymentExists", target ],
+                (* Used to issue a single warning about OverwriteTarget: *)
+                Failure[ "DeployAgentTools::DeploymentExists", _ ] :>
+                    Missing[ "DeploymentExists", target ],
+
+                (* Some clients aren't supported on all operating systems: *)
+                Failure[ "DeployAgentTools::UnknownInstallLocation", _ ] :>
+                    Missing[ "Unsupported", { target, $OperatingSystem } ],
+
+                (* Other failures are propagated to the top level: *)
                 other_Failure :> throwTop @ other
             }
         ],
-        { DeployAgentTools::DeploymentExists }
+        { DeployAgentTools::DeploymentExists, DeployAgentTools::UnknownInstallLocation }
     ];
 
 deployAgentToolsQuietly // endDefinition;

--- a/Kernel/DeployAgentTools.wl
+++ b/Kernel/DeployAgentTools.wl
@@ -328,8 +328,10 @@ deployAgentToolsQuietly[ target_, server_, opts: $$deployAgentToolsOptions ] :=
     Quiet[
         Replace[
             catchAlways @ DeployAgentTools[ target, server, opts ],
-            Failure[ "DeployAgentTools::DeploymentExists", _ ] :>
-                Missing[ "DeploymentExists", target ]
+            {
+                Failure[ "DeployAgentTools::DeploymentExists", _ ] :> Missing[ "DeploymentExists", target ],
+                other_Failure :> throwTop @ other
+            }
         ],
         { DeployAgentTools::DeploymentExists }
     ];

--- a/Kernel/DeployAgentTools.wl
+++ b/Kernel/DeployAgentTools.wl
@@ -305,7 +305,7 @@ deployAllAgentTools[ server0_, opts: $$deployAgentToolsOptions ] := Enclose[
                  ];
 
         results = ConfirmMatch[
-            Map[ deployAgentToolsQuietly[ #, server, opts ] &, clients ],
+            Map[ deployAgentToolsQuietly[ #, resolveServerForClient[ #, server ], opts ] &, clients ],
             { (_AgentToolsDeployment | Missing[ "DeploymentExists", _ ] | Missing[ "Unsupported", _ ]).. },
             "Results"
         ];
@@ -320,6 +320,19 @@ deployAllAgentTools[ server0_, opts: $$deployAgentToolsOptions ] := Enclose[
 ];
 
 deployAllAgentTools // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*resolveServerForClient*)
+(* When `server === Automatic`, resolve each client's `DefaultToolset` directly
+   from the client name.  Going through the 2-arg `defaultToolsetForTarget`
+   inside `DeployAgentTools[target, Automatic, opts]` would let an explicit
+   `"ApplicationName" -> name` option override the per-client default, which
+   defeats the point of `All`. *)
+resolveServerForClient // beginDefinition;
+resolveServerForClient[ client_String, Automatic ] := defaultToolsetForTarget @ client;
+resolveServerForClient[ _, server_ ] := server;
+resolveServerForClient // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Kernel/Messages.wl
+++ b/Kernel/Messages.wl
@@ -69,6 +69,7 @@ AgentTools::CodeInspectorInvalidConfidence  = "Confidence level must be between 
 
 (* DeployAgentTools messages *)
 AgentTools::DeploymentExists                = "A deployment already exists for target `1`. Use OverwriteTarget -> True to replace it.";
+AgentTools::DeploymentsExistWarning         = "Warning: Some deployments already exist. Use OverwriteTarget -> True to replace them.";
 AgentTools::DeploymentNotFound              = "No deployment found with UUID \"`1`\".";
 AgentTools::InvalidDeploymentData           = "Invalid deployment data: `1`.";
 AgentTools::InvalidDeployTarget             = "Invalid deployment target: `1`. Expected a client name string, {name, directory}, or File[\[Ellipsis]].";

--- a/Kernel/Messages.wl
+++ b/Kernel/Messages.wl
@@ -72,7 +72,7 @@ AgentTools::DeploymentExists                = "A deployment already exists for t
 AgentTools::DeploymentsExistWarning         = "Warning: Some deployments already exist. Use OverwriteTarget -> True to replace them.";
 AgentTools::DeploymentNotFound              = "No deployment found with UUID \"`1`\".";
 AgentTools::InvalidDeploymentData           = "Invalid deployment data: `1`.";
-AgentTools::InvalidDeployTarget             = "Invalid deployment target: `1`. Expected a client name string, {name, directory}, or File[\[Ellipsis]].";
+AgentTools::InvalidDeployTarget             = "Invalid deployment target: `1`. Expected a client name string, {name, directory}, File[\[Ellipsis]], or All.";
 
 (* PacletTools messages *)
 AgentTools::PacletToolsInvalidPath          = "The path \"`1`\" does not exist. Provide an absolute path to either the paclet root directory or the definition notebook (.nb) file.";

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ CreateMCPServer["My MCP Server", <|
 | `UninstallMCPServer[client]` | Remove all servers from a client |
 | `UninstallMCPServer[client, name]` | Remove a specific server from a client |
 | `DeployAgentTools[target]` | Deploy tools to a client with tracked deployment management |
+| `DeployAgentTools[All]` | Deploy tools to every client in `$SupportedMCPClients` (see [docs/deploy-agent-tools.md](docs/deploy-agent-tools.md#deploying-to-all-clients)) |
 | `ValidateAgentToolsPacletExtension[paclet]` | Validate an `"AgentTools"` paclet extension |
 | `DeployedAgentTools[]` | List all tracked deployments |
 | `CreatePreferencesContent[]` | Build the preferences panel UI for managing deployed Wolfram toolsets (see [docs/preferences-content.md](docs/preferences-content.md)) |

--- a/Tests/DeployAgentTools.wlt
+++ b/Tests/DeployAgentTools.wlt
@@ -1366,6 +1366,80 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*Unsupported Clients Return Missing["Unsupported", ...]*)
+(* Clients without an InstallLocation entry for the current operating system
+   should be reported as Missing["Unsupported", {client, $OperatingSystem}]
+   rather than failing the entire DeployAgentTools[All, ...] call. *)
+
+(* Synthetic client whose InstallLocation never matches any real OS *)
+$alwaysUnsupportedEntry = <|
+    "Aliases"         -> { },
+    "ConfigFormat"    -> "JSON",
+    "ConfigKey"       -> { "mcpServers" },
+    "DefaultToolset"  -> "WolframLanguage",
+    "DisplayName"     -> "Always Unsupported Test Client",
+    "InstallLocation" -> <| "DefinitelyNotARealOS" :> { "/never/used" } |>,
+    "Name"            -> "AlwaysUnsupported",
+    "ProjectSupport"  -> False,
+    "ServerConverter" -> Identity,
+    "URL"             -> "https://example.com"
+|>;
+
+VerificationTest[
+    $allDepUnsupported = Block[
+        {
+            Wolfram`AgentTools`$SupportedMCPClients    = <|
+                KeyTake[ Wolfram`AgentTools`$SupportedMCPClients, { "Cursor" } ],
+                "AlwaysUnsupported" -> $alwaysUnsupportedEntry
+            |>,
+            $HomeDirectory                             = $allTestTmpHome,
+            Wolfram`AgentTools`Common`$deploymentsPath =
+                FileNameJoin @ { $allTestTmpHome, ".deployments_unsupported" }
+        },
+        DeployAgentTools[ All, "VerifyLLMKit" -> False ]
+    ],
+    _List? (Length @ # === 2 &),
+    SameTest -> MatchQ,
+    TestID   -> "DeployAgentTools-All-UnsupportedClientShape"
+]
+
+VerificationTest[
+    Cases[ $allDepUnsupported, _Missing ],
+    { Missing[ "Unsupported", { "AlwaysUnsupported", $OperatingSystem } ] },
+    TestID -> "DeployAgentTools-All-UnsupportedClientPayload"
+]
+
+VerificationTest[
+    Length @ Cases[ $allDepUnsupported, _AgentToolsDeployment ],
+    1,
+    TestID -> "DeployAgentTools-All-UnsupportedClientStillDeploysSupported"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*DeploymentsExistWarning Only Fires for DeploymentExists*)
+(* When only unsupported clients are skipped (no DeploymentExists entries),
+   AgentTools::DeploymentsExistWarning must NOT be issued. *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`$SupportedMCPClients    = <|
+                "AlwaysUnsupported" -> $alwaysUnsupportedEntry
+            |>,
+            $HomeDirectory                             = $allTestTmpHome,
+            Wolfram`AgentTools`Common`$deploymentsPath =
+                FileNameJoin @ { $allTestTmpHome, ".deployments_unsupported_only" }
+        },
+        DeployAgentTools[ All, "VerifyLLMKit" -> False ]
+    ],
+    { Missing[ "Unsupported", { "AlwaysUnsupported", $OperatingSystem } ] },
+    { },
+    SameTest -> MatchQ,
+    TestID   -> "DeployAgentTools-All-NoWarningForUnsupportedOnly"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*Cleanup*)
 VerificationTest[
     Quiet @ DeleteDirectory[ $allTestTmpHome, DeleteContents -> True ];

--- a/Tests/DeployAgentTools.wlt
+++ b/Tests/DeployAgentTools.wlt
@@ -1172,4 +1172,206 @@ VerificationTest[
     TestID -> "DeployAgentTools-Automatic-Cleanup@@Tests/DeployAgentTools.wlt:1167,1-1173,2"
 ]
 
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*DeployAgentTools[All, ...]*)
+(* These tests redirect $HomeDirectory and $deploymentsPath so that real client
+   config files on the test machine are not touched, and pin
+   $SupportedMCPClients to a small set of clients that have valid install
+   locations on the current operating system. *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Setup*)
+VerificationTest[
+    $allTestTmpHome    = CreateDirectory[ ];
+    $allTestDeployPath = FileNameJoin @ { $allTestTmpHome, ".deployments" };
+    $allTestClients    = KeyTake[
+        Wolfram`AgentTools`$SupportedMCPClients,
+        { "Cursor", "ClaudeCode" }
+    ];
+    Length @ $allTestClients,
+    2,
+    TestID -> "DeployAgentTools-All-Setup"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Basic Result Shape*)
+VerificationTest[
+    $allDep1 = Block[
+        {
+            Wolfram`AgentTools`$SupportedMCPClients = $allTestClients,
+            $HomeDirectory                          = $allTestTmpHome,
+            Wolfram`AgentTools`Common`$deploymentsPath = $allTestDeployPath
+        },
+        DeployAgentTools[ All, "VerifyLLMKit" -> False ]
+    ],
+    { _AgentToolsDeployment, _AgentToolsDeployment },
+    SameTest -> MatchQ,
+    TestID   -> "DeployAgentTools-All-BasicResultShape"
+]
+
+VerificationTest[
+    Length @ $allDep1,
+    Length @ $allTestClients,
+    TestID -> "DeployAgentTools-All-LengthMatchesClients"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Per-Client DefaultToolset (Automatic Server)*)
+(* With server = Automatic (the default), each deployment should pick up its
+   client's "DefaultToolset" from $SupportedMCPClients.  Both Cursor and
+   ClaudeCode are coding clients -> "WolframLanguage". *)
+VerificationTest[
+    Sort @ Map[ #[ "Toolset" ] &, $allDep1 ],
+    { "WolframLanguage", "WolframLanguage" },
+    TestID -> "DeployAgentTools-All-AutomaticToolsetPerClient"
+]
+
+VerificationTest[
+    Sort @ Map[ #[ "ClientName" ] &, $allDep1 ],
+    Sort @ Keys @ $allTestClients,
+    TestID -> "DeployAgentTools-All-CoversEveryClient"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Re-Deploy Without Overwrite Returns Missing Entries*)
+VerificationTest[
+    $allDep2 = Block[
+        {
+            Wolfram`AgentTools`$SupportedMCPClients = $allTestClients,
+            $HomeDirectory                          = $allTestTmpHome,
+            Wolfram`AgentTools`Common`$deploymentsPath = $allTestDeployPath
+        },
+        Quiet[
+            DeployAgentTools[ All, "VerifyLLMKit" -> False ],
+            { DeployAgentTools::DeploymentsExistWarning }
+        ]
+    ],
+    { Missing[ "DeploymentExists", _ ], Missing[ "DeploymentExists", _ ] },
+    SameTest -> MatchQ,
+    TestID   -> "DeployAgentTools-All-MissingDeploymentExistsEntries"
+]
+
+VerificationTest[
+    Sort @ Map[ #[[ 2 ]] &, $allDep2 ],
+    Sort @ Keys @ $allTestClients,
+    TestID -> "DeployAgentTools-All-MissingTargetsAreClientNames"
+]
+
+(* The DeploymentsExistWarning message should be issued when at least one
+   client is skipped due to an existing deployment. *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`$SupportedMCPClients = $allTestClients,
+            $HomeDirectory                          = $allTestTmpHome,
+            Wolfram`AgentTools`Common`$deploymentsPath = $allTestDeployPath
+        },
+        DeployAgentTools[ All, "VerifyLLMKit" -> False ]
+    ],
+    _List,
+    { DeployAgentTools::DeploymentsExistWarning },
+    SameTest -> MatchQ,
+    TestID   -> "DeployAgentTools-All-WarningMessageIssued"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*OverwriteTarget -> True Replaces Every Deployment*)
+VerificationTest[
+    $allDep1UUIDs = Sort @ Map[ #[ "UUID" ] &, $allDep1 ];
+    $allDep3 = Block[
+        {
+            Wolfram`AgentTools`$SupportedMCPClients = $allTestClients,
+            $HomeDirectory                          = $allTestTmpHome,
+            Wolfram`AgentTools`Common`$deploymentsPath = $allTestDeployPath
+        },
+        DeployAgentTools[ All, OverwriteTarget -> True, "VerifyLLMKit" -> False ]
+    ],
+    { _AgentToolsDeployment, _AgentToolsDeployment },
+    SameTest -> MatchQ,
+    TestID   -> "DeployAgentTools-All-OverwriteShape"
+]
+
+VerificationTest[
+    (* All UUIDs in the new result should be different from the originals *)
+    Intersection[ Sort @ Map[ #[ "UUID" ] &, $allDep3 ], $allDep1UUIDs ],
+    { },
+    TestID -> "DeployAgentTools-All-OverwriteNewUUIDs"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Explicit Server Argument*)
+(* DeployAgentTools[All, server, ...] should use the given server for every
+   client instead of falling back to per-client DefaultToolset. *)
+VerificationTest[
+    $allDep4 = Block[
+        {
+            Wolfram`AgentTools`$SupportedMCPClients = $allTestClients,
+            $HomeDirectory                          = $allTestTmpHome,
+            Wolfram`AgentTools`Common`$deploymentsPath = $allTestDeployPath
+        },
+        DeployAgentTools[
+            All,
+            "Wolfram",
+            OverwriteTarget -> True,
+            "VerifyLLMKit"  -> False
+        ]
+    ],
+    { _AgentToolsDeployment, _AgentToolsDeployment },
+    SameTest -> MatchQ,
+    TestID   -> "DeployAgentTools-All-ExplicitServerShape"
+]
+
+VerificationTest[
+    Sort @ DeleteDuplicates @ Map[ #[ "Toolset" ] &, $allDep4 ],
+    { "Wolfram" },
+    TestID -> "DeployAgentTools-All-ExplicitServerOverridesDefault"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*1-Argument Form Defaults to Automatic*)
+(* DeployAgentTools[All] (no server argument) should be equivalent to
+   DeployAgentTools[All, Automatic, ...].  Use a fresh deployments path so
+   nothing already exists. *)
+VerificationTest[
+    $allDep5Path = FileNameJoin @ { $allTestTmpHome, ".deployments_1arg" };
+    $allDep5 = Block[
+        {
+            Wolfram`AgentTools`$SupportedMCPClients = $allTestClients,
+            $HomeDirectory                          = $allTestTmpHome,
+            Wolfram`AgentTools`Common`$deploymentsPath = $allDep5Path
+        },
+        (* Use OverwriteTarget so we don't conflict with the configs already
+           written under $allTestTmpHome by earlier tests. *)
+        DeployAgentTools[ All, OverwriteTarget -> True, "VerifyLLMKit" -> False ]
+    ],
+    { _AgentToolsDeployment, _AgentToolsDeployment },
+    SameTest -> MatchQ,
+    TestID   -> "DeployAgentTools-All-1ArgForm"
+]
+
+VerificationTest[
+    (* 1-arg form falls through to per-client DefaultToolset, like Automatic *)
+    Sort @ DeleteDuplicates @ Map[ #[ "Toolset" ] &, $allDep5 ],
+    { "WolframLanguage" },
+    TestID -> "DeployAgentTools-All-1ArgFormUsesDefaultToolset"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Cleanup*)
+VerificationTest[
+    Quiet @ DeleteDirectory[ $allTestTmpHome, DeleteContents -> True ];
+    True,
+    True,
+    TestID -> "DeployAgentTools-All-Cleanup"
+]
+
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/DeployAgentTools.wlt
+++ b/Tests/DeployAgentTools.wlt
@@ -1366,6 +1366,68 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*resolveServerForClient Helper*)
+(* Unit tests for the per-client server resolver used by deployAllAgentTools.
+   When server is Automatic, each client's own DefaultToolset is used; an
+   explicit server passes through. *)
+VerificationTest[
+    resolveServerForClient = Wolfram`AgentTools`DeployAgentTools`Private`resolveServerForClient;
+    resolveServerForClient[ "Cursor", Automatic ],
+    "WolframLanguage",
+    TestID -> "DeployAgentTools-All-resolveServerForClient-CursorAutomatic"
+]
+
+VerificationTest[
+    resolveServerForClient[ "ClaudeDesktop", Automatic ],
+    "Wolfram",
+    TestID -> "DeployAgentTools-All-resolveServerForClient-ClaudeDesktopAutomatic"
+]
+
+VerificationTest[
+    resolveServerForClient[ "Cursor", "Wolfram" ],
+    "Wolfram",
+    TestID -> "DeployAgentTools-All-resolveServerForClient-ExplicitPassthrough"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*ApplicationName Doesn't Override Per-Client Default*)
+(* When server is Automatic, an explicit "ApplicationName" option must not
+   override each client's own DefaultToolset.  Without the resolveServerForClient
+   indirection, DeployAgentTools[target, Automatic, opts] gives ApplicationName
+   precedence over target-based resolution, which would silently rewrite every
+   client's toolset to whatever ApplicationName resolves to. *)
+VerificationTest[
+    $allDepAppName = Block[
+        {
+            Wolfram`AgentTools`$SupportedMCPClients    = $allTestClients,
+            $HomeDirectory                             = $allTestTmpHome,
+            Wolfram`AgentTools`Common`$deploymentsPath =
+                FileNameJoin @ { $allTestTmpHome, ".deployments_appname" }
+        },
+        DeployAgentTools[
+            All,
+            "VerifyLLMKit"    -> False,
+            "ApplicationName" -> "ClaudeDesktop"
+        ]
+    ],
+    { _AgentToolsDeployment, _AgentToolsDeployment },
+    SameTest -> MatchQ,
+    TestID   -> "DeployAgentTools-All-ApplicationName-Setup"
+]
+
+VerificationTest[
+    (* ClaudeDesktop's DefaultToolset is "Wolfram"; if ApplicationName were
+       being honored as the default-toolset selector, both deployments would
+       come back as "Wolfram".  Both Cursor and ClaudeCode are coding clients,
+       so the correct result is "WolframLanguage" for both. *)
+    Sort @ DeleteDuplicates @ Map[ #[ "Toolset" ] &, $allDepAppName ],
+    { "WolframLanguage" },
+    TestID -> "DeployAgentTools-All-ApplicationName-PerClientDefault"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*Unsupported Clients Return Missing["Unsupported", ...]*)
 (* Clients without an InstallLocation entry for the current operating system
    should be reported as Missing["Unsupported", {client, $OperatingSystem}]

--- a/docs/deploy-agent-tools.md
+++ b/docs/deploy-agent-tools.md
@@ -98,8 +98,9 @@ The return value is a list with one entry per client:
 
 - `AgentToolsDeployment[...]` for each newly created deployment
 - `Missing["DeploymentExists", target]` for any client that already had a deployment and was skipped (only when `OverwriteTarget -> False`)
+- `Missing["Unsupported", {target, $OperatingSystem}]` for any client that has no install location on the current operating system (e.g. clients with platform-specific config paths)
 
-When at least one client is skipped, `AgentTools::DeploymentsExistWarning` is issued. Use `OverwriteTarget -> True` to replace existing deployments instead of skipping them.
+When at least one client is skipped because of an existing deployment, `AgentTools::DeploymentsExistWarning` is issued. Use `OverwriteTarget -> True` to replace existing deployments instead of skipping them. The warning is not issued for unsupported clients — those entries simply appear in the result list so callers can see which clients were skipped.
 
 ## AgentToolsDeployment
 

--- a/docs/deploy-agent-tools.md
+++ b/docs/deploy-agent-tools.md
@@ -24,13 +24,15 @@ In the current phase, `DeployAgentTools` wraps `InstallMCPServer` to deploy MCP 
 DeployAgentTools[target]
 DeployAgentTools[target, server]
 DeployAgentTools[target, server, opts]
+DeployAgentTools[All]
+DeployAgentTools[All, server]
 ```
 
 ### Arguments
 
 | Argument | Type | Description |
 |----------|------|-------------|
-| `target` | `String`, `File[...]`, or `{String, dir}` | The client to deploy to (same target formats as `InstallMCPServer`) |
+| `target` | `String`, `File[...]`, `{String, dir}`, or `All` | The client to deploy to (same target formats as `InstallMCPServer`). Pass `All` to deploy to every client in `$SupportedMCPClients` (see [Deploying to All Clients](#deploying-to-all-clients)). |
 | `server` | `MCPServerObject`, `String`, or `Automatic` | The MCP server to deploy. Defaults to `Automatic`, which resolves to the target client's default toolset (see [mcp-clients.md](mcp-clients.md#clients-with-installmcpserver-support)) — `"WolframLanguage"` for coding clients and `"Wolfram"` for chat clients. For `File[...]` targets the per-client default only applies when the path or content identifies a known client (or `"ApplicationName"` is supplied); otherwise it falls back to `"Wolfram"`. |
 
 ### Options
@@ -62,6 +64,9 @@ dep = DeployAgentTools[{"ClaudeCode", "/path/to/project"}]
 dep = DeployAgentTools["ClaudeCode",
     "ToolOptions" -> <|"WolframLanguageEvaluator" -> <|"Method" -> "Local"|>|>
 ]
+
+(* Deploy to every supported client at once *)
+deps = DeployAgentTools[All]
 ```
 
 ### Behavior
@@ -73,6 +78,28 @@ dep = DeployAgentTools["ClaudeCode",
 5. Calls `InstallMCPServer` with the resolved target and filtered options
 6. Creates a persistent deployment record on disk
 7. Returns an `AgentToolsDeployment` object
+
+### Deploying to All Clients
+
+`DeployAgentTools[All]` deploys to every client in `$SupportedMCPClients`. The server defaults to `Automatic` so each client receives its own configured default toolset (`"WolframLanguage"` for coding clients, `"Wolfram"` for chat clients); pass an explicit second argument to deploy the same server everywhere.
+
+```wl
+(* One default deployment per supported client *)
+deps = DeployAgentTools[All]
+
+(* Force a specific toolset for every client *)
+deps = DeployAgentTools[All, "WolframLanguage"]
+
+(* Replace any existing deployments along the way *)
+deps = DeployAgentTools[All, OverwriteTarget -> True]
+```
+
+The return value is a list with one entry per client:
+
+- `AgentToolsDeployment[...]` for each newly created deployment
+- `Missing["DeploymentExists", target]` for any client that already had a deployment and was skipped (only when `OverwriteTarget -> False`)
+
+When at least one client is skipped, `AgentTools::DeploymentsExistWarning` is issued. Use `OverwriteTarget -> True` to replace existing deployments instead of skipping them.
 
 ## AgentToolsDeployment
 


### PR DESCRIPTION
## Summary

- Add `DeployAgentTools[All, ...]` to deploy to every client in `$SupportedMCPClients` in a single call
- Each client receives its configured default toolset when `server` is `Automatic` (`"WolframLanguage"` for coding clients, `"Wolfram"` for chat clients); pass an explicit second argument to override
- Clients with existing deployments are skipped (returning `Missing["DeploymentExists", target]`) and a `DeploymentsExistWarning` is emitted; use `OverwriteTarget -> True` to replace them
- Updates `README.md` and `docs/deploy-agent-tools.md` with the new syntax, behavior, and a "Deploying to All Clients" section

## Test plan

- [ ] `TestReport` passes for `Tests/DeployAgentTools.wlt`, including the new `All`-target tests covering:
  - per-client `Automatic` toolset resolution
  - explicit server override applied to every client
  - `OverwriteTarget -> True` replacing existing deployments
  - `Missing["DeploymentExists", ...]` entries for skipped clients
  - `AgentTools::DeploymentsExistWarning` emitted when at least one client is skipped
- [ ] `CodeInspector` reports no new issues on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)