### PR TITLE
Fetch WolframAlpha images in parallel via URLSubmit

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -67,6 +67,7 @@
         "Unparseable",
         "USERBASE",
         "USERPROFILE",
+        "webp",
         "wolframalpha",
         "wolframengine",
         "WOLFRAMINIT",

--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -12,12 +12,13 @@ Needs[ "Wolfram`Chatbook`" -> "cb`" ];
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Configuration*)
-$protocolVersion    = "2024-11-05";
-$toolWarmupDelay    = 5; (* seconds *)
-$clientName         = None;
-$clientSupportsUI   = False;
-$currentMCPServer   = None;
-$mcpEvaluation      = False;
+$protocolVersion     = "2024-11-05";
+$toolWarmupDelay     = 5; (* seconds *)
+$waImageFetchTimeout = 5; (* seconds, applied to the whole WA image batch via TaskWait *)
+$clientName          = None;
+$clientSupportsUI    = False;
+$currentMCPServer    = None;
+$mcpEvaluation       = False;
 
 $logTimeStamp := DateString[
     {
@@ -728,13 +729,35 @@ graphicsToImageContent // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
+(*makeImageContent*)
+makeImageContent // beginDefinition;
+
+makeImageContent[
+    URL[ url_String ],
+    KeyValuePattern @ {
+        "StatusCode"    -> 200,
+        "BodyByteArray" -> bytes_ByteArray,
+        "Headers"       -> KeyValuePattern[ "content-type" -> type_String ? (StringStartsQ[ "image/" ]) ]
+    }
+] := {
+    <| "type" -> "text" , "text" -> "![Image](" <> url <> ")" |>,
+    <| "type" -> "image", "data" -> BaseEncode @ bytes, "mimeType" -> type |>
+};
+
+makeImageContent[ URL[ url_String ], _ ] :=
+    { <| "type" -> "text", "text" -> "![Image](" <> url <> ")" |> };
+
+makeImageContent // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
 (*extractWolframAlphaImages*)
 
 (* Pattern for WolframAlpha image URLs in markdown *)
 (* Matches: public6.wolframalpha.com, www6.wolframalpha.com, etc. *)
 $$waImageURLPattern = Shortest[
     "![" ~~ Except[ "]" ]... ~~ "](" ~~
-    url: ("https://" ~~ __ ~~ "wolframalpha.com/files/" ~~ __ ~~ (".gif" | ".png" | ".jpg" | ".jpeg")) ~~
+    url: ("https://" ~~ __ ~~ "wolframalpha.com/files/" ~~ __ ~~ (".gif"|".png"|".jpg"|".jpeg"|".webp"|".svg")) ~~
     ")"
 ];
 
@@ -744,44 +767,50 @@ extractWolframAlphaImages // beginDefinition;
 extractWolframAlphaImages[ str_String ] /; ! $mcpEvaluation := str;
 
 extractWolframAlphaImages[ str_String ] := Enclose[
-    Catch @ Module[ { parts, hasImages, contentItems },
+    Catch @ Module[ { parts, urls, fetched, tasks, replaced, contentItems },
 
-        (* Split string into text segments and URLs *)
-        parts = StringSplit[ str, $$waImageURLPattern :> url ];
+        (* Split string into text segments and URL[..] tokens *)
+        parts = StringSplit[ str, $$waImageURLPattern :> URL[ url ] ];
+        urls  = Cases[ parts, _URL ];
 
-        (* If no images found, return plain text *)
-        If[ Length @ parts === 1 && StringQ @ First @ parts,
-            Throw @ str  (* Return plain string for backward compatibility *)
+        (* If no images found, return plain text for backward compatibility *)
+        If[ urls === { }, Throw @ str ];
+
+        (* Pre-fill every URL with a text-only fallback so a timeout still yields the markdown link *)
+        fetched = AssociationMap[ <| "type" -> "text", "text" -> "![Image](" <> First @ # <> ")" |> &, urls ];
+
+        (* Submit all URLs concurrently; each handler overwrites its slot in `fetched` on success.
+           The outer Function captures the URL in a closure so each handler knows its own key. *)
+        tasks = Function[ u,
+            URLSubmit[
+                u,
+                HandlerFunctions     -> <| "BodyReceived" -> Function[ fetched[ u ] = makeImageContent[ u, # ] ] |>,
+                HandlerFunctionsKeys -> { "StatusCode", "BodyByteArray", "Headers" }
+            ]
+        ] /@ urls;
+
+        (* Bound the whole batch, not each request *)
+        TaskWait[ tasks, TimeConstraint -> $waImageFetchTimeout ];
+        Quiet[ TaskRemove /@ tasks ];
+
+        replaced = Flatten @ Replace[
+            parts,
+            {
+                ""       :> Nothing,
+                s_String :> <| "type" -> "text", "text" -> s |>,
+                u_URL    :> fetched[ u ]
+            },
+            { 1 }
         ];
 
-        hasImages = False;
-        contentItems = Flatten @ Map[
-            Function[ item,
-                If[ StringQ @ item && ! StringStartsQ[ item, "https://" ],
-                    (* Text segment: create text content *)
-                    If[ StringLength @ item > 0,
-                        { <| "type" -> "text", "text" -> item |> },
-                        { }
-                    ],
-                    (* URL: import image and create both text + image content *)
-                    hasImages = True;
-                    Module[ { img, imageContent },
-                        img = Quiet @ TimeConstrained[ Import[ item, "Image" ], 5, $Failed ];
-                        imageContent = If[ ImageQ @ img, graphicsToImageContent @ img, $Failed ];
-                        Flatten @ {
-                            (* Always include the markdown link as text *)
-                            <| "type" -> "text", "text" -> "![Image](" <> item <> ")" |>,
-                            (* Add base64 image if import succeeded *)
-                            If[ AssociationQ @ imageContent, imageContent, Nothing ]
-                        }
-                    ]
-                ]
-            ],
-            parts
+        (* Merge runs of adjacent text items into one *)
+        contentItems = SequenceReplace[
+            replaced,
+            { as: KeyValuePattern[ "type" -> "text" ].. } :>
+                <| "type" -> "text", "text" -> StringJoin @ Lookup[ { as }, "text" ] |>
         ];
 
-        (* If we successfully extracted images, return structured content *)
-        If[ TrueQ @ hasImages && MatchQ[ contentItems, { __Association } ],
+        If[ MatchQ[ contentItems, { __Association } ],
             <| "Content" -> contentItems |>,
             str  (* Fallback to plain string *)
         ]

--- a/Tests/Graphics.wlt
+++ b/Tests/Graphics.wlt
@@ -283,14 +283,16 @@ VerificationTest[
 ]
 
 VerificationTest[
-    With[
-        { result = extractWolframAlphaImages @
-            "Before ![Image](https://public6.wolframalpha.com/files/test.jpg) After" },
-        (* Should have at least text content items *)
-        Length @ result[ "Content" ] >= 2
+    With[ { result = extractWolframAlphaImages[ "Before ![Image](https://public6.wolframalpha.com/files/test.jpg) After" ] },
+        And[
+            AssociationQ @ result,
+            MatchQ[ result, KeyValuePattern[ "Content" -> { __Association } ] ],
+            MemberQ[ result[ "Content" ], KeyValuePattern @ { "type" -> "text", "text" -> _? (StringContainsQ[ "Before" ]) } ],
+            MemberQ[ result[ "Content" ], KeyValuePattern @ { "type" -> "text", "text" -> _? (StringContainsQ[ "After" ]) } ]
+        ]
     ],
     True,
-    TestID -> "extractWolframAlphaImages-MultipleContentItems@@Tests/Graphics.wlt:285,1-294,2"
+    TestID -> "extractWolframAlphaImages-MultipleContentItems@@Tests/Graphics.wlt:285,1-296,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -306,7 +308,7 @@ VerificationTest[
         AssociationQ @ result || StringContainsQ[ result, "wolframalpha.com" ]
     ],
     True,
-    TestID -> "extractWolframAlphaImages-WWW6Domain@@Tests/Graphics.wlt:301,1-310,2"
+    TestID -> "extractWolframAlphaImages-WWW6Domain@@Tests/Graphics.wlt:303,1-312,2"
 ]
 
 VerificationTest[
@@ -317,7 +319,7 @@ VerificationTest[
         AssociationQ @ result || StringContainsQ[ result, "wolframalpha.com" ]
     ],
     True,
-    TestID -> "extractWolframAlphaImages-JpegExtension@@Tests/Graphics.wlt:312,1-321,2"
+    TestID -> "extractWolframAlphaImages-JpegExtension@@Tests/Graphics.wlt:314,1-323,2"
 ]
 
 VerificationTest[
@@ -325,7 +327,7 @@ VerificationTest[
         "![Result](https://example.com/files/image.png)",
     _String,
     SameTest -> MatchQ,
-    TestID   -> "extractWolframAlphaImages-NonWADomain@@Tests/Graphics.wlt:323,1-329,2"
+    TestID   -> "extractWolframAlphaImages-NonWADomain@@Tests/Graphics.wlt:325,1-331,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -338,7 +340,7 @@ VerificationTest[
         MemberQ[ result[ "Content" ], KeyValuePattern[ { "type" -> "text", "text" -> _? (StringContainsQ[ "Before" ]) } ] ]
     ],
     True,
-    TestID -> "extractWolframAlphaImages-PreservesTextBefore@@Tests/Graphics.wlt:334,1-342,2"
+    TestID -> "extractWolframAlphaImages-PreservesTextBefore@@Tests/Graphics.wlt:336,1-344,2"
 ]
 
 VerificationTest[
@@ -348,7 +350,7 @@ VerificationTest[
         MemberQ[ result[ "Content" ], KeyValuePattern[ { "type" -> "text", "text" -> _? (StringContainsQ[ "After" ]) } ] ]
     ],
     True,
-    TestID -> "extractWolframAlphaImages-PreservesTextAfter@@Tests/Graphics.wlt:344,1-352,2"
+    TestID -> "extractWolframAlphaImages-PreservesTextAfter@@Tests/Graphics.wlt:346,1-354,2"
 ]
 
 VerificationTest[
@@ -359,7 +361,7 @@ VerificationTest[
         MemberQ[ result[ "Content" ], KeyValuePattern[ { "type" -> "text", "text" -> _? (StringContainsQ[ "wolframalpha.com" ]) } ] ]
     ],
     True,
-    TestID -> "extractWolframAlphaImages-PreservesURLInText@@Tests/Graphics.wlt:354,1-363,2"
+    TestID -> "extractWolframAlphaImages-PreservesURLInText@@Tests/Graphics.wlt:356,1-365,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)


### PR DESCRIPTION
## Summary

- Replace the sequential `Import[..., "Image"]` loop in `extractWolframAlphaImages` with concurrent `URLSubmit` requests bounded by a single `TaskWait[TimeConstraint -> $waImageFetchTimeout]`, so total batch latency tracks the slowest fetch instead of summing across all images.
- New `makeImageContent` helper passes the server's original bytes and `content-type` straight through (preserving animated GIFs), eliminating the prior `Rasterize`/PNG round-trip.
- Extend the URL pattern to accept `.webp` and `.svg`, and merge adjacent text items in the final content list so the output stays compact when fetches fail.

## Test plan

- [ ] `TestReport` for `Tests/Graphics.wlt` passes, including the loosened `extractWolframAlphaImages-MultipleContentItems` assertion that now accepts the merged-adjacent-text shape on failed fetches.
- [ ] `CodeInspector` clean on `Kernel/StartMCPServer.wl`.
- [ ] Manual smoke: invoke a WolframAlpha query that returns multiple image pods and confirm the MCP response includes one `image` item per successful URL (with the original mime type) and falls back to the markdown text link when a fetch times out.
- [ ] Verify an animated GIF response retains its animation (no PNG rasterization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)