### PR TITLE
Add experimental inline notebook embedding for MCP Apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ See [building.md](docs/building.md) for detailed instructions.
   - `StartMCPServer.wl`: Implementation for starting MCP servers
   - `SupportedClients.wl`: Registry of supported MCP clients (`$SupportedMCPClients`) and relevant utility functions
   - `ValidateAgentToolsPacletExtension.wl`: Validation of `"AgentTools"` [paclet extensions](docs/paclet-extensions.md)
-  - `UIResources.wl`: [MCP Apps](docs/mcp-apps.md) UI resource registry, client capability detection, and shared cloud notebook deployment helper
+  - `UIResources.wl`: [MCP Apps](docs/mcp-apps.md) UI resource registry, client capability detection, and shared notebook delivery helpers (cloud deployment and experimental inline embedding)
   - `Utilities.wl`: General-purpose helpers — LLMKit subscription checks, Chatbook version verification, and `toJSRegex` for converting ICU/PCRE patterns to ECMA 262 (used when sanitizing tool schema `"pattern"` fields)
   - `YAML.wl`: YAML import/export helpers (`importYAML`, `importYAMLString`, `exportYAML`, `exportYAMLString`) used by YAML-based MCP clients (e.g. Goose)
   - `Tools/`: Contains several files defining predefined MCP tools used by default servers. If tool schemas are modified, we need to rebuild agent skills.

