### PR TITLE
Add resumable session support to the WolframLanguageEvaluator tool

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
 	},
 	"metadata":{
 		"description":"A collection of Wolfram agent skills",
-		"version":"2.1.10"
+		"version":"2.1.24"
 	},
 	"plugins":[
 		{

--- a/.cspell.json
+++ b/.cspell.json
@@ -58,6 +58,7 @@
         "Stylesheet",
         "subcontext",
         "subcontexts",
+        "subkernel",
         "Subsubsubsection",
         "toolsets",
         "Touchpoints",

--- a/AgentSkills/Skills/wolfram-alpha/SKILL.md
+++ b/AgentSkills/Skills/wolfram-alpha/SKILL.md
@@ -4,7 +4,7 @@ description: Queries Wolfram|Alpha for up-to-date computational results and retr
 compatibility: Requires the Wolfram MCP server or wolframscript on PATH
 metadata:
   author: Wolfram Research
-  version: 2.1.10
+  version: 2.1.24
 ---
 
 # Wolfram|Alpha

--- a/AgentSkills/Skills/wolfram-language/SKILL.md
+++ b/AgentSkills/Skills/wolfram-language/SKILL.md
@@ -4,7 +4,7 @@ description: Evaluates Wolfram Language code, searches documentation, inspects c
 compatibility: Requires the Wolfram MCP server or wolframscript on PATH
 metadata:
   author: Wolfram Research
-  version: 2.1.10
+  version: 2.1.24
 ---
 
 # Wolfram Language

--- a/AgentSkills/Skills/wolfram-language/references/Scripts.md
+++ b/AgentSkills/Skills/wolfram-language/references/Scripts.md
@@ -41,7 +41,7 @@ The argument MUST be a string literal -- it parses before evaluation, so runtime
 **Usage:**
 
 ```
-wolframscript -f scripts/WolframLanguageEvaluator.wls <code> [--timeConstraint value]
+wolframscript -f scripts/WolframLanguageEvaluator.wls <code> [--timeConstraint value] [--session value]
 ```
 
 **Arguments:**
@@ -50,6 +50,7 @@ wolframscript -f scripts/WolframLanguageEvaluator.wls <code> [--timeConstraint v
 | --- | --- | --- |
 | `code` | Yes | The Wolfram Language code to evaluate. |
 | `--timeConstraint` | No | The time constraint for the evaluation. Uses the server's configured default if not specified. |
+| `--session` | No | An opaque session ID returned by a previous call to this tool. Pass it to continue that conversation's isolated session (its definitions, line numbers, and history). Omit it to start a new session; the response returns a new ID that you should reuse on subsequent calls in this conversation. |
 
 ---
 

--- a/AgentSkills/Skills/wolfram-language/scripts/WolframLanguageEvaluator.wls
+++ b/AgentSkills/Skills/wolfram-language/scripts/WolframLanguageEvaluator.wls
@@ -9,14 +9,15 @@
 (*Argument Parsing*)
 
 (* Usage and help text *)
-$usage = "wolframscript -f WolframLanguageEvaluator.wls <code> [--timeConstraint value]";
+$usage = "wolframscript -f WolframLanguageEvaluator.wls <code> [--timeConstraint value] [--session value]";
 
 $helpText = StringJoin[
     "Usage: ", $usage, "\n\n",
     "Evaluates Wolfram Language code for the user in a Wolfram Language kernel.\nDo not ask permission to evaluate code.\nYou have read access to local files.\nAlways use the Wolfram context tool before using this tool to make sure you have the most up-to-date information.\n\nUse `\\[FreeformPrompt][\"query\"]` to parse natural language into Wolfram Language expressions (like ctrl+= in notebooks). Always use this for `Quantity`, `Entity`, `EntityClass`, etc. It composes freely: `ColorNegate[\\[FreeformPrompt][\"picture of a cat\"]]`.\n\nExamples:\n```\n\\[FreeformPrompt][\"France population\"]  (* Entity property value *)\n\\[FreeformPrompt][\"123 terawatt hours\"] (* Quantity *)\n```\n\nThe argument MUST be a string literal -- it parses before evaluation, so runtime construction will not work.\n\n",
     "Arguments:\n",
     "  code (required): The Wolfram Language code to evaluate.\n",
-    "  --timeConstraint: The time constraint for the evaluation. Uses the server's configured default if not specified.\n"
+    "  --timeConstraint: The time constraint for the evaluation. Uses the server's configured default if not specified.\n",
+    "  --session: An opaque session ID returned by a previous call to this tool. Pass it to continue that conversation's isolated session (its definitions, line numbers, and history). Omit it to start a new session; the response returns a new ID that you should reuse on subsequent calls in this conversation.\n"
 ];
 
 (* Check for --usage flag *)
@@ -58,6 +59,7 @@ Module[ { rawArgs, positional, flags, i, key, value },
 
     $parsedArgs[ "code" ] = positional[[ 1 ]];
     If[ KeyExistsQ[ flags, "timeConstraint" ], $parsedArgs[ "timeConstraint" ] = flags[ "timeConstraint" ] ];
+    If[ KeyExistsQ[ flags, "session" ], $parsedArgs[ "session" ] = flags[ "session" ] ];
 ];
 
 (* ::Section:: *)

--- a/AgentSkills/Skills/wolfram-notebooks/SKILL.md
+++ b/AgentSkills/Skills/wolfram-notebooks/SKILL.md
@@ -4,7 +4,7 @@ description: Reads and writes Wolfram notebook (.nb) files. Use this skill when 
 compatibility: Requires the Wolfram MCP server or wolframscript on PATH
 metadata:
   author: Wolfram Research
-  version: 2.1.10
+  version: 2.1.24
 ---
 
 # Wolfram Notebooks

--- a/AgentSkills/Skills/wolfram-paclets/SKILL.md
+++ b/AgentSkills/Skills/wolfram-paclets/SKILL.md
@@ -4,7 +4,7 @@ description: Checks, builds, and submits Wolfram Language paclets. Use this skil
 compatibility: Requires the Wolfram MCP server or wolframscript on PATH
 metadata:
   author: Wolfram Research
-  version: 2.1.10
+  version: 2.1.24
 ---
 
 # Wolfram Paclets

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -21,11 +21,18 @@ $cloudImagePermissions := If[ $imageExportMethod === "CloudPublic", "Public", "P
 $line                   = 1;
 $outputSizeLimit        = 100000;
 
+(* Evaluator session state (plain load-time assignments, so they reset on every (re)load; see the Sessions section) *)
+$currentSessionID = None;
+$sessionStatus    = None;
+
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Tool Option Configuration*)
 $evaluatorMethod   := toolOptionValue[ "WolframLanguageEvaluator", "Method" ];
 $imageExportMethod := toolOptionValue[ "WolframLanguageEvaluator", "ImageExportMethod" ];
+$maxSessionCount   := toolOptionValue[ "WolframLanguageEvaluator", "MaxSessionCount" ];
+$maxSessionBytes   := toolOptionValue[ "WolframLanguageEvaluator", "MaxSessionBytes" ];
+$maxSessionAge     := toolOptionValue[ "WolframLanguageEvaluator", "MaxSessionAge"   ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -73,6 +80,11 @@ $defaultMCPTools[ "WolframLanguageEvaluator" ] := LLMTool @ <|
             "Interpreter" -> "Integer",
             "Help"        -> "The time constraint for the evaluation. Uses the server's configured default if not specified.",
             "Required"    -> False
+        |>,
+        "session" -> <|
+            "Interpreter" -> "String",
+            "Help"        -> "An opaque session ID returned by a previous call to this tool. Pass it to continue that conversation's isolated session (its definitions, line numbers, and history). Omit it to start a new session; the response returns a new ID that you should reuse on subsequent calls in this conversation.",
+            "Required"    -> False
         |>
     }
 |>;
@@ -83,7 +95,10 @@ $defaultMCPTools[ "WolframLanguageEvaluator" ] := LLMTool @ <|
 $defaultToolOptions[ "WolframLanguageEvaluator" ] = <|
     "Method"            -> "Session",
     "ImageExportMethod" -> None,
-    "TimeConstraint"    -> 60
+    "TimeConstraint"    -> 60,
+    "MaxSessionCount"   -> 100,
+    "MaxSessionBytes"   -> 1073741824, (* 1 GB *)
+    "MaxSessionAge"     -> Quantity[ 1, "Months" ]
 |>;
 
 (* ::**************************************************************************************************************:: *)
@@ -95,10 +110,17 @@ $defaultToolOptions[ "WolframLanguageEvaluator" ] = <|
 (*evaluateWolframLanguage*)
 evaluateWolframLanguage // beginDefinition;
 
-evaluateWolframLanguage[ KeyValuePattern @ { "code" -> code_, "timeConstraint" -> timeConstraint_ } ] :=
-    If[ TrueQ @ $clientSupportsUI && TrueQ @ $deployCloudNotebooks,
-        evaluateWolframLanguageUI[ code, timeConstraint ],
-        evaluateWolframLanguage[ code, timeConstraint ]
+evaluateWolframLanguage[ args: KeyValuePattern[ "code" -> code_ ] ] :=
+    Module[ { timeConstraint, session },
+        timeConstraint = Lookup[ args, "timeConstraint", Missing[ "timeConstraint" ] ];
+        session        = Lookup[ args, "session", Missing[ "session" ] ];
+        withSession[
+            session,
+            If[ TrueQ @ $clientSupportsUI && TrueQ @ $deployCloudNotebooks,
+                evaluateWolframLanguageUI[ code, timeConstraint ],
+                evaluateWolframLanguage[ code, timeConstraint ]
+            ]
+        ]
     ];
 
 evaluateWolframLanguage[ code_String, _Missing ] :=
@@ -500,6 +522,352 @@ initializePacletInLocalKernel[ ] := Enclose[
 initializePacletInLocalKernel // endDefinition;
 
 (* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Sessions*)
+(* Each conversation gets an isolated, resumable evaluation session, keyed by an opaque ID supplied by
+   the AI via the "session" parameter. A session is simulated with a per-session $Context plus saved /
+   restored $Line and In/Out/InString/MessageList history, and persisted to disk so it survives server
+   restarts. Works for both "Session" (in-process) and "Local" (separate kernel) methods: the session-
+   defining mutations and the disk read/write run through useEvaluatorKernel so they execute in whichever
+   kernel evaluates the user's code. *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Session ID Generation*)
+$sessionIDLetters    := $sessionIDLetters    = Join[ CharacterRange[ "a", "z" ], CharacterRange[ "A", "Z" ] ];
+$sessionIDCharacters := $sessionIDCharacters = Join[ $sessionIDLetters, CharacterRange[ "0", "9" ] ];
+
+createSessionID // beginDefinition;
+(* First character is a letter so the ID is a valid context component; 8 chars total. *)
+createSessionID[ ] := StringJoin[ RandomChoice[ $sessionIDLetters ], RandomChoice[ $sessionIDCharacters, 7 ] ];
+createSessionID // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*validSessionIDQ*)
+(* Guards "Sessions`" <> id <> "`" against backtick / space / path injection: must start with a letter,
+   contain only word characters, and be of bounded length. *)
+validSessionIDQ // beginDefinition;
+validSessionIDQ[ id_String ] := StringLength @ id <= 64 && StringMatchQ[ id, LetterCharacter ~~ WordCharacter... ];
+validSessionIDQ[ _ ] := False;
+validSessionIDQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Session Paths*)
+sessionsPath // beginDefinition;
+sessionsPath[ ] := fileNameJoin @ { $rootPath, "Sessions" };
+sessionsPath // endDefinition;
+
+sessionFile // beginDefinition;
+sessionFile[ id_String ] := fileNameJoin @ { sessionsPath[ ], id <> ".mx" };
+sessionFile // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Starting, Saving, and Resuming Sessions*)
+(* The *InKernel companions run inside useEvaluatorKernel (so they execute in the eval kernel) and return
+   the eval kernel's $Line; the outer functions update the MCP-side $currentSessionID and the file-scoped
+   $line that drives the "Line" option passed to WolframLanguageToolEvaluate. *)
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+startSession // beginDefinition;
+startSession[ id_String ] := Enclose[
+    Module[ { line },
+        line = ConfirmMatch[ useEvaluatorKernel @ startSessionInKernel @ id, _Integer, "Seed" ];
+        $currentSessionID = id;
+        $line             = line;
+        id
+    ],
+    throwInternalFailure
+];
+startSession // endDefinition;
+
+startSessionInKernel // beginDefinition;
+startSessionInKernel[ id_String ] := (
+    $Context        = "Sessions`" <> id <> "`";
+    $ContextPath    = { $Context, "System`" };
+    $ContextAliases = <| |>;
+    Unprotect[ In, InString, Out, MessageList ];
+    DownValues[ In ]          = { };
+    DownValues[ InString ]    = { };
+    DownValues[ Out ]         = { };
+    DownValues[ MessageList ] = { };
+    Protect[ In, InString, Out, MessageList ];
+    $Line = 1; (* seed 1 -> first label Out[1]=, matching the original $line origin *)
+    $Line
+);
+startSessionInKernel // endDefinition;
+
+
+(* Re-point the eval kernel at an already-live session's context (used when continuing the current
+   session). Unlike startSession it does NOT reset In/Out/$Line: the continuing session's history and
+   the file-scoped $line counter persist between calls. *)
+enterSessionContext // beginDefinition;
+enterSessionContext[ id_String ] := Enclose[
+    ConfirmMatch[ useEvaluatorKernel @ enterSessionContextInKernel @ id, Null, "Entered" ];
+    id,
+    throwInternalFailure
+];
+enterSessionContext // endDefinition;
+
+enterSessionContextInKernel // beginDefinition;
+enterSessionContextInKernel[ id_String ] := (
+    $Context        = "Sessions`" <> id <> "`";
+    $ContextPath    = { $Context, "System`" };
+    $ContextAliases = <| |>;
+    Null
+);
+enterSessionContextInKernel // endDefinition;
+
+
+saveSession // beginDefinition;
+saveSession[ id_String ] := Enclose[
+    Module[ { dir, file },
+        dir  = ConfirmBy[ ensureDirectory @ sessionsPath[ ], directoryQ, "Directory" ];
+        file = ConfirmBy[ sessionFile @ id, fileQ, "File" ];
+        ConfirmMatch[ useEvaluatorKernel @ saveSessionInKernel[ id, First @ file ], True, "Saved" ];
+        cleanupSessions[ ]; (* cleanup-after-write, mirrors Common.wl failure-log handling *)
+        file
+    ],
+    throwInternalFailure
+];
+saveSession // endDefinition;
+
+saveSessionInKernel // beginDefinition;
+saveSessionInKernel[ id_String, path_String ] :=
+    Module[ { tmp },
+        $sessionInfo = <|
+            "$Context"        -> $Context,
+            "$ContextPath"    -> $ContextPath,
+            "$ContextAliases" -> $ContextAliases,
+            "$Line"           -> $Line,
+            "In"              -> DownValues[ In ],
+            "InString"        -> DownValues[ InString ],
+            "Out"             -> DownValues[ Out ],
+            "MessageList"     -> DownValues[ MessageList ]
+        |>;
+        tmp = path <> ".tmp";
+        (* DumpSave the session $Context (all user symbols) plus the held $sessionInfo symbol; the With
+           injects the evaluated context string while DumpSave's HoldRest keeps $sessionInfo a symbol. *)
+        With[ { ctx = $Context },
+            DumpSave[ tmp, { ctx, $sessionInfo }, "SymbolAttributes" -> False ]
+        ];
+        RenameFile[ tmp, path, OverwriteTarget -> True ]; (* atomic-ish: never leave a half-written .mx *)
+        True
+    ];
+saveSessionInKernel // endDefinition;
+
+
+resumeSession // beginDefinition;
+resumeSession[ id_String ] := Enclose[
+    Module[ { file, seed },
+        file = ConfirmBy[ sessionFile @ id, fileQ, "File" ];
+        seed = If[ FileExistsQ @ First @ file,
+                   useEvaluatorKernel @ resumeSessionInKernel @ First @ file,
+                   $Failed
+               ];
+        If[ IntegerQ @ seed,
+            $currentSessionID = id; $line = seed; id,
+            (* Missing or corrupt session file: signal the caller to start fresh (no bug report). *)
+            $Failed
+        ]
+    ],
+    throwInternalFailure
+];
+resumeSession // endDefinition;
+
+resumeSessionInKernel // beginDefinition;
+resumeSessionInKernel[ path_String ] :=
+    Module[ { info },
+        $sessionInfo = $Failed; (* clear stale so a failed Get is detectable *)
+        Quiet @ Get @ path;
+        info = $sessionInfo;
+        If[ AssociationQ @ info,
+            $Context        = info[ "$Context" ];
+            $ContextPath    = info[ "$ContextPath" ];
+            $ContextAliases = info[ "$ContextAliases" ];
+            $Line           = info[ "$Line" ];
+            Unprotect[ In, InString, Out, MessageList ];
+            DownValues[ In ]          = info[ "In" ];
+            DownValues[ InString ]    = info[ "InString" ];
+            DownValues[ Out ]         = info[ "Out" ];
+            DownValues[ MessageList ] = info[ "MessageList" ];
+            Protect[ In, InString, Out, MessageList ];
+            $Line,
+            (* else: malformed payload *)
+            $Failed
+        ]
+    ];
+resumeSessionInKernel // endDefinition;
+
+(* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Session Cleanup*)
+(* Prune oldest-first by age, then count, then total byte budget. The current session's file is always
+   retained, so it is excluded from the candidate set (and from the limits). *)
+cleanupSessions // beginDefinition;
+cleanupSessions[ ] := cleanupSessions[ $maxSessionCount, $maxSessionBytes, $maxSessionAge ];
+cleanupSessions[ maxCount_, maxBytes_, maxAge_ ] :=
+    Catch @ Module[ { dir, all, files, dated, cutoff, old, keep, byCount, bySize, toDelete },
+        dir = First @ sessionsPath[ ];
+        If[ ! DirectoryQ @ dir, Throw @ Null ];
+        all = FileNames[ "*.mx", dir ];
+        files = If[ StringQ @ $currentSessionID,
+                    DeleteCases[ all, f_ /; FileBaseName @ f === $currentSessionID ],
+                    all
+                ];
+        If[ files === { }, Throw @ Null ];
+        dated   = SortBy[ files, FileDate[ #, "Modification" ] & ]; (* oldest first *)
+        cutoff  = toAgeCutoff @ maxAge;
+        old     = If[ cutoff === None, { }, Select[ dated, FileDate[ #, "Modification" ] < cutoff & ] ];
+        keep    = DeleteCases[ dated, Alternatives @@ old ];
+        byCount = If[ IntegerQ @ maxCount && Length @ keep > maxCount, Take[ keep, Length @ keep - maxCount ], { } ];
+        keep    = Drop[ keep, Length @ byCount ];
+        bySize  = sessionsOverByteBudget[ keep, maxBytes ];
+        toDelete = Union[ old, byCount, bySize ];
+        If[ toDelete =!= { }, Quiet[ DeleteFile /@ toDelete ] ];
+    ];
+cleanupSessions // endDefinition;
+
+toAgeCutoff // beginDefinition;
+toAgeCutoff[ q_Quantity ]      := Now - q;
+toAgeCutoff[ s_String ]        := With[ { q = Quiet @ Quantity @ s }, If[ QuantityQ @ q, Now - q, None ] ];
+toAgeCutoff[ n_? NumericQ ]    := Now - Quantity[ n, "Seconds" ];
+toAgeCutoff[ None | Infinity ] := None;
+toAgeCutoff[ _ ]               := None;
+toAgeCutoff // endDefinition;
+
+sessionsOverByteBudget // beginDefinition;
+sessionsOverByteBudget[ _List, max_ ] /; ! IntegerQ @ max := { };
+sessionsOverByteBudget[ files_List, max_Integer ] :=
+    Module[ { sizes, acc, drop },
+        sizes = AssociationMap[ FileByteCount, files ]; (* oldest-first order preserved *)
+        acc   = Total @ Values @ sizes;
+        drop  = { };
+        If[ acc <= max, Return[ { }, Module ] ];
+        Do[
+            If[ acc <= max, Break[ ] ];
+            AppendTo[ drop, f ];
+            acc -= sizes[ f ],
+            { f, files }
+        ];
+        drop
+    ];
+sessionsOverByteBudget // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Session Orchestration*)
+(* The single place that compares the incoming session to $currentSessionID. withSession scopes
+   $Context/$ContextPath to the evaluation (Internal`InheritedBlock), so each call must (re-)point the
+   eval kernel at the session context: a continuing session re-enters its context (its definitions and
+   In/Out/$Line history persist in the kernel between calls); a different existing session is resumed
+   from disk; an unknown ID starts a fresh session reusing that ID. The outgoing session is not saved
+   here on a switch because every call already saves its session at the end (see withSession). *)
+applySession // beginDefinition;
+applySession[ _Missing | None ]                     := ( $sessionStatus = "new"; startSessionSafe @ createSessionID[ ] );
+applySession[ id_String ] /; ! validSessionIDQ @ id := ( $sessionStatus = "new"; startSessionSafe @ createSessionID[ ] );
+applySession[ id_String ] :=
+    Which[
+        id === $currentSessionID,
+            $sessionStatus = "continued"; enterSessionContextSafe @ id,
+        FileExistsQ @ First @ sessionFile @ id,
+            $sessionStatus = "resumed"; resumeSessionSafe @ id,
+        True,
+            $sessionStatus = "reused"; startSessionSafe @ id
+    ];
+applySession // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*Swallow-safe wrappers*)
+(* Session bookkeeping must never abort the user's evaluation result. catchAlways contains any throw even
+   inside the outer catchTop; Quiet suppresses incidental DumpSave/Get messages. *)
+startSessionSafe // beginDefinition;
+startSessionSafe[ id_String ] :=
+    Replace[
+        Quiet @ catchAlways @ startSession @ id,
+        Except[ _String ] :> ( $currentSessionID = id; $line = 1; id )
+    ];
+startSessionSafe // endDefinition;
+
+resumeSessionSafe // beginDefinition;
+resumeSessionSafe[ id_String ] :=
+    Replace[
+        Quiet @ catchAlways @ resumeSession @ id,
+        Except[ _String ] :> ( $sessionStatus = "reused"; startSessionSafe @ id )
+    ];
+resumeSessionSafe // endDefinition;
+
+enterSessionContextSafe // beginDefinition;
+enterSessionContextSafe[ id_String ] :=
+    Replace[
+        Quiet @ catchAlways @ enterSessionContext @ id,
+        Except[ _String ] :> startSessionSafe @ id
+    ];
+enterSessionContextSafe // endDefinition;
+
+saveSessionSafe // beginDefinition;
+saveSessionSafe[ id_String ] := (Quiet @ catchAlways @ saveSession @ id;);
+saveSessionSafe // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*withSession*)
+(* Single choke point wrapping both eval paths: set up the session, evaluate, save, then append the
+   session info. HoldRest defers the evaluation until the session is active. Internal`InheritedBlock
+   scopes $Context/$ContextPath/$ContextAliases to this call: the session context is active during the
+   evaluation and the save, then restored to the kernel's neutral baseline afterward. Symbols created
+   during the block (the user's definitions) persist in their session context, as do the session's
+   In/Out/$Line (which are not in the block), so isolation and history survive across calls while the
+   kernel is never left in a session context between calls. *)
+withSession // beginDefinition;
+withSession // Attributes = { HoldRest };
+withSession[ session_, eval_ ] :=
+    Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
+        Module[ { id, result },
+            id     = applySession @ session;
+            result = eval;
+            saveSessionSafe @ id;
+            appendSessionInfo[ result, id ]
+        ]
+    ];
+withSession // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*appendSessionInfo*)
+appendSessionInfo // beginDefinition;
+appendSessionInfo[ as_Association, id_String ] /; KeyExistsQ[ as, "Content" ] :=
+    Append[ as, "Content" -> Append[ as[ "Content" ], sessionInfoContentItem @ id ] ];
+appendSessionInfo[ str_String, id_String ] := str <> sessionInfoText @ id;
+appendSessionInfo[ other_, id_String ] :=
+    <| "Content" -> { <| "type" -> "text", "text" -> ToString @ other |>, sessionInfoContentItem @ id } |>;
+appendSessionInfo // endDefinition;
+
+sessionInfoContentItem // beginDefinition;
+sessionInfoContentItem[ id_String ] := <| "type" -> "text", "text" -> sessionInfoText @ id |>;
+sessionInfoContentItem // endDefinition;
+
+sessionInfoText // beginDefinition;
+sessionInfoText[ id_String ] := StringJoin[
+    "\n\n<system-reminder>Wolfram session ID: ", id, ".",
+    If[ $sessionStatus === "reused",
+        " (No saved state was found for this ID, so a new empty session was started.)",
+        ""
+    ],
+    " To continue this session (its definitions, line numbers, and history) in your next call to this tool, pass session=\"", id,
+    "\". Omit the session parameter only to start a new, empty session.</system-reminder>"
+];
+sessionInfoText // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -441,6 +441,7 @@ useEvaluatorKernel // endDefinition;
 (* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
 
 evaluateInLocalKernel // beginDefinition;
+evaluateInLocalKernel // Attributes = { HoldAllComplete };
 
 evaluateInLocalKernel[ eval_ ] :=
     Block[ (* FIXME: Expose this as an option in WolframLanguageToolEvaluate *)
@@ -527,11 +528,17 @@ initializePacletInLocalKernel // endDefinition;
 (* ::Section::Closed:: *)
 (*Sessions*)
 (* Each conversation gets an isolated, resumable evaluation session, keyed by an opaque ID supplied by
-   the AI via the "session" parameter. A session is simulated with a per-session $Context plus saved /
-   restored $Line and In/Out/InString/MessageList history, and persisted to disk so it survives server
-   restarts. Works for both "Session" (in-process) and "Local" (separate kernel) methods: the session-
-   defining mutations and the disk read/write run through useEvaluatorKernel so they execute in whichever
-   kernel evaluates the user's code. *)
+   the AI via the "session" parameter. Isolation comes from a per-session $Context: the session functions
+   run via useEvaluatorKernel and point the controlling kernel's $Context at "Sessions`<id>`", so the
+   user's code parses into that context (and, under the "Local" method, the resulting fully qualified
+   symbols then evaluate in that context inside the eval subkernel). State is persisted to disk so sessions
+   survive server restarts.
+
+   Line numbering is owned by the file-scoped $line: the authoritative per-session counter, persisted in
+   the session payload and passed as the "Line" option. Under the in-process "Session" method that option
+   drives the In/Out label directly. Under "Local" the user's code runs in a persistent subkernel whose own
+   $Line produces the label and the option does not reach it, so syncEvalKernelLine pushes $line into that
+   subkernel's $Line at each session boundary, after which the two advance in lockstep. *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
@@ -578,9 +585,11 @@ sessionFile // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Starting, Saving, and Resuming Sessions*)
-(* The *InKernel companions run inside useEvaluatorKernel (so they execute in the eval kernel) and return
-   the eval kernel's $Line; the outer functions update the MCP-side $currentSessionID and the file-scoped
-   $line that drives the "Line" option passed to WolframLanguageToolEvaluate. *)
+(* The *InKernel companions set up the kernel-side session state ($Context, In/Out history, $Line) via
+   useEvaluatorKernel and return the line seed; the outer functions update the MCP-side $currentSessionID
+   and the file-scoped $line. Note that under the "Local" method useEvaluatorKernel runs these in the
+   controlling kernel (which is what points its $Context at the session so the user's code parses into it);
+   the user's code itself runs in the eval subkernel, whose $Line is set separately via syncEvalKernelLine. *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -653,6 +662,37 @@ enterSessionContextInKernel // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
+(*syncEvalKernelLine*)
+(* Push the session's line counter into the eval kernel's $Line. Only needed for the "Local" method: there
+   the user's code runs in a persistent subkernel whose own $Line produces the In/Out label, and the "Line"
+   option does not reach it. (For in-process methods the "Line" option drives the label directly, so this
+   is a no-op.) Routed through evaluateInLocalKernel0 so it targets the subkernel; its $Line-- rollback
+   cancels the main-loop increment, leaving $Line set to exactly the next user line. Called at session
+   boundaries (see withSession); within a session the subkernel's $Line then advances in lockstep with
+   $line. *)
+syncEvalKernelLine // beginDefinition;
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+syncEvalKernelLine[ line_Integer ] /; $evaluatorMethod === "Local" :=
+    Block[ { Wolfram`Chatbook`Sandbox`Private`$includeDefinitions = False },
+        With[ { n = line }, evaluateInLocalKernel0[ $Line = n ] ]
+    ];
+(* :!CodeAnalysis::EndBlock:: *)
+syncEvalKernelLine[ _Integer ] := Null;
+syncEvalKernelLine // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*syncEvalKernelLineSafe*)
+(* Line bookkeeping must never abort the user's evaluation result (mirrors startSessionSafe et al.). *)
+syncEvalKernelLineSafe // beginDefinition;
+syncEvalKernelLineSafe[ line_Integer ] := Quiet @ catchAlways @ syncEvalKernelLine @ line;
+syncEvalKernelLineSafe[ _ ] := Null;
+syncEvalKernelLineSafe // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
 (*saveSession*)
 saveSession // beginDefinition;
 
@@ -681,7 +721,8 @@ saveSessionInKernel[ id_String, path_String ] :=
             "$Context"        -> $Context,
             "$ContextPath"    -> $ContextPath,
             "$ContextAliases" -> $ContextAliases,
-            "$Line"           -> $Line,
+            "$Line"           -> $Line, (* eval kernel's $Line, kept for reference / back-compat *)
+            "$line"           -> $line, (* authoritative per-session counter that drives resume *)
             "In"              -> DownValues[ In ],
             "InString"        -> DownValues[ InString ],
             "Out"             -> DownValues[ Out ],
@@ -729,22 +770,25 @@ resumeSessionInKernel // beginDefinition;
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
 resumeSessionInKernel[ path_String ] :=
-    Module[ { info },
+    Module[ { info, line },
         $sessionInfo = $Failed; (* clear stale so a failed Get is detectable *)
         Quiet @ Get @ path;
         info = $sessionInfo;
         If[ AssociationQ @ info,
+            (* "$line" is the authoritative per-session counter; fall back to the kernel "$Line" for
+               sessions written before it was persisted. *)
+            line            = Replace[ info[ "$line" ], Except[ _Integer ] :> info[ "$Line" ] ];
             $Context        = info[ "$Context" ];
             $ContextPath    = info[ "$ContextPath" ];
             $ContextAliases = info[ "$ContextAliases" ];
-            $Line           = info[ "$Line" ];
+            $Line           = line;
             Unprotect[ In, InString, Out, MessageList ];
             DownValues[ In ]          = info[ "In" ];
             DownValues[ InString ]    = info[ "InString" ];
             DownValues[ Out ]         = info[ "Out" ];
             DownValues[ MessageList ] = info[ "MessageList" ];
             Protect[ In, InString, Out, MessageList ];
-            $Line,
+            line,
             (* else: malformed payload *)
             $Failed
         ]
@@ -928,7 +972,11 @@ withSession // Attributes = { HoldRest };
 withSession[ session_, eval_ ] :=
     Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
         Module[ { id, result },
-            id     = applySession @ session;
+            id = applySession @ session;
+            (* applySession has set $line and the session $Context. For the "Local" method also push $line
+               into the eval subkernel's $Line at a boundary (a continued session already tracks it in
+               lockstep); no-op for in-process methods. *)
+            If[ $sessionStatus =!= "continued", syncEvalKernelLineSafe @ $line ];
             result = eval;
             saveSessionSafe @ id;
             appendSessionInfo[ result, id ]

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -539,13 +539,16 @@ initializePacletInLocalKernel // endDefinition;
 $sessionIDLetters    := $sessionIDLetters    = Join[ CharacterRange[ "a", "z" ], CharacterRange[ "A", "Z" ] ];
 $sessionIDCharacters := $sessionIDCharacters = Join[ $sessionIDLetters, CharacterRange[ "0", "9" ] ];
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*createSessionID*)
 createSessionID // beginDefinition;
 (* First character is a letter so the ID is a valid context component; 8 chars total. *)
 createSessionID[ ] := StringJoin[ RandomChoice[ $sessionIDLetters ], RandomChoice[ $sessionIDCharacters, 7 ] ];
 createSessionID // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
-(* ::Subsection::Closed:: *)
+(* ::Subsubsection::Closed:: *)
 (*validSessionIDQ*)
 (* Guards "Sessions`" <> id <> "`" against backtick / space / path injection: must start with a letter,
    contain only word characters, and be of bounded length. *)
@@ -557,10 +560,17 @@ validSessionIDQ // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Session Paths*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*sessionsPath*)
 sessionsPath // beginDefinition;
 sessionsPath[ ] := fileNameJoin @ { $rootPath, "Sessions" };
 sessionsPath // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*sessionFile*)
 sessionFile // beginDefinition;
 sessionFile[ id_String ] := fileNameJoin @ { sessionsPath[ ], id <> ".mx" };
 sessionFile // endDefinition;
@@ -572,11 +582,11 @@ sessionFile // endDefinition;
    the eval kernel's $Line; the outer functions update the MCP-side $currentSessionID and the file-scoped
    $line that drives the "Line" option passed to WolframLanguageToolEvaluate. *)
 
-(* :!CodeAnalysis::BeginBlock:: *)
-(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
-(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
-
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*startSession*)
 startSession // beginDefinition;
+
 startSession[ id_String ] := Enclose[
     Module[ { line },
         line = ConfirmMatch[ useEvaluatorKernel @ startSessionInKernel @ id, _Integer, "Seed" ];
@@ -586,9 +596,15 @@ startSession[ id_String ] := Enclose[
     ],
     throwInternalFailure
 ];
+
 startSession // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*startSessionInKernel*)
 startSessionInKernel // beginDefinition;
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
 startSessionInKernel[ id_String ] := (
     $Context        = "Sessions`" <> id <> "`";
     $ContextPath    = { $Context, "System`" };
@@ -602,31 +618,44 @@ startSessionInKernel[ id_String ] := (
     $Line = 1; (* seed 1 -> first label Out[1]=, matching the original $line origin *)
     $Line
 );
+(* :!CodeAnalysis::EndBlock:: *)
 startSessionInKernel // endDefinition;
 
-
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*enterSessionContext*)
 (* Re-point the eval kernel at an already-live session's context (used when continuing the current
    session). Unlike startSession it does NOT reset In/Out/$Line: the continuing session's history and
    the file-scoped $line counter persist between calls. *)
 enterSessionContext // beginDefinition;
+
 enterSessionContext[ id_String ] := Enclose[
     ConfirmMatch[ useEvaluatorKernel @ enterSessionContextInKernel @ id, Null, "Entered" ];
     id,
     throwInternalFailure
 ];
+
 enterSessionContext // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*enterSessionContextInKernel*)
 enterSessionContextInKernel // beginDefinition;
+
 enterSessionContextInKernel[ id_String ] := (
     $Context        = "Sessions`" <> id <> "`";
     $ContextPath    = { $Context, "System`" };
     $ContextAliases = <| |>;
     Null
 );
+
 enterSessionContextInKernel // endDefinition;
 
-
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*saveSession*)
 saveSession // beginDefinition;
+
 saveSession[ id_String ] := Enclose[
     Module[ { dir, file },
         dir  = ConfirmBy[ ensureDirectory @ sessionsPath[ ], directoryQ, "Directory" ];
@@ -637,9 +666,15 @@ saveSession[ id_String ] := Enclose[
     ],
     throwInternalFailure
 ];
+
 saveSession // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*saveSessionInKernel*)
 saveSessionInKernel // beginDefinition;
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
 saveSessionInKernel[ id_String, path_String ] :=
     Module[ { tmp },
         $sessionInfo = <|
@@ -661,10 +696,14 @@ saveSessionInKernel[ id_String, path_String ] :=
         RenameFile[ tmp, path, OverwriteTarget -> True ]; (* atomic-ish: never leave a half-written .mx *)
         True
     ];
+(* :!CodeAnalysis::EndBlock:: *)
 saveSessionInKernel // endDefinition;
 
-
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*resumeSession*)
 resumeSession // beginDefinition;
+
 resumeSession[ id_String ] := Enclose[
     Module[ { file, seed },
         file = ConfirmBy[ sessionFile @ id, fileQ, "File" ];
@@ -680,9 +719,15 @@ resumeSession[ id_String ] := Enclose[
     ],
     throwInternalFailure
 ];
+
 resumeSession // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*resumeSessionInKernel*)
 resumeSessionInKernel // beginDefinition;
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
 resumeSessionInKernel[ path_String ] :=
     Module[ { info },
         $sessionInfo = $Failed; (* clear stale so a failed Get is detectable *)
@@ -704,17 +749,22 @@ resumeSessionInKernel[ path_String ] :=
             $Failed
         ]
     ];
-resumeSessionInKernel // endDefinition;
-
 (* :!CodeAnalysis::EndBlock:: *)
+resumeSessionInKernel // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Session Cleanup*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*cleanupSessions*)
 (* Prune oldest-first by age, then count, then total byte budget. The current session's file is always
    retained, so it is excluded from the candidate set (and from the limits). *)
 cleanupSessions // beginDefinition;
+
 cleanupSessions[ ] := cleanupSessions[ $maxSessionCount, $maxSessionBytes, $maxSessionAge ];
+
 cleanupSessions[ maxCount_, maxBytes_, maxAge_ ] :=
     Catch @ Module[ { dir, all, files, dated, cutoff, old, keep, byCount, bySize, toDelete },
         dir = First @ sessionsPath[ ];
@@ -735,8 +785,12 @@ cleanupSessions[ maxCount_, maxBytes_, maxAge_ ] :=
         toDelete = Union[ old, byCount, bySize ];
         If[ toDelete =!= { }, Quiet[ DeleteFile /@ toDelete ] ];
     ];
+
 cleanupSessions // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*toAgeCutoff*)
 toAgeCutoff // beginDefinition;
 toAgeCutoff[ q_Quantity ]      := Now - q;
 toAgeCutoff[ s_String ]        := With[ { q = Quiet @ Quantity @ s }, If[ QuantityQ @ q, Now - q, None ] ];
@@ -745,7 +799,11 @@ toAgeCutoff[ None | Infinity ] := None;
 toAgeCutoff[ _ ]               := None;
 toAgeCutoff // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*sessionsOverByteBudget*)
 sessionsOverByteBudget // beginDefinition;
+
 sessionsOverByteBudget[ _List, max_ ] /; ! IntegerQ @ max := { };
 sessionsOverByteBudget[ files_List, max_Integer ] :=
     Module[ { sizes, acc, drop },
@@ -761,6 +819,7 @@ sessionsOverByteBudget[ files_List, max_Integer ] :=
         ];
         drop
     ];
+
 sessionsOverByteBudget // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -772,55 +831,89 @@ sessionsOverByteBudget // endDefinition;
    In/Out/$Line history persist in the kernel between calls); a different existing session is resumed
    from disk; an unknown ID starts a fresh session reusing that ID. The outgoing session is not saved
    here on a switch because every call already saves its session at the end (see withSession). *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*applySession*)
 applySession // beginDefinition;
-applySession[ _Missing | None ]                     := ( $sessionStatus = "new"; startSessionSafe @ createSessionID[ ] );
-applySession[ id_String ] /; ! validSessionIDQ @ id := ( $sessionStatus = "new"; startSessionSafe @ createSessionID[ ] );
+
+applySession[ _Missing | None ] := (
+    $sessionStatus = "new";
+    startSessionSafe @ createSessionID[ ]
+);
+
+applySession[ id_String ] /; ! validSessionIDQ @ id := (
+    $sessionStatus = "new";
+    startSessionSafe @ createSessionID[ ]
+);
+
 applySession[ id_String ] :=
     Which[
         id === $currentSessionID,
-            $sessionStatus = "continued"; enterSessionContextSafe @ id,
+            $sessionStatus = "continued";
+            enterSessionContextSafe @ id,
+
         FileExistsQ @ First @ sessionFile @ id,
-            $sessionStatus = "resumed"; resumeSessionSafe @ id,
+            $sessionStatus = "resumed";
+            resumeSessionSafe @ id,
+
         True,
-            $sessionStatus = "reused"; startSessionSafe @ id
+            $sessionStatus = "reused";
+            startSessionSafe @ id
     ];
+
 applySession // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
-(*Swallow-safe wrappers*)
+(*startSessionSafe*)
 (* Session bookkeeping must never abort the user's evaluation result. catchAlways contains any throw even
    inside the outer catchTop; Quiet suppresses incidental DumpSave/Get messages. *)
 startSessionSafe // beginDefinition;
+
 startSessionSafe[ id_String ] :=
     Replace[
         Quiet @ catchAlways @ startSession @ id,
-        Except[ _String ] :> ( $currentSessionID = id; $line = 1; id )
+        Except[ _String ] :> ($currentSessionID = id; $line = 1; id)
     ];
+
 startSessionSafe // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*resumeSessionSafe*)
 resumeSessionSafe // beginDefinition;
+
 resumeSessionSafe[ id_String ] :=
     Replace[
         Quiet @ catchAlways @ resumeSession @ id,
         Except[ _String ] :> ( $sessionStatus = "reused"; startSessionSafe @ id )
     ];
+
 resumeSessionSafe // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*enterSessionContextSafe*)
 enterSessionContextSafe // beginDefinition;
+
 enterSessionContextSafe[ id_String ] :=
     Replace[
         Quiet @ catchAlways @ enterSessionContext @ id,
         Except[ _String ] :> startSessionSafe @ id
     ];
+
 enterSessionContextSafe // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*saveSessionSafe*)
 saveSessionSafe // beginDefinition;
-saveSessionSafe[ id_String ] := (Quiet @ catchAlways @ saveSession @ id;);
+saveSessionSafe[ id_String ] := Quiet @ catchAlways @ saveSession @ id;
 saveSessionSafe // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
-(* ::Subsection::Closed:: *)
+(* ::Subsubsection::Closed:: *)
 (*withSession*)
 (* Single choke point wrapping both eval paths: set up the session, evaluate, save, then append the
    session info. HoldRest defers the evaluation until the session is active. Internal`InheritedBlock
@@ -831,6 +924,7 @@ saveSessionSafe // endDefinition;
    kernel is never left in a session context between calls. *)
 withSession // beginDefinition;
 withSession // Attributes = { HoldRest };
+
 withSession[ session_, eval_ ] :=
     Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
         Module[ { id, result },
@@ -840,33 +934,48 @@ withSession[ session_, eval_ ] :=
             appendSessionInfo[ result, id ]
         ]
     ];
+
 withSession // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
-(* ::Subsection::Closed:: *)
+(* ::Subsubsection::Closed:: *)
 (*appendSessionInfo*)
 appendSessionInfo // beginDefinition;
+
 appendSessionInfo[ as_Association, id_String ] /; KeyExistsQ[ as, "Content" ] :=
     Append[ as, "Content" -> Append[ as[ "Content" ], sessionInfoContentItem @ id ] ];
-appendSessionInfo[ str_String, id_String ] := str <> sessionInfoText @ id;
-appendSessionInfo[ other_, id_String ] :=
-    <| "Content" -> { <| "type" -> "text", "text" -> ToString @ other |>, sessionInfoContentItem @ id } |>;
+
+appendSessionInfo[ str_String, id_String ] :=
+    str <> sessionInfoText @ id;
+
+appendSessionInfo[ other_, id_String ] := <|
+    "Content" -> {
+        <| "type" -> "text", "text" -> ToString @ other |>,
+        sessionInfoContentItem @ id
+    }
+|>;
+
 appendSessionInfo // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*sessionInfoContentItem*)
 sessionInfoContentItem // beginDefinition;
 sessionInfoContentItem[ id_String ] := <| "type" -> "text", "text" -> sessionInfoText @ id |>;
 sessionInfoContentItem // endDefinition;
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*sessionInfoText*)
 sessionInfoText // beginDefinition;
+
 sessionInfoText[ id_String ] := StringJoin[
     "\n\n<system-reminder>Wolfram session ID: ", id, ".",
-    If[ $sessionStatus === "reused",
-        " (No saved state was found for this ID, so a new empty session was started.)",
-        ""
-    ],
+    If[ $sessionStatus === "reused", " (No saved state was found for this ID, so a new empty session was started.)", "" ],
     " To continue this session (its definitions, line numbers, and history) in your next call to this tool, pass session=\"", id,
     "\". Omit the session parameter only to start a new, empty session.</system-reminder>"
 ];
+
 sessionInfoText // endDefinition;
 
 (* ::**************************************************************************************************************:: *)

--- a/Notes/evaluator-tool-sessions.md
+++ b/Notes/evaluator-tool-sessions.md
@@ -1,0 +1,184 @@
+# WL Evaluator Tool Sessions
+
+## Motivation
+
+Currently, many MCP clients will start a single MCP server process and share it across individual chat sessions. This is good for reducing memory consumption, start-up times, etc, but it can lead to issues when an AI is calling the WolframLanguageEvaluator tool in a new chat conversation if it's already been used in another one:
+
+* Definitions made in previous conversations are still present, so something like `Solve[..., x]` could fail if `x` was previously defined. The AI in the current conversation wouldn't be aware of this.
+
+* Line numbers in outputs would appear to start at a higher value, which could be confusing.
+
+* Switching back and forth between conversation threads often result in definitions that overwrite each other.
+
+## Goals
+
+* We should have a ``"session"`` parameter added to the WolframLanguageEvaluator tool
+
+* This would be an optional parameter, that when not provided indicates that it's the start of a new session
+
+* We would simulate a unique kernel session by using a ``$Context`` based on the session ID
+
+* Sessions would be saved to disk, so they could also be resumed after the MCP server restarts
+
+* When returning a result from the WolframLanguageEvaluator tool, we would append the unique session ID along with instructions to use this ID in future calls to resume the session
+
+## Implementation notes
+
+```wl
+In[1]:= Needs["Wolfram`AgentTools`"];
+```
+
+### Generating session IDs
+
+Something like this can be used to generate a session ID that's also usable as a context:
+
+```wl
+In[1]:=
+$letters = Join[CharacterRange["a", "z"], CharacterRange["A", "Z"]];
+$characters = Join[$letters, CharacterRange["0", "9"]];
+SessionTesting`createSessionID[] := RandomChoice[$letters] <> RandomSample[$characters, 5];
+
+In[4]:= SessionTesting`sessionID = SessionTesting`createSessionID[]
+
+Out[4]= "Y3mK4u"
+```
+
+**Note:** The `SessionTesting` namespace is just used in this notebook for demonstration purposes since we're switching contexts. This would not be relevant in actual production code.
+
+### Starting a new session
+
+First we would save the current session (if one has been started already).
+
+Then start a new session via something like the following:
+
+```wl
+In[5]:=
+SessionTesting`startSession[sessionID_String] := (
+	$Context = "Sessions`" <> sessionID <> "`";
+	$ContextPath = {$Context, "System`"};
+	$ContextAliases = <||>;
+	Unprotect[In, InString, Out, MessageList];
+	DownValues[In] = {};
+	DownValues[InString] = {};
+	DownValues[Out] = {};
+	DownValues[MessageList] = {};
+	Protect[In, InString, Out, MessageList];
+	$Line = 0;
+);
+
+In[6]:= SessionTesting`startSession[SessionTesting`sessionID]
+```
+
+Create test definitions in the new session:
+
+```wl
+In[1]:= MyFunction[x_] := x + 1;
+
+In[2]:= MyFunction[5]
+
+Out[2]= 6
+```
+
+### Saving sessions
+
+We should use something like this as the storage location (see Files.wl):
+
+```wl
+In[3]:= SessionTesting`$sessionsPath := FileNameJoin @ {Wolfram`AgentTools`Common`$rootPath, "Sessions"}
+```
+
+Save with something like this:
+
+```wl
+In[4]:=
+SessionTesting`saveSession[sessionID_String] :=
+	Module[{file},
+	file = FileNameJoin @ {GeneralUtilities`EnsureDirectory @ SessionTesting`$sessionsPath, sessionID <> ".mx" };
+	SessionTesting`$sessionInfo = <|
+		"$Context"        -> $Context,
+		"$ContextPath"    -> $ContextPath,
+		"$ContextAliases" -> $ContextAliases,
+		"$Line"           -> $Line,
+		"In"              -> DownValues[In],
+		"InString"        -> DownValues[InString],
+		"Out"             -> DownValues[Out],
+		"MessageList"     -> DownValues[MessageList]
+	|>;
+	DumpSave[file, Evaluate @ {$Context, "SessionTesting`$sessionInfo"}, "SymbolAttributes" -> False];
+	file
+];
+```
+
+Save our current session:
+
+```wl
+In[5]:= SessionTesting`saveSession[SessionTesting`sessionID]
+
+Out[5]= "C:\\Users\\rhennigan\\AppData\\Roaming\\Wolfram\\ApplicationData\\Wolfram\\AgentTools\\Sessions\\Y3mK4u.mx"
+```
+
+#### Resuming sessions
+
+First start another session:
+
+```wl
+In[6]:= SessionTesting`newSessionID = SessionTesting`createSessionID[]
+
+Out[6]= "Go98MP"
+
+In[7]:= SessionTesting`startSession[SessionTesting`newSessionID]
+
+In[1]:= MyFunction[x_] := 2x
+
+In[2]:= MyFunction[5]
+
+Out[2]= 10
+```
+
+We can resume another session with something like this:
+
+```wl
+In[3]:=
+SessionTesting`resumeSession[sessionID_String] :=
+	Module[{file, info},
+		file = FileNameJoin @ {SessionTesting`$sessionsPath, sessionID <> ".mx"};
+		Get@file;
+		info = SessionTesting`$sessionInfo;
+		$Context = info["$Context"];
+		$ContextPath = info["$ContextPath"];
+		$ContextAliases = info["$ContextAliases"];
+		$Line = info["$Line"];
+		Unprotect[In, InString, Out, MessageList];
+		DownValues[In] = info["In"];
+		DownValues[InString] = info["InString"];
+		DownValues[Out] = info["Out"];
+		DownValues[MessageList] = info["MessageList"];
+		Protect[In, InString, Out, MessageList];
+	];
+```
+
+Resume our original session:
+
+```wl
+In[4]:= SessionTesting`resumeSession[SessionTesting`sessionID]
+
+In[6]:= MyFunction[5]
+
+Out[6]= 6
+```
+
+### Additional notes
+
+We should store the current session ID in a persistent ``$currentSessionID``, which should start out as ``None``. That way, we can compare the "session" parameter of an incoming WL evaluator tool call to ``$currentSessionID``. If they are the same, we don't need to resume.
+
+We should save the current session after every WL evaluator tool call. This way, sessions can be resumed even if the MCP server is restarted during a conversation.
+
+There should be some limits for sessions stored on disk:
+
+* A maximum number of session files (e.g. 100)
+
+* A maximum total byte count of session files (e.g. 1 GB)
+
+* A maximum time to persist session files (e.g. 1 month)
+
+Starting, saving, and resuming sessions must be done with the ``useEvaluatorKernel`` wrapper function.

--- a/Tests/EvaluatorSessions.wlt
+++ b/Tests/EvaluatorSessions.wlt
@@ -1,0 +1,414 @@
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`AgentToolsTests`", FileNameJoin @ { DirectoryName @ $TestFileName, "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions@@Tests/EvaluatorSessions.wlt:4,1-9,2"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`AgentTools`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext@@Tests/EvaluatorSessions.wlt:11,1-16,2"
+]
+
+(* Helper to extract text from tool results (handles both string and structured content) *)
+extractToolText[ str_String ] := str;
+extractToolText[ as_Association ] /; KeyExistsQ[ as, "Content" ] :=
+    StringJoin @ Cases[ as[ "Content" ], KeyValuePattern[ { "type" -> "text", "text" -> t_String } ] :> t ];
+extractToolText[ _ ] := "";
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Tool Options and Schema*)
+VerificationTest[
+    Wolfram`AgentTools`Common`$defaultToolOptions[ "WolframLanguageEvaluator" ],
+    KeyValuePattern @ {
+        "MaxSessionCount" -> 100,
+        "MaxSessionBytes" -> _Integer,
+        "MaxSessionAge"   -> _Quantity
+    },
+    SameTest -> MatchQ,
+    TestID   -> "DefaultToolOptions-SessionLimits@@Tests/EvaluatorSessions.wlt:30,1-39,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Common`$toolOptions = <| |> },
+        {
+            Wolfram`AgentTools`Common`toolOptionValue[ "WolframLanguageEvaluator", "MaxSessionCount" ],
+            Head @ Wolfram`AgentTools`Common`toolOptionValue[ "WolframLanguageEvaluator", "MaxSessionAge" ]
+        }
+    ],
+    { 100, Quantity },
+    SameTest -> MatchQ,
+    TestID   -> "ToolOptionValue-SessionLimitDefaults@@Tests/EvaluatorSessions.wlt:41,1-51,2"
+]
+
+VerificationTest[
+    StringContainsQ[
+        ToString[ Wolfram`AgentTools`StartMCPServer`Private`toolSchema @ $DefaultMCPTools[ "WolframLanguageEvaluator" ], InputForm ],
+        "session"
+    ],
+    True,
+    TestID -> "Schema-HasSessionParameter@@Tests/EvaluatorSessions.wlt:53,1-60,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Session ID Generation and Validation*)
+VerificationTest[
+    StringMatchQ[ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`createSessionID[ ], LetterCharacter ~~ WordCharacter.. ],
+    True,
+    TestID -> "CreateSessionID-ValidContextComponent@@Tests/EvaluatorSessions.wlt:65,1-69,2"
+]
+
+VerificationTest[
+    StringLength @ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`createSessionID[ ],
+    8,
+    TestID -> "CreateSessionID-Length@@Tests/EvaluatorSessions.wlt:71,1-75,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`validSessionIDQ /@ { "Abc123", "x", "Z9z9z9z9" },
+    { True, True, True },
+    TestID -> "ValidSessionIDQ-Accepts@@Tests/EvaluatorSessions.wlt:77,1-81,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`validSessionIDQ /@ { "1abc", "a b", "a`b", "", "has-dash", 123, StringJoin @ ConstantArray[ "a", 65 ] },
+    { False, False, False, False, False, False, False },
+    TestID -> "ValidSessionIDQ-Rejects@@Tests/EvaluatorSessions.wlt:83,1-87,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Session Paths*)
+VerificationTest[
+    StringEndsQ[ First @ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionsPath[ ], "Sessions" ],
+    True,
+    TestID -> "SessionsPath-EndsWithSessions@@Tests/EvaluatorSessions.wlt:92,1-96,2"
+]
+
+VerificationTest[
+    StringEndsQ[ First @ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionFile[ "Abc123" ], "Sessions/Abc123.mx" ],
+    True,
+    TestID -> "SessionFile-Path@@Tests/EvaluatorSessions.wlt:98,1-102,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*toAgeCutoff*)
+VerificationTest[
+    Head @ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`toAgeCutoff[ Quantity[ 1, "Months" ] ],
+    DateObject,
+    TestID -> "ToAgeCutoff-Quantity@@Tests/EvaluatorSessions.wlt:107,1-111,2"
+]
+
+VerificationTest[
+    Head @ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`toAgeCutoff[ 2592000 ],
+    DateObject,
+    TestID -> "ToAgeCutoff-Number@@Tests/EvaluatorSessions.wlt:113,1-117,2"
+]
+
+VerificationTest[
+    {
+        Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`toAgeCutoff[ None ],
+        Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`toAgeCutoff[ Infinity ],
+        Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`toAgeCutoff[ True ]
+    },
+    { None, None, None },
+    TestID -> "ToAgeCutoff-DisabledAndCatchAll@@Tests/EvaluatorSessions.wlt:119,1-127,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*sessionsOverByteBudget*)
+VerificationTest[
+    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionsOverByteBudget[ { }, 100 ],
+    { },
+    TestID -> "SessionsOverByteBudget-Empty@@Tests/EvaluatorSessions.wlt:132,1-136,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionsOverByteBudget[ { "a", "b" }, "not an integer" ],
+    { },
+    TestID -> "SessionsOverByteBudget-NonIntegerBudgetDisabled@@Tests/EvaluatorSessions.wlt:138,1-142,2"
+]
+
+VerificationTest[
+    Module[ { root, files, sz, result },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsBytes_" <> CreateUUID[ ] };
+        CreateDirectory[ root, CreateIntermediateDirectories -> True ];
+        files = Table[
+            With[ { f = FileNameJoin @ { root, "b" <> ToString[ i ] <> ".mx" } },
+                Export[ f, ConstantArray[ 0, 500 ], "MX" ]; f
+            ],
+            { i, 3 }
+        ];
+        sz     = FileByteCount @ First @ files;
+        (* Budget ~1.5 files -> drop the 2 oldest, keep the newest *)
+        result = Length @ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionsOverByteBudget[ files, sz + Quotient[ sz, 2 ] ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        result
+    ],
+    2,
+    TestID -> "SessionsOverByteBudget-DropsOldest@@Tests/EvaluatorSessions.wlt:144,1-162,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*cleanupSessions*)
+VerificationTest[
+    Module[ { root, sdir, result },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsCleanup_" <> CreateUUID[ ] };
+        sdir = FileNameJoin @ { root, "Sessions" };
+        CreateDirectory[ sdir, CreateIntermediateDirectories -> True ];
+        Do[ Export[ FileNameJoin @ { sdir, "s" <> ToString[ i ] <> ".mx" }, i, "MX" ], { i, 5 } ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath = root,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cleanupSessions[ 3, Infinity, None ]
+        ];
+        result = Length @ FileNames[ "*.mx", sdir ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        result
+    ],
+    3,
+    TestID -> "CleanupSessions-CountLimitKeepsNewest@@Tests/EvaluatorSessions.wlt:167,1-186,2"
+]
+
+VerificationTest[
+    Module[ { root, sdir, result },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsCleanup_" <> CreateUUID[ ] };
+        sdir = FileNameJoin @ { root, "Sessions" };
+        CreateDirectory[ sdir, CreateIntermediateDirectories -> True ];
+        Do[ Export[ FileNameJoin @ { sdir, "keep" <> ToString[ i ] <> ".mx" }, i, "MX" ], { i, 3 } ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath = root,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = "keep2"
+            },
+            (* maxCount 0 deletes every non-current file; the current session must survive *)
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cleanupSessions[ 0, Infinity, None ]
+        ];
+        result = FileBaseName /@ FileNames[ "*.mx", sdir ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        result
+    ],
+    { "keep2" },
+    SameTest -> MatchQ,
+    TestID   -> "CleanupSessions-CurrentSessionSurvives@@Tests/EvaluatorSessions.wlt:188,1-209,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*appendSessionInfo and sessionInfoText*)
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "resumed" },
+        StringContainsQ[ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoText[ "Abc123" ], "session=\"Abc123\"" ]
+    ],
+    True,
+    TestID -> "SessionInfoText-ContainsId@@Tests/EvaluatorSessions.wlt:214,1-220,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "reused" },
+        StringContainsQ[ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoText[ "Abc123" ], "No saved state" ]
+    ],
+    True,
+    TestID -> "SessionInfoText-ReusedNotice@@Tests/EvaluatorSessions.wlt:222,1-228,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "new" },
+        StringContainsQ[ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoText[ "Abc123" ], "No saved state" ]
+    ],
+    False,
+    TestID -> "SessionInfoText-NewHasNoReuseNotice@@Tests/EvaluatorSessions.wlt:230,1-236,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "new" },
+        Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`appendSessionInfo[
+            <| "Content" -> { <| "type" -> "text", "text" -> "hi" |> } |>,
+            "Abc123"
+        ]
+    ],
+    KeyValuePattern[
+        "Content" -> {
+            <| "type" -> "text", "text" -> "hi" |>,
+            <| "type" -> "text", "text" -> _String? (StringContainsQ[ #, "Abc123" ] &) |>
+        }
+    ],
+    SameTest -> MatchQ,
+    TestID   -> "AppendSessionInfo-AppendsToContent@@Tests/EvaluatorSessions.wlt:238,1-253,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "new" },
+        KeyExistsQ[
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`appendSessionInfo[
+                <| "Content" -> { <| "type" -> "text", "text" -> "x" |> }, "_meta" -> <| "notebookUrl" -> "u" |> |>,
+                "Abc123"
+            ],
+            "_meta"
+        ]
+    ],
+    True,
+    TestID -> "AppendSessionInfo-PreservesMeta@@Tests/EvaluatorSessions.wlt:255,1-267,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "new" },
+        MatchQ[
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`appendSessionInfo[ "plain text", "Abc123" ],
+            _String? (StringContainsQ[ #, "plain text" ] && StringContainsQ[ #, "Abc123" ] &)
+        ]
+    ],
+    True,
+    TestID -> "AppendSessionInfo-String@@Tests/EvaluatorSessions.wlt:269,1-278,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Integration: end-to-end session behavior*)
+(* These invoke the real tool (non-UI path), redirecting session storage to a temporary root so the
+   user's real Sessions directory is untouched. $currentSessionID is reset per test for determinism. *)
+
+(* Definitions in one session do not leak into another; switching back resumes the right state. *)
+VerificationTest[
+    Module[ { root, tool, r3 },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSess_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            tool[ <| "code" -> "isoX = 42", "session" -> "IsoSessA" |> ];
+            tool[ <| "code" -> "isoX = 7",  "session" -> "IsoSessB" |> ];
+            r3 = tool[ <| "code" -> "isoX", "session" -> "IsoSessA" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        StringContainsQ[ extractToolText @ r3, "42" ]
+    ],
+    True,
+    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:287,1-306,2"
+]
+
+(* Re-passing the same session ID continues it: definitions persist and line numbers advance. *)
+VerificationTest[
+    Module[ { root, tool, r2, text },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSess_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            tool[ <| "code" -> "cy = 5", "session" -> "ContSess" |> ];
+            r2 = tool[ <| "code" -> "cy + 1", "session" -> "ContSess" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        text = extractToolText @ r2;
+        StringContainsQ[ text, "6" ] && StringContainsQ[ text, "Out[2]" ]
+    ],
+    True,
+    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:309,1-328,2"
+]
+
+(* A session resumes from disk after its in-kernel symbols are gone (simulated server restart). *)
+VerificationTest[
+    Module[ { root, tool, r2 },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSess_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            tool[ <| "code" -> "restartY = 99", "session" -> "RestartSess" |> ];
+            (* Simulate a server restart: drop the in-kernel session symbols and the live session pointer *)
+            Quiet @ Remove[ "Sessions`RestartSess`*" ];
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None;
+            r2 = tool[ <| "code" -> "restartY", "session" -> "RestartSess" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        StringContainsQ[ extractToolText @ r2, "99" ]
+    ],
+    True,
+    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:331,1-352,2"
+]
+
+(* Every result echoes the session ID with resume instructions. *)
+VerificationTest[
+    Module[ { root, tool, r },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSess_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            r = tool[ <| "code" -> "1 + 1", "session" -> "AppendSess" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        StringContainsQ[ extractToolText @ r, "session=\"AppendSess\"" ]
+    ],
+    True,
+    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:355,1-372,2"
+]
+
+(* A fresh session's first evaluation is labeled Out[1]. *)
+VerificationTest[
+    Module[ { root, tool, r },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSess_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            r = tool[ <| "code" -> "1 + 1", "session" -> "LineSess" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        StringContainsQ[ extractToolText @ r, "Out[1]" ]
+    ],
+    True,
+    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:375,1-392,2"
+]
+
+(* An unknown / expired session ID starts a fresh session reusing that ID and says so. *)
+VerificationTest[
+    Module[ { root, tool, text },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSess_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        text = Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            extractToolText @ tool[ <| "code" -> "1", "session" -> "NeverSavedXyz" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        StringContainsQ[ text, "NeverSavedXyz" ] && StringContainsQ[ text, "No saved state" ]
+    ],
+    True,
+    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:395,1-412,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/EvaluatorSessions.wlt
+++ b/Tests/EvaluatorSessions.wlt
@@ -279,6 +279,25 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
+(*syncEvalKernelLine*)
+(* For in-process methods the "Line" option already drives the In/Out label, so syncEvalKernelLine is a
+   no-op (it only does work for the "Local" method, which runs the user's code in a separate subkernel). *)
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Common`$toolOptions = <| |> }, (* Method defaults to "Session" *)
+        Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`syncEvalKernelLine[ 5 ]
+    ],
+    Null,
+    TestID -> "SyncEvalKernelLine-NoOpForInProcess@@Tests/EvaluatorSessions.wlt:285,1-291,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`syncEvalKernelLineSafe[ "not an integer" ],
+    Null,
+    TestID -> "SyncEvalKernelLineSafe-IgnoresNonInteger@@Tests/EvaluatorSessions.wlt:293,1-297,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
 (*Integration: end-to-end session behavior*)
 (* These invoke the real tool (non-UI path), redirecting session storage to a temporary root so the
    user's real Sessions directory is untouched. $currentSessionID is reset per test for determinism. *)
@@ -302,7 +321,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r3, "42" ]
     ],
     True,
-    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:287,1-306,2"
+    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:306,1-325,2"
 ]
 
 (* Re-passing the same session ID continues it: definitions persist and line numbers advance. *)
@@ -324,7 +343,7 @@ VerificationTest[
         StringContainsQ[ text, "6" ] && StringContainsQ[ text, "Out[2]" ]
     ],
     True,
-    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:309,1-328,2"
+    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:328,1-347,2"
 ]
 
 (* A session resumes from disk after its in-kernel symbols are gone (simulated server restart). *)
@@ -348,7 +367,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r2, "99" ]
     ],
     True,
-    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:331,1-352,2"
+    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:350,1-371,2"
 ]
 
 (* Every result echoes the session ID with resume instructions. *)
