### PR TITLE
Revise WolframLanguageEvaluator and context tool descriptions

### DIFF
--- a/Kernel/Tools/Context.wl
+++ b/Kernel/Tools/Context.wl
@@ -32,19 +32,30 @@ $$maxItemsSpec = Automatic | _Integer? Positive;
 (* ::Subsection::Closed:: *)
 (*WolframContext*)
 $wolframContextToolDescription = "\
-Uses semantic search to retrieve any relevant information from Wolfram. Always use this tool at the start of \
-new conversations or if the topic changes to ensure you have up-to-date relevant information. This uses semantic \
-search, so the context argument should be written in natural language (not a search query) and contain as much detail \
-as possible (up to 250 words).";
+Combined lookup spanning both Wolfram Language documentation and Wolfram|Alpha knowledge. \
+Use this tool to:
+- Approach a topic that spans both real-world knowledge and Wolfram Language programming \
+(e.g., chemistry, physics, finance, geography).
+- Cast a wider net early in exploration to surface relevant context from both sources at once.
+- Survey a domain before deciding whether you need data lookup, code reference, or both.
+
+When the question is clearly programming-focused or clearly factual, prefer the more specific \
+`WolframLanguageContext` or `WolframAlphaContext` instead.
+
+Argument is a natural-language description, not a search query.";
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*WolframAlphaContext*)
 $waContextToolDescription = "\
-Uses semantic search to retrieve any relevant information from Wolfram Alpha. Always use this tool at the start of \
-new conversations or if the topic changes to ensure you have up-to-date relevant information. This uses semantic \
-search, so the context argument should be written in natural language (not a search query) and contain as much detail \
-as possible (up to 250 words).";
+Computational knowledge lookup powered by Wolfram|Alpha \[LongDash] the authoritative source for \
+real-world data, scientific constants, entity properties, and curated factual knowledge. \
+Use this tool to:
+- Look up real-world data and current facts (populations, prices, dates, geographic info, scientific constants).
+- Resolve natural-language quantities and entities to structured form (`Quantity`, `Entity`, `DateObject`, etc.).
+- Cross-reference factual knowledge alongside symbolic computation.
+
+Argument is a natural-language description, not a search query.";
 
 $wolframAlphaMissingLLMKitTemplate = StringTemplate[ "\
 `Level`: Unable to generate Wolfram|Alpha context due to missing LLMKit subscription. \
@@ -57,10 +68,13 @@ $wolframAlphaNoCloudTemplate = StringTemplate[ "\
 (* ::Subsection::Closed:: *)
 (*WolframLanguageContext*)
 $wlContextToolDescription = "\
-Uses semantic search to retrieve information from various sources that can be used to help write Wolfram Language \
-code. Always use this tool at the start of new conversations or if the topic changes to ensure you have up-to-date \
-relevant information. This uses semantic search, so the context argument should be written in natural language \
-(not a search query) and contain as much detail as possible.";
+Documentation lookup for Wolfram Language. WL has 6000+ functions with non-obvious naming \[LongDash] \
+its API surface is wide and often surprising. Use this tool to:
+- Find full documentation, options, and calling forms for a function you're about to use.
+- Verify a function's documented behavior when code isn't behaving as expected.
+- Discover what built-in functions exist for a given goal, or look up the right symbol when you don't know its name.
+
+Argument is a natural-language description, not a search query.";
 
 $documentationPromptHeader = "\
 IMPORTANT: Here are some Wolfram documentation snippets that you should use to respond:\n\n";

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -32,10 +32,14 @@ $imageExportMethod := toolOptionValue[ "WolframLanguageEvaluator", "ImageExportM
 (*Prompts*)
 (* TODO: We need a way to make this description dynamic, e.g. when "Method" is "Session", it also has write access *)
 $wolframLanguageEvaluatorToolDescription = "\
-Evaluates Wolfram Language code for the user in a Wolfram Language kernel.
-Do not ask permission to evaluate code.
-You have read access to local files.
-Always use the Wolfram context tool before using this tool to make sure you have the most up-to-date information.
+Evaluates Wolfram Language code in a live, persistent kernel session. \
+Definitions, variables, and loaded packages survive across calls.
+
+The user installed this MCP server deliberately \[LongDash] they want Wolfram Language used where it fits \
+(computation, symbolic math, data lookups, plotting, etc.) to get results. \
+When a request fits, evaluate code and return the result.
+
+Read and write local files directly from code (e.g. with `Import`, `Export`).
 
 Use `\[FreeformPrompt][\"query\"]` to parse natural language into Wolfram Language expressions \
 (like ctrl+= in notebooks). Always use this for `Quantity`, `Entity`, `EntityClass`, etc. \


### PR DESCRIPTION
### Motivation

Following recent mailing list feedback that agents in Claude Desktop reach for `wolframscript` via shell rather than the `WolframLanguageEvaluator` tool when computing in Wolfram Language. The MCP tool's description doesn't communicate what makes it preferable to a shell-spawned `wolframscript` invocation: a persistent kernel that avoids per-call startup cost.

Reviewing the four affected tool descriptions, several coupled issues compound that core gap:

1. **`WolframLanguageEvaluator`'s key advantage — a persistent kernel that avoids `wolframscript`'s per-call startup cost — isn't stated in the description.** The current text describes the mechanism (*"Evaluates Wolfram Language code... in a Wolfram Language kernel"*) but not what makes it preferable.

2. **The cross-tool nag *"Always use the Wolfram context tool before using this tool"* is unconditional.** Unconditional "always" directives lose their force when applied to situations they don't fit, and dilute the credibility of other directives in the same prompt. The intent — "look things up first" — is valuable; the unconditional mandate undermines it.

3. **The three context tools have nearly identical descriptions** with an *"Always use at the start of new conversations"* mandate that doesn't condition on situation. An agent gets effectively the same signal from all three and can't disambiguate.

4. **`WolframLanguageEvaluator`'s *"read access to local files"* understates the default `Method -> "Session"` capability** — already flagged by the TODO at `Kernel/Tools/WolframLanguageEvaluator.wl:33`.

These issues are coupled: addressing (2) requires the context tools to self-promote properly, which is what (3) is about. This PR addresses them together.

### Design principles

Four cross-cutting principles guided the redesign. These are arguments, not measurements — happy to discuss any of them:

- **Positive framing.** Rules of the form *"do not X"* require the agent to recognize and suppress X, which is fragile. Rules of the form *"do Y, because Z"* give a positive directive plus reasoning the agent can apply contextually. Throughout the new descriptions, directives are positive, with reasoning anchored in *why* they hold.

- **No cross-tool mandates.** Tool descriptions should sell their own tool, not other tools. Cross-tool coupling (Tool A's description pointing the agent at Tool B first) doesn't scale and undermines its own credibility when applied unconditionally. The "look things up first" intent is preserved, but relocated to where it belongs.

- **Situational triggers over blanket mandates.** Concrete situational conditions (*"when verifying documented behavior"*, *"when code isn't behaving as expected"*) give the agent something matchable against the current task. Blanket mandates require the agent to either over-apply them or ignore them — both failure modes.

- **Disambiguation through positive recommendation.** `WolframContext` is the broadest of the three context tools — a naive agent under uncertainty will default to it, doubling latency and result volume. Rather than deprecating it, the new description positions it as a fallback by *positively recommending* the specific tools when the domain is clear.

### Changes per file

**`Kernel/Tools/WolframLanguageEvaluator.wl`**

- **New opening:** *"Evaluates Wolfram Language code in a live, persistent kernel session. Definitions, variables, and loaded packages survive across calls."* States the actual differentiator from a fresh `wolframscript` subprocess; the original description never did.

- **Replaced** *"Do not ask permission to evaluate code"* with reasoning-based framing: *"The user installed this MCP server deliberately — they want Wolfram Language used where it fits (computation, symbolic math, data lookups, plotting, etc.) to get results. When a request fits, evaluate code and return the result."* The intent is for the agent to contextually calibrate (lean in when WL fits, avoid forcing WL into unrelated requests) rather than apply a bare rule.

- **Resolved the TODO at line 33:** *"read access to local files"* → *"Read and write local files directly from code (e.g. with `Import`, `Export`)"*. The original understated default `Method -> "Session"` capability. The examples also softly steer toward in-code file ops.

- **Removed** *"Always use the Wolfram context tool before using this tool..."*. The intent is preserved — relocated to the context tool descriptions themselves where it can be properly conditioned.

- **The `\[FreeformPrompt]` block is unchanged.** Out of scope for this PR.

**`Kernel/Tools/Context.wl`**

All three context tool descriptions rewritten with situational triggers and disambiguation:

- The *"Always use at the start of new conversations or if the topic changes"* mandate is removed in favor of per-tool triggers an agent can match against current state.
- The *"up to 250 words"* / *"as much detail as possible"* guidance is removed — let the agent decide.
- `WolframLanguageContext` triggers focus on programming (function lookup, behavior verification, symbol discovery).
- `WolframAlphaContext` triggers focus on factual lookups (real-world data, entity resolution, knowledge cross-reference).
- `WolframContext` leads with cross-domain queries (chemistry, physics, finance, geography) and explicitly recommends the specific tools when the domain is clear.

### Testing

Smoke-tested locally with Claude Desktop on representative scenarios. Behavior matches expectations — agents reach for `WolframLanguageEvaluator` directly for computation requests without narrating first, and the context tools differentiate appropriately by query type.