--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -176,7 +176,7 @@
             loadingEl.style.display = "flex";
 
             embedderLoaded.then(function() {
-                return WolframNotebookEmbedder.embed(url, notebookContainer, {
+                return WolframNotebookEmbedder.embed((url.startsWith("http") ? url : {expr: url}), notebookContainer, {
                     allowInteract: true,
                     showRenderProgress: true,
                     width: null,

--- a/Assets/Apps/notebook-viewer.html
+++ b/Assets/Apps/notebook-viewer.html
@@ -194,7 +194,7 @@
                     maxHeight: typeof maxHeight === "number" && maxHeight > 0 ? maxHeight : Infinity
                 };
 
-                return WolframNotebookEmbedder.embed(url, containerEl, opts);
+                return WolframNotebookEmbedder.embed((url.startsWith("http") ? url : {expr: url}), containerEl, opts);
             }).then(function(nb) {
                 embedded = nb;
                 loadingEl.style.display = "none";

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -267,7 +267,7 @@
             loadingEl.style.display = "flex";
 
             embedderLoaded.then(function() {
-                return WolframNotebookEmbedder.embed(url, notebookContainer, {
+                return WolframNotebookEmbedder.embed((url.startsWith("http") ? url : {expr: url}), notebookContainer, {
                     allowInteract: true,
                     showRenderProgress: true,
                     width: null,

--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -26,6 +26,7 @@ BeginPackage[ "Wolfram`AgentTools`Common`" ];
 `catchTopAs;
 `chatbookVersionCheck;
 `defaultEnvironment;
+`delayedDisplay;
 `deployCloudNotebookForMCPApp;
 `directoryQ;
 `endDefinition;

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -351,7 +351,7 @@ toOutputBoxes // beginDefinition;
 
 toOutputBoxes[ (HoldForm|HoldCompleteForm)[ expr_ ] ] :=
     Block[ { $OutputSizeLimit = $outputSizeLimit },
-        cb`CachedBoxes @ OutputSizeLimit`PrePrint @ expr
+        delayedDisplay @ cb`CachedBoxes @ OutputSizeLimit`PrePrint @ expr
     ];
 
 toOutputBoxes // endDefinition;

--- a/Kernel/UIResources.wl
+++ b/Kernel/UIResources.wl
@@ -23,6 +23,10 @@ $includeAppearanceElements = False;
 $deployedNotebookRoot      = "AgentTools/Notebooks";
 $deployCloudNotebooks     := $deployCloudNotebooks = $CloudConnected; (* must be connected to deploy notebooks *)
 
+(* Inline notebooks are not yet the default since there are still some issues to work out.
+   These can be enabled via the following environment variable: *)
+$mcpAppsNotebookMethod := $mcpAppsNotebookMethod = Environment[ "MCP_APPS_NOTEBOOK_METHOD" ];
+
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Cloud Notebooks*)
@@ -31,6 +35,14 @@ $deployCloudNotebooks     := $deployCloudNotebooks = $CloudConnected; (* must be
 (* ::Subsection::Closed:: *)
 (*deployCloudNotebookForMCPApp*)
 deployCloudNotebookForMCPApp // beginDefinition;
+
+deployCloudNotebookForMCPApp[ nb_Notebook, _ ] /; $mcpAppsNotebookMethod === "Inline" := Enclose[
+    (* This should be true if this function is being called: *)
+    ConfirmAssert[ $deployCloudNotebooks, "DeployCloudNotebooksAssert" ];
+
+    ConfirmBy[ ExportString[ nb, "NB" ], StringQ, "Exported" ],
+    throwInternalFailure
+];
 
 deployCloudNotebookForMCPApp[ nb_Notebook, identifier_ ] := Enclose[
     Module[ { hash, target, deployed },
@@ -66,6 +78,29 @@ deployCloudNotebookForMCPApp[ nb_Notebook, identifier_ ] := Enclose[
 ];
 
 deployCloudNotebookForMCPApp // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*delayedDisplay*)
+(* This is a workaround for plots showing up empty when embedding an inline notebook expression instead of a URL *)
+delayedDisplay // beginDefinition;
+
+delayedDisplay[ boxes_ ] /; $mcpAppsNotebookMethod =!= "Inline" := boxes;
+
+delayedDisplay[ boxes_ ] /; FreeQ[ boxes, GraphicsBox|Graphics3DBox ] := boxes;
+
+delayedDisplay[ boxes_ ] :=
+    With[ { b64 = BaseEncode @ BinarySerialize[ Unevaluated @ RawBoxes @ boxes, PerformanceGoal -> "Size" ] },
+        ToBoxes @ DynamicModule[
+            { display },
+            Dynamic[ Replace[ display, _Symbol :> ProgressIndicator[ Appearance -> "Percolate" ] ] ],
+            Initialization            :> (display = BinaryDeserialize @ BaseDecode @ b64),
+            SynchronousInitialization -> False,
+            UnsavedVariables          :> { display }
+        ]
+    ];
+
+delayedDisplay // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Tests/MCPApps.wlt
+++ b/Tests/MCPApps.wlt
@@ -1194,4 +1194,121 @@ VerificationTest[
     TestID   -> "DeployCloudNotebookForMCPApp-NotANotebook@@Tests/MCPApps.wlt:1190,1-1195,2"
 ]
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*Inline Method Returns Serialized Notebook String*)
+VerificationTest[
+    Block[ {
+        Wolfram`AgentTools`UIResources`Private`$mcpAppsNotebookMethod = "Inline",
+        Wolfram`AgentTools`Common`$deployCloudNotebooks = True
+    },
+        StringQ @ Wolfram`AgentTools`Common`deployCloudNotebookForMCPApp[
+            Notebook @ { Cell[ "1 + 1", "Input" ] },
+            "some-id"
+        ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "DeployCloudNotebookForMCPApp-InlineReturnsString@@Tests/MCPApps.wlt:1200,1-1213,2"
+]
+
+VerificationTest[
+    Block[ {
+        Wolfram`AgentTools`UIResources`Private`$mcpAppsNotebookMethod = "Inline",
+        Wolfram`AgentTools`Common`$deployCloudNotebooks = True
+    },
+        ImportString[
+            Wolfram`AgentTools`Common`deployCloudNotebookForMCPApp[
+                Notebook @ { Cell[ "1 + 1", "Input" ] },
+                "some-id"
+            ],
+            "NB"
+        ]
+    ],
+    _Notebook,
+    SameTest -> MatchQ,
+    TestID   -> "DeployCloudNotebookForMCPApp-InlineRoundTrips@@Tests/MCPApps.wlt:1215,1-1231,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*Inline Method Still Asserts Deploy Enabled*)
+VerificationTest[
+    Quiet @ Block[ {
+        Wolfram`AgentTools`UIResources`Private`$mcpAppsNotebookMethod = "Inline",
+        Wolfram`AgentTools`Common`$deployCloudNotebooks = False
+    },
+        Wolfram`AgentTools`Common`deployCloudNotebookForMCPApp[
+            Notebook @ { Cell[ "test", "Input" ] },
+            "some-id"
+        ]
+    ],
+    _Failure,
+    SameTest -> MatchQ,
+    TestID   -> "DeployCloudNotebookForMCPApp-InlineAssertsDeployEnabled@@Tests/MCPApps.wlt:1236,1-1249,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*delayedDisplay*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*Inline Mode Wraps Graphics Output Asynchronously*)
+VerificationTest[
+    Block[ { Wolfram`AgentTools`UIResources`Private`$mcpAppsNotebookMethod = "Inline" },
+        Wolfram`AgentTools`Common`delayedDisplay @ ToBoxes @ Graphics @ { Disk[ ] }
+    ],
+    _DynamicModuleBox,
+    SameTest -> MatchQ,
+    TestID   -> "DelayedDisplay-InlineWrapsGraphics@@Tests/MCPApps.wlt:1258,1-1265,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`UIResources`Private`$mcpAppsNotebookMethod = "Inline" },
+        Wolfram`AgentTools`Common`delayedDisplay @ ToBoxes @ Graphics3D @ { Sphere[ ] }
+    ],
+    _DynamicModuleBox,
+    SameTest -> MatchQ,
+    TestID   -> "DelayedDisplay-InlineWrapsGraphics3D@@Tests/MCPApps.wlt:1267,1-1274,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*Inline Mode Serializes the Original Graphics Box Away*)
+VerificationTest[
+    Block[ { Wolfram`AgentTools`UIResources`Private`$mcpAppsNotebookMethod = "Inline" },
+        FreeQ[ Wolfram`AgentTools`Common`delayedDisplay @ ToBoxes @ Graphics @ { Disk[ ] }, GraphicsBox ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "DelayedDisplay-InlineSerializesGraphics@@Tests/MCPApps.wlt:1279,1-1286,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*Inline Mode Leaves Graphics-Free Output Unchanged*)
+VerificationTest[
+    Block[ { Wolfram`AgentTools`UIResources`Private`$mcpAppsNotebookMethod = "Inline" },
+        Wolfram`AgentTools`Common`delayedDisplay @ RowBox @ { "1", "+", "1" }
+    ],
+    RowBox @ { "1", "+", "1" },
+    SameTest -> MatchQ,
+    TestID   -> "DelayedDisplay-InlineGraphicsFreeUnchanged@@Tests/MCPApps.wlt:1291,1-1298,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*No-Op Outside Inline Mode*)
+VerificationTest[
+    With[ { boxes = ToBoxes @ Graphics @ { Disk[ ] } },
+        Block[ { Wolfram`AgentTools`UIResources`Private`$mcpAppsNotebookMethod = Null },
+            Wolfram`AgentTools`Common`delayedDisplay @ boxes === boxes
+        ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "DelayedDisplay-NonInlineNoOp@@Tests/MCPApps.wlt:1303,1-1312,2"
+]
+
 (* :!CodeAnalysis::EndBlock:: *)

--- a/docs/mcp-apps.md
+++ b/docs/mcp-apps.md
@@ -82,6 +82,21 @@ The fallback is per-tool:
 - `WolframLanguageEvaluator` always has a text/image result it can return, so it degrades in place.
 - `WolframAlpha` has no text-only fallback app view, so its entry in `$toolUIAssociations` is itself conditional on `$deployCloudNotebooks` — when the flag is `False`, no `_meta.ui` is attached to the tool definition and the client never sees it as a UI-enabled tool.
 
+### Notebook Delivery: Cloud vs. Inline
+
+By default, a UI-enhanced notebook is deployed to the Wolfram Cloud and its URL is sent to the app in `_meta.notebookUrl`. An experimental alternative serializes the notebook and embeds it inline, avoiding the cloud round-trip. The delivery method is selected by the `MCP_APPS_NOTEBOOK_METHOD` environment variable:
+
+| `MCP_APPS_NOTEBOOK_METHOD` | Behavior of `deployCloudNotebookForMCPApp` |
+|----------------------------|--------------------------------------------|
+| unset (default) | Deploys the notebook with `CloudDeploy` and returns the cloud URL |
+| `"Inline"` | Returns `ExportString[nb, "NB"]` — the serialized notebook itself — instead of a URL |
+
+The same `notebookUrl` field carries both forms. Each viewer app (`evaluator-viewer.html`, `notebook-viewer.html`, `wolframalpha-viewer.html`) decides how to embed based on the value: a string starting with `http` is embedded as a cloud URL, while any other value is passed to `WolframNotebookEmbedder.embed` as an inline notebook expression (`{expr: ...}`).
+
+Inline embedding is **experimental and not yet the default**. Both methods currently require an active cloud connection, since the UI-enhanced path is gated on `$deployCloudNotebooks` regardless of the delivery method (the `"Inline"` branch only asserts the flag rather than deploying).
+
+When inline embedding is active, graphics can render empty in the embedded notebook. The `delayedDisplay` helper works around this for `WolframLanguageEvaluator` output: any output boxes containing `GraphicsBox`/`Graphics3DBox` are serialized and reconstructed asynchronously inside a `DynamicModule` (showing a progress indicator until ready). Outside inline mode, or for output without graphics, `delayedDisplay` returns the boxes unchanged.
+
 ## Available UI Resources
 
 | URI | HTML Asset | Description |
@@ -205,7 +220,8 @@ Add tests in `Tests/` for the new resource. See the existing test files (`Tests/
 | `$uiResourceRegistry` | `Common` | Association of loaded UI resources keyed by URI |
 | `$toolUIAssociations` | `Common` | Mapping of tool names to UI resource URIs (entries may be `RuleDelayed` to gate on `$deployCloudNotebooks`) |
 | `$deployCloudNotebooks` | `Common` | Session flag gating cloud notebook deployment; initialized from `$CloudConnected` and set to `False` after a deployment failure |
-| `deployCloudNotebookForMCPApp` | `Common` | Shared helper that deploys a notebook for a UI-enhanced tool result and disables `$deployCloudNotebooks` on failure |
+| `deployCloudNotebookForMCPApp` | `Common` | Shared helper that delivers a notebook for a UI-enhanced tool result — deploys to the cloud and returns a URL, or returns the serialized notebook when `MCP_APPS_NOTEBOOK_METHOD` is `"Inline"`; disables `$deployCloudNotebooks` on a deploy failure |
+| `delayedDisplay` | `Common` | Wraps `WolframLanguageEvaluator` output boxes so graphics reconstruct asynchronously when notebooks are embedded inline; a no-op outside inline mode or for graphics-free output |
 | `clientSupportsUIQ` | `Common` | Checks if an `initialize` message advertises UI support |
 | `mcpAppsEnabledQ` | `Common` | Checks the `MCP_APPS_ENABLED` environment variable |
 | `initializeUIResources` | `Common` | Loads HTML assets into the resource registry |

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -434,6 +434,7 @@ Include these environment variables for proper operation:
 | `WOLFRAM_USERBASE` | Path to user's Wolfram files (`$UserBaseDirectory`) |
 | `APPDATA` | (Windows only) Path to application data (typically `ParentDirectory[$UserBaseDirectory]`) |
 | `MCP_APPS_ENABLED` | Set to `"false"` to disable [MCP Apps](mcp-apps.md) UI resources (optional) |
+| `MCP_APPS_NOTEBOOK_METHOD` | Set to `"Inline"` to embed [MCP Apps](mcp-apps.md) notebooks inline instead of deploying them to the cloud (experimental, optional) |
 | `MCP_TOOL_OPTIONS` | JSON string of tool option overrides, set automatically by `"ToolOptions"` (optional) |
 
 ### Getting the Configuration


### PR DESCRIPTION
## Summary

Adds an experimental, opt-in alternative to cloud-deploying MCP Apps notebooks: when `MCP_APPS_NOTEBOOK_METHOD=Inline`, the notebook is serialized and embedded directly in the viewer app instead of being deployed to the Wolfram Cloud and referenced by URL. This avoids the cloud deployment round-trip for UI-enhanced `WolframLanguageEvaluator` and `WolframAlpha` results.

The feature is **gated behind an environment variable and is not the default** — with the variable unset, behavior is unchanged (cloud deployment + URL).

## How it works

- **`$mcpAppsNotebookMethod`** (`Kernel/UIResources.wl`) reads `MCP_APPS_NOTEBOOK_METHOD`. When `"Inline"`, `deployCloudNotebookForMCPApp[nb, _]` returns `ExportString[nb, "NB"]` (the serialized notebook) instead of deploying and returning a cloud URL.
- **Viewer apps** (`evaluator-viewer.html`, `notebook-viewer.html`, `wolframalpha-viewer.html`) inspect the `_meta.notebookUrl` value: a string starting with `http` is embedded as a cloud URL; anything else is passed to `WolframNotebookEmbedder.embed` as an inline expression (`{expr: ...}`).
- **`delayedDisplay`** (`Kernel/UIResources.wl`, declared in `Kernel/CommonSymbols.wl`, used by `Kernel/Tools/WolframLanguageEvaluator.wl`) works around a bug where plots render empty when embedded inline: output boxes containing `GraphicsBox`/`Graphics3DBox` are serialized and reconstructed asynchronously inside a `DynamicModule` with a progress indicator. It is a no-op outside inline mode or for graphics-free output.

> **Note:** Inline mode currently still requires an active cloud connection, since the UI-enhanced path remains gated on `$deployCloudNotebooks`.

## Documentation

- `docs/mcp-apps.md`: new "Notebook Delivery: Cloud vs. Inline" subsection and Key Symbols table updates.
- `docs/mcp-clients.md`: `MCP_APPS_NOTEBOOK_METHOD` added to the environment variable reference.
- `AGENTS.md`: `UIResources.wl` description updated to mention inline embedding.

## Test plan

- [ ] **Default path** (env var unset): UI-enhanced `WolframLanguageEvaluator` / `WolframAlpha` results still deploy a cloud notebook and embed by URL — no behavior change.
- [ ] **Inline path** (`MCP_APPS_NOTEBOOK_METHOD=Inline`): results embed the notebook inline without a cloud deployment, in a UI-capable client (e.g. Claude Desktop).
- [ ] **Graphics**: confirm plots render (not empty) in the inline-embedded notebook, exercising the `delayedDisplay` workaround.
- [ ] **Regression**: run the existing MCP Apps tests (`Tests/MCPApps.wlt`, `Tests/NotebookViewer.wlt`) to confirm no regression.

## Related issue

None identified — experimental follow-up to the existing MCP Apps notebook embedding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)