@@ -368,7 +387,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "session=\"AppendSess\"" ]
     ],
     True,
-    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:355,1-372,2"
+    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:374,1-391,2"
 ]
 
 (* A fresh session's first evaluation is labeled Out[1]. *)
@@ -388,7 +407,32 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "Out[1]" ]
     ],
     True,
-    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:375,1-392,2"
+    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:394,1-411,2"
+]
+
+(* Resuming a session continues its line numbering rather than resetting it: A reaches Out[2], B
+   intervenes (so A is no longer the current session), then resuming A is labeled Out[3]. Regression
+   test for the cross-session line-number bug. *)
+VerificationTest[
+    Module[ { root, tool, r },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSess_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            tool[ <| "code" -> "11", "session" -> "ResumeLineA" |> ]; (* Out[1] *)
+            tool[ <| "code" -> "22", "session" -> "ResumeLineA" |> ]; (* Out[2] *)
+            tool[ <| "code" -> "33", "session" -> "ResumeLineB" |> ]; (* B intervenes; A no longer current *)
+            r = tool[ <| "code" -> "44", "session" -> "ResumeLineA" |> ] (* resume A -> Out[3] *)
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        StringContainsQ[ extractToolText @ r, "Out[3]" ]
+    ],
+    True,
+    TestID -> "Integration-ResumeContinuesLineNumbering@@Tests/EvaluatorSessions.wlt:416,1-436,2"
 ]
 
 (* An unknown / expired session ID starts a fresh session reusing that ID and says so. *)
