### PR TITLE
Bugfix: Create missing directories when writing notebooks (GH#200)

### DIFF
--- a/AgentSkills/Skills/wolfram-notebooks/references/Scripts.md
+++ b/AgentSkills/Skills/wolfram-notebooks/references/Scripts.md
@@ -35,7 +35,7 @@ wolframscript -f scripts/WriteNotebook.wls <file> <markdown> [--overwrite value]
 
 | Argument | Required | Description |
 | --- | --- | --- |
-| `file` | Yes | The file to write the notebook to (must end in .nb). |
+| `file` | Yes | The file to write the notebook to (must end in .nb). Any missing parent directories are created automatically. |
 | `markdown` | Yes | The markdown text to write to a notebook. |
 | `--overwrite` | No | Whether to overwrite an existing file (default is False). |
 

--- a/AgentSkills/Skills/wolfram-notebooks/scripts/WriteNotebook.wls
+++ b/AgentSkills/Skills/wolfram-notebooks/scripts/WriteNotebook.wls
@@ -15,7 +15,7 @@ $helpText = StringJoin[
     "Usage: ", $usage, "\n\n",
     "Converts markdown text to a Wolfram notebook and saves it to a file.\n\n",
     "Arguments:\n",
-    "  file (required): The file to write the notebook to (must end in .nb).\n",
+    "  file (required): The file to write the notebook to (must end in .nb). Any missing parent directories are created automatically.\n",
     "  markdown (required): The markdown text to write to a notebook.\n",
     "  --overwrite: Whether to overwrite an existing file (default is False).\n"
 ];

--- a/Kernel/Tools/Notebooks.wl
+++ b/Kernel/Tools/Notebooks.wl
@@ -44,7 +44,7 @@ $defaultMCPTools[ "WriteNotebook" ] := LLMTool @ <|
     "Parameters"  -> {
         "file" -> <|
             "Interpreter" -> "String",
-            "Help"        -> "The file to write the notebook to (must end in .nb).",
+            "Help"        -> "The file to write the notebook to (must end in .nb). Any missing parent directories are created automatically.",
             "Required"    -> True
         |>,
         "overwrite" -> <|
@@ -119,11 +119,23 @@ writeNotebook[ KeyValuePattern @ { "markdown" -> markdown_, "file" -> file_, "ov
     writeNotebook[ markdown, file, TrueQ @ overwrite ];
 
 writeNotebook[ markdown_String, file_String, overwrite: True|False ] := Enclose[
-    Catch @ Module[ { nb },
+    Catch @ Module[ { dir, nb, exported },
         If[ FileExistsQ @ file && ! overwrite, Throw[ "File already exists: " <> file ] ];
+        dir = DirectoryName @ file;
+        If[ dir =!= "" && ! DirectoryQ @ dir,
+            Quiet @ CreateDirectory[ dir, CreateIntermediateDirectories -> True ];
+            If[ ! DirectoryQ @ dir,
+                Throw[ "Cannot write the notebook because the directory does not exist and could not be created: " <> dir ]
+            ]
+        ];
         ConfirmMatch[ chatbookVersionCheck[ ], True, "ChatbookVersionCheck" ];
         nb = ConfirmMatch[ importMarkdownString[ markdown, "Notebook" ], _Notebook, "Notebook" ];
-        ConfirmBy[ Export[ file, nb, "NB" ], FileExistsQ, "File" ]
+        exported = Quiet @ Export[ file, nb, "NB" ];
+        If[ ! StringQ @ exported || ! FileExistsQ @ exported,
+            Throw[ "Unable to write the notebook to the file: " <> file <>
+                   ". The path may be invalid or the location may not be writable." ]
+        ];
+        exported
     ],
     throwInternalFailure
 ];

--- a/Tests/Tools.wlt
+++ b/Tests/Tools.wlt
@@ -178,11 +178,45 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*Missing Directories*)
+
+(* Writing to a path whose parent directories do not exist should create the
+   intermediate directories rather than failing with an internal error (GH#200). *)
+VerificationTest[
+    $missingDirRoot         = FileNameJoin @ { $TemporaryDirectory, "AgentToolsMissingDir_" <> CreateUUID[ ] };
+    $missingDirNotebookFile = FileNameJoin @ { $missingDirRoot, "nested", "test.nb" };
+    { DirectoryQ @ $missingDirRoot, StringQ @ $missingDirNotebookFile },
+    { False, True },
+    SameTest -> MatchQ,
+    TestID   -> "WriteNotebook-MissingDirectory-Setup-GH#200"
+]
+
+VerificationTest[
+    $writeNotebookTool[ <|
+        "markdown"  -> "# Created In New Directory",
+        "file"      -> $missingDirNotebookFile,
+        "overwrite" -> False
+    |> ],
+    _String? FileExistsQ,
+    SameTest -> MatchQ,
+    TestID   -> "WriteNotebook-MissingDirectory-CreatesPath-GH#200"
+]
+
+VerificationTest[
+    FileExistsQ @ $missingDirNotebookFile,
+    True,
+    SameTest -> SameQ,
+    TestID   -> "WriteNotebook-MissingDirectory-FileExists-GH#200"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*Cleanup*)
 VerificationTest[
     If[ FileExistsQ @ $tempNotebookFile, DeleteFile @ $tempNotebookFile ];
-    FileExistsQ @ $tempNotebookFile,
-    False,
+    If[ DirectoryQ @ $missingDirRoot, DeleteDirectory[ $missingDirRoot, DeleteContents -> True ] ];
+    { FileExistsQ @ $tempNotebookFile, DirectoryQ @ $missingDirRoot },
+    { False, False },
     SameTest -> SameQ,
     TestID   -> "WriteNotebook-Cleanup@@Tests/Tools.wlt:182,1-188,2"
 ]


### PR DESCRIPTION
## Summary

Fixes #200.

The `WriteNotebook` tool wrapped `Export` in `ConfirmBy[ Export[...], FileExistsQ, "File" ]`. When given an unwritable file path — for example one whose parent directory does not exist — `Export` returned `$Failed` (issuing `Export::nodir`), and the `ConfirmBy` tripped `throwInternalFailure`. This surfaced an expected user error (a bad file path) as an "unexpected internal error" complete with a bug-report link.

This PR changes the tool to handle missing/unwritable paths gracefully:

- **Create missing parent directories.** Before exporting, if the target directory does not exist, the tool now creates it (and any intermediate directories) via `CreateDirectory[ dir, CreateIntermediateDirectories -> True ]`, so writing to a nested path just works.
- **Return clean, actionable messages instead of internal failures.** If the directory cannot be created, or the file still cannot be written (e.g. an existing but read-only location), the tool returns a plain string message using the same `Catch`/`Throw` convention already used for the "File already exists" case.
- **Document the behavior.** The `file` parameter help now notes that missing parent directories are created automatically, and the generated `wolfram-notebooks` skill artifacts were rebuilt to match.

## Test plan

- `Tests/Tools.wlt` — added three `GH#200` regression tests: a missing nested directory is created, the notebook is written successfully, and the file exists afterward (with cleanup).
- Ran `Tests/Tools.wlt` via the TestReport tool: **63/63 pass**.
- Ran CodeInspector on `Kernel/Tools/Notebooks.wl`: no issues.
- Manually verified the failure paths return clean string messages (not `Failure[...]`): a directory that cannot be created (under `/proc`) and an existing-but-unwritable location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)