### PR TITLE
Use Elegant screen style environment for evaluator UI results

### DIFF
--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -324,7 +324,8 @@ makeEvaluatorUIResult[
 
         nb = Notebook[
             { Cell @ CellGroupData[ { inputCell, outputCell }, Open ] },
-            CellLabelAutoDelete -> False
+            CellLabelAutoDelete    -> False,
+            ScreenStyleEnvironment -> "Elegant"
         ];
 
         deployed = ConfirmMatch[


### PR DESCRIPTION
## Summary

The Wolfram Language evaluator builds a deployed notebook for its UI results in `makeEvaluatorUIResult`. This sets `ScreenStyleEnvironment -> "Elegant"` on that notebook so evaluator UI results render with the Elegant screen style environment.

## Changes

- `Kernel/Tools/WolframLanguageEvaluator.wl`: Add `ScreenStyleEnvironment -> "Elegant"` to the `Notebook` constructed for evaluator UI results.

## Test plan

- [ ] Trigger an evaluator UI result and confirm the deployed notebook renders with the Elegant screen style environment.
- [ ] Verify existing input/output cell rendering (including cell labels) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)