@@ -408,7 +452,7 @@ VerificationTest[
         StringContainsQ[ text, "NeverSavedXyz" ] && StringContainsQ[ text, "No saved state" ]
     ],
     True,
-    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:395,1-412,2"
+    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:439,1-456,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)


### PR DESCRIPTION
## Summary

Many MCP clients run a single long-lived MCP server process shared across all chat conversations — good for memory and start-up time, but it means the `WolframLanguageEvaluator` tool silently leaks state between unrelated conversations:

- Definitions from a previous conversation persist, so e.g. `Solve[…, x]` can fail because `x` was defined elsewhere — invisibly to the AI in the current conversation.
- Line numbers appear to start mid-stream rather than at `In[1]`.
- Switching between conversation threads lets their definitions overwrite each other.

This PR gives each conversation an isolated, resumable Wolfram Language evaluation session. Design notes: `Notes/evaluator-tool-sessions.md`.

## What's included

Three commits:

**1. Session support (`5c15a9b`)**
- New optional `session` parameter: omit to start a fresh session; pass a previously returned ID to resume one. Every result appends a `<system-reminder>` carrying the session ID and resume instructions.
- Per-session isolation via `$Context = "Sessions`<id>`"` plus saved/restored `$Line` and `In`/`Out`/`InString`/`MessageList` history, persisted to disk as `.mx` (atomic temp-file + `RenameFile`) so sessions survive a server restart. Works for both the in-process `"Session"` method and the separate-kernel `"Local"` method (all session ops route through `useEvaluatorKernel`).
- Context is scoped per call with `` Internal`InheritedBlock ``, so the kernel is never left in a session context between calls while definitions and history still persist.
- Configurable limits as tool options: `MaxSessionCount` (100), `MaxSessionBytes` (1 GB), `MaxSessionAge` (1 month); oldest-first pruning after every save, current session always retained.
- Hardening: `validSessionIDQ` blocks context injection; swallow-safe wrappers ensure session bookkeeping never breaks an evaluation; unknown/corrupt IDs degrade to a fresh session reusing the ID.
- Rebuilds the agent skills for the new schema.

**2. Code reorganization (`4b2acd5`)** — section headers, readability formatting, and per-function `CodeAnalysis::Disable` scoping. No behavioral change.

**3. Line-numbering fix (`3b05886`)** — Under the `"Local"` method the user's code runs in a persistent subkernel whose own `$Line` drives the In/Out label, so the `"Line"` option never reached it and resumed sessions restarted their numbering. Adds the file-scoped `$line` as the authoritative per-session counter (persisted, with `$Line` fallback for older payloads) and `syncEvalKernelLine` to push it into the subkernel at session boundaries, after which the two advance in lockstep.

## Test plan

- ✅ `Tests/EvaluatorSessions.wlt` — **34/34 passing** (run via the TestReport tool). Covers session-ID validation, start/save/resume round-trips, pruning by count/bytes/age, the swallow-safe wrappers, `syncEvalKernelLine` behavior, and end-to-end integration including:
  - a fresh session starts at `In[1]`,
  - resuming a session continues its line numbering across an intervening session (regression test for the bug fixed in `3b05886`),
  - unknown/expired IDs fall back to a fresh session reusing the ID.
- ✅ CodeInspector on `Kernel/Tools/WolframLanguageEvaluator.wl` — no new issues (only two pre-existing `$includeDefinitions` FIXME warnings, unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)