### PR TITLE
Bugfix: Handle LLMKit usage-limit failures in context tools

### DIFF
--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -41,6 +41,8 @@ BeginPackage[ "Wolfram`AgentTools`Common`" ];
 `importResourceFunction;
 `initializeVectorDatabases;
 `llmKitSubscribedQ;
+`llmKitUsageLimitFailureQ;
+`llmKitUsageLimitMessage;
 `makeDeploymentBoxes;
 `makeMCPServerObjectBoxes;
 `mcpServerDirectory;

--- a/Kernel/Tools/Context.wl
+++ b/Kernel/Tools/Context.wl
@@ -53,6 +53,11 @@ Inform the user that they can subscribe at the following URL in order to improve
 $wolframAlphaNoCloudTemplate = StringTemplate[ "\
 `Level`: Unable to generate Wolfram|Alpha context due to missing cloud connection." ];
 
+$wolframAlphaUsageLimitTemplate = StringTemplate[ "\
+`Level`: Unable to generate Wolfram|Alpha context because the LLMKit usage limit has been exceeded. \
+Inform the user that they have exceeded their LLMKit usage limit. \
+The service returned the following message: `Message`" ];
+
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*WolframLanguageContext*)
@@ -66,6 +71,11 @@ $documentationPromptHeader = "\
 IMPORTANT: Here are some Wolfram documentation snippets that you should use to respond:\n\n";
 
 $snippetTemplate = StringTemplate[ "<result url='`URI`'>\n\n`Text`\n\n</result>" ];
+
+$documentationUsageLimitTemplate = StringTemplate[ "\
+Unable to retrieve relevant Wolfram Language documentation because the LLMKit usage limit has been exceeded. \
+Inform the user that they have exceeded their LLMKit usage limit. \
+The service returned the following message: `Message`" ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -226,11 +236,11 @@ relatedWolframAlphaPrompt[ context_, level_ ] :=
 
 (* When subscribed and called as a tool (not internally), extract images *)
 relatedWolframAlphaPrompt[ context_, "Error", True ] :=
-    extractWolframAlphaImages @ relatedWolframAlphaResults @ context;
+    extractWolframAlphaImages @ relatedWolframAlphaResults[ context, "Error" ];
 
 (* When called internally (e.g., from relatedWolframContext), return plain string *)
 relatedWolframAlphaPrompt[ context_, level_, True ] :=
-    relatedWolframAlphaResults @ context;
+    relatedWolframAlphaResults[ context, level ];
 
 relatedWolframAlphaPrompt[ context_, level_, False ] := Enclose[
     Module[ { info, url, connected, template },
@@ -253,29 +263,41 @@ relatedWolframAlphaResults // beginDefinition;
 relatedWolframAlphaResults[ KeyValuePattern[ "context" -> context_ ] ] :=
     relatedWolframAlphaResults @ context;
 
-relatedWolframAlphaResults[ context_String ] := Enclose[
-    Module[ { maxItems, includeWLResults, prompt },
+relatedWolframAlphaResults[ context_String ] :=
+    relatedWolframAlphaResults[ context, "Error" ];
+
+relatedWolframAlphaResults[ context_String, level_String ] := Enclose[
+    Module[ { maxItems, includeWLResults, result },
 
         ConfirmMatch[ chatbookVersionCheck[ ], True, "ChatbookVersionCheck" ];
 
         maxItems = ConfirmMatch[ toMaxItems @ $waMaxItems, $$maxItemsSpec, "WolframAlphaMaxItems" ];
         includeWLResults = Replace[ $waIncludeWLResults, Except[ True|False ] :> Automatic ];
 
-        prompt = ConfirmBy[
-            Quiet[
-                cb`RelatedWolframAlphaResults[
-                    context,
-                    "Prompt",
-                    "MaxItems"         -> maxItems,
-                    "IncludeWLResults" -> includeWLResults
-                ],
-                { WolframAlpha::kbserr }
+        result = Quiet[
+            cb`RelatedWolframAlphaResults[
+                context,
+                "Prompt",
+                "MaxItems"         -> maxItems,
+                "IncludeWLResults" -> includeWLResults
             ],
-            StringQ,
-            "Prompt"
+            { WolframAlpha::kbserr }
         ];
 
-        StringTrim @ prompt
+        (* A user who has exceeded their LLMKit usage limit gets a Failure here; turn it into a useful
+           message instead of letting it become an opaque internal failure. *)
+        If[ llmKitUsageLimitFailureQ @ result,
+            ConfirmBy[
+                TemplateApply[
+                    $wolframAlphaUsageLimitTemplate,
+                    <| "Level" -> level, "Message" -> llmKitUsageLimitMessage @ result |>
+                ],
+                StringQ,
+                "UsageLimitMessage"
+            ],
+            (* else *)
+            StringTrim @ ConfirmBy[ result, StringQ, "Prompt" ]
+        ]
     ],
     throwInternalFailure
 ];
@@ -291,18 +313,33 @@ relatedDocumentation[ KeyValuePattern[ "context" -> context_ ] ] :=
     relatedDocumentation @ context;
 
 relatedDocumentation[ context_String ] := Enclose[
-    Module[ { prompt, formatted },
+    Module[ { result, prompt, formatted },
 
         ConfirmMatch[ chatbookVersionCheck[ ], True, "ChatbookVersionCheck" ];
 
-        prompt = ConfirmBy[ relatedDocumentation0 @ context, StringQ, "Prompt" ];
+        result = relatedDocumentation0 @ context;
 
-        formatted = If[ StringTrim @ prompt === "",
-                        "",
-                        $documentationPromptHeader <> formatDocumentationSnippets @ prompt
-                    ];
+        (* A user who has exceeded their LLMKit usage limit gets a Failure here; turn it into a useful
+           message instead of letting it become an opaque internal failure. *)
+        If[ llmKitUsageLimitFailureQ @ result,
+            ConfirmBy[
+                TemplateApply[
+                    $documentationUsageLimitTemplate,
+                    <| "Message" -> llmKitUsageLimitMessage @ result |>
+                ],
+                StringQ,
+                "UsageLimitMessage"
+            ],
+            (* else *)
+            prompt = ConfirmBy[ result, StringQ, "Prompt" ];
 
-        ConfirmBy[ formatted, StringQ, "Result" ]
+            formatted = If[ StringTrim @ prompt === "",
+                            "",
+                            $documentationPromptHeader <> formatDocumentationSnippets @ prompt
+                        ];
+
+            ConfirmBy[ formatted, StringQ, "Result" ]
+        ]
     ],
     throwInternalFailure
 ];

--- a/Kernel/Utilities.wl
+++ b/Kernel/Utilities.wl
@@ -65,6 +65,55 @@ $fallBackLLMKitInfo := <|
 |>;
 
 (* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*llmKitUsageLimitFailureQ*)
+
+(* Detects the Failure that LLMKit-backed services (e.g. RelatedWolframAlphaResults, RelatedDocumentation)
+   return when the user has exhausted their LLMKit usage/credit allotment. The service responds with HTTP 429
+   and an error code such as "credits-per-month-limit-exceeded". The markers can be buried inside nested
+   Failure objects, so we search the whole expression rather than matching a fixed shape. *)
+llmKitUsageLimitFailureQ // beginDefinition;
+
+llmKitUsageLimitFailureQ[ failure_Failure ] := Or[
+    ! FreeQ[ failure, KeyValuePattern[ "StatusCode" -> 429 ] ],
+    ! FreeQ[ failure, _String? usageLimitCodeQ ]
+];
+
+llmKitUsageLimitFailureQ[ _ ] := False;
+
+llmKitUsageLimitFailureQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*usageLimitCodeQ*)
+usageLimitCodeQ // beginDefinition;
+usageLimitCodeQ[ s_String ] := StringContainsQ[ s, "credits" | "limit-exceeded" | "quota" | "usage-limit", IgnoreCase -> True ];
+usageLimitCodeQ[ _ ] := False;
+usageLimitCodeQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*llmKitUsageLimitMessage*)
+
+$defaultUsageLimitMessage = "The LLMKit usage limit has been exceeded.";
+
+(* Extracts the human-readable error message from an LLMKit usage-limit Failure, falling back to a generic
+   message when the service response does not include one. *)
+llmKitUsageLimitMessage // beginDefinition;
+
+llmKitUsageLimitMessage[ failure_Failure ] := Replace[
+    FirstCase[
+        failure,
+        KeyValuePattern[ "error" -> KeyValuePattern[ "message" -> message_String ] ] :> message,
+        Missing[ "NotFound" ],
+        Infinity
+    ],
+    Except[ _String ] :> $defaultUsageLimitMessage
+];
+
+llmKitUsageLimitMessage // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Dependencies*)
 $minimumChatbookVersion = "2.3.0";

--- a/Tests/Tools.wlt
+++ b/Tests/Tools.wlt
@@ -188,7 +188,7 @@ VerificationTest[
     { DirectoryQ @ $missingDirRoot, StringQ @ $missingDirNotebookFile },
     { False, True },
     SameTest -> MatchQ,
-    TestID   -> "WriteNotebook-MissingDirectory-Setup-GH#200"
+    TestID   -> "WriteNotebook-MissingDirectory-Setup-GH#200@@Tests/Tools.wlt:185,1-192,2"
 ]
 
 VerificationTest[
@@ -199,14 +199,14 @@ VerificationTest[
     |> ],
     _String? FileExistsQ,
     SameTest -> MatchQ,
-    TestID   -> "WriteNotebook-MissingDirectory-CreatesPath-GH#200"
+    TestID   -> "WriteNotebook-MissingDirectory-CreatesPath-GH#200@@Tests/Tools.wlt:194,1-203,2"
 ]
 
 VerificationTest[
     FileExistsQ @ $missingDirNotebookFile,
     True,
     SameTest -> SameQ,
-    TestID   -> "WriteNotebook-MissingDirectory-FileExists-GH#200"
+    TestID   -> "WriteNotebook-MissingDirectory-FileExists-GH#200@@Tests/Tools.wlt:205,1-210,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -218,7 +218,7 @@ VerificationTest[
     { FileExistsQ @ $tempNotebookFile, DirectoryQ @ $missingDirRoot },
     { False, False },
     SameTest -> SameQ,
-    TestID   -> "WriteNotebook-Cleanup@@Tests/Tools.wlt:182,1-188,2"
+    TestID   -> "WriteNotebook-Cleanup@@Tests/Tools.wlt:215,1-222,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -232,28 +232,28 @@ VerificationTest[
     $evaluatorTool = $DefaultMCPTools[ "WolframLanguageEvaluator" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageEvaluator-GetTool@@Tests/Tools.wlt:197,1-202,2"
+    TestID   -> "WolframLanguageEvaluator-GetTool@@Tests/Tools.wlt:231,1-236,2"
 ]
 
 VerificationTest[
     $evalResult1 = $evaluatorTool[ <| "code" -> "1 + 1" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageEvaluator-BasicEval@@Tests/Tools.wlt:204,1-209,2"
+    TestID   -> "WolframLanguageEvaluator-BasicEval@@Tests/Tools.wlt:238,1-243,2"
 ]
 
 VerificationTest[
     StringContainsQ[ extractToolText @ $evalResult1, "2" ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageEvaluator-CorrectResult@@Tests/Tools.wlt:211,1-216,2"
+    TestID   -> "WolframLanguageEvaluator-CorrectResult@@Tests/Tools.wlt:245,1-250,2"
 ]
 
 VerificationTest[
     StringContainsQ[ extractToolText @ $evalResult1, "Out[" ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageEvaluator-HasOutLabel@@Tests/Tools.wlt:218,1-223,2"
+    TestID   -> "WolframLanguageEvaluator-HasOutLabel@@Tests/Tools.wlt:252,1-257,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -263,14 +263,14 @@ VerificationTest[
     $evalResult2 = $evaluatorTool[ <| "code" -> "Range[5]", "timeConstraint" -> 30 |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageEvaluator-WithTimeConstraint@@Tests/Tools.wlt:228,1-233,2"
+    TestID   -> "WolframLanguageEvaluator-WithTimeConstraint@@Tests/Tools.wlt:262,1-267,2"
 ]
 
 VerificationTest[
     StringContainsQ[ extractToolText @ $evalResult2, "{1, 2, 3, 4, 5}" ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageEvaluator-RangeResult@@Tests/Tools.wlt:235,1-240,2"
+    TestID   -> "WolframLanguageEvaluator-RangeResult@@Tests/Tools.wlt:269,1-274,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -280,14 +280,14 @@ VerificationTest[
     $evalResult3 = $evaluatorTool[ <| "code" -> "Table[n^2, {n, 1, 4}]" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageEvaluator-TableExpression@@Tests/Tools.wlt:245,1-250,2"
+    TestID   -> "WolframLanguageEvaluator-TableExpression@@Tests/Tools.wlt:279,1-284,2"
 ]
 
 VerificationTest[
     StringContainsQ[ extractToolText @ $evalResult3, "{1, 4, 9, 16}" ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageEvaluator-TableResult@@Tests/Tools.wlt:252,1-257,2"
+    TestID   -> "WolframLanguageEvaluator-TableResult@@Tests/Tools.wlt:286,1-291,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -297,14 +297,14 @@ VerificationTest[
     $evalResult4 = $evaluatorTool[ <| "code" -> "StringJoin[\"Hello\", \" \", \"World\"]" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageEvaluator-StringExpression@@Tests/Tools.wlt:262,1-267,2"
+    TestID   -> "WolframLanguageEvaluator-StringExpression@@Tests/Tools.wlt:296,1-301,2"
 ]
 
 VerificationTest[
     StringContainsQ[ extractToolText @ $evalResult4, "Hello World" ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageEvaluator-StringResult@@Tests/Tools.wlt:269,1-274,2"
+    TestID   -> "WolframLanguageEvaluator-StringResult@@Tests/Tools.wlt:303,1-308,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -314,28 +314,28 @@ VerificationTest[
     $evalResultPrint1 = $evaluatorTool[ <| "code" -> "Print[\"Hello from Print\"]; 42" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageEvaluator-PrintBasic@@Tests/Tools.wlt:279,1-284,2"
+    TestID   -> "WolframLanguageEvaluator-PrintBasic@@Tests/Tools.wlt:313,1-318,2"
 ]
 
 VerificationTest[
     StringContainsQ[ extractToolText @ $evalResultPrint1, "Hello from Print" ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageEvaluator-PrintOutputCaptured@@Tests/Tools.wlt:286,1-291,2"
+    TestID   -> "WolframLanguageEvaluator-PrintOutputCaptured@@Tests/Tools.wlt:320,1-325,2"
 ]
 
 VerificationTest[
     StringContainsQ[ extractToolText @ $evalResultPrint1, "42" ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageEvaluator-PrintResultIncluded@@Tests/Tools.wlt:293,1-298,2"
+    TestID   -> "WolframLanguageEvaluator-PrintResultIncluded@@Tests/Tools.wlt:327,1-332,2"
 ]
 
 VerificationTest[
     $evalResultPrint2 = $evaluatorTool[ <| "code" -> "Print[\"First\"]; Print[\"Second\"]; Print[\"Third\"]; \"Done\"" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageEvaluator-MultiplePrints@@Tests/Tools.wlt:300,1-305,2"
+    TestID   -> "WolframLanguageEvaluator-MultiplePrints@@Tests/Tools.wlt:334,1-339,2"
 ]
 
 VerificationTest[
@@ -344,14 +344,14 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageEvaluator-MultiplePrintsCaptured@@Tests/Tools.wlt:307,1-314,2"
+    TestID   -> "WolframLanguageEvaluator-MultiplePrintsCaptured@@Tests/Tools.wlt:341,1-348,2"
 ]
 
 VerificationTest[
     $evalResultPrint3 = $evaluatorTool[ <| "code" -> "Do[Print[i], {i, 3}]; \"Complete\"" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageEvaluator-PrintInLoop@@Tests/Tools.wlt:316,1-321,2"
+    TestID   -> "WolframLanguageEvaluator-PrintInLoop@@Tests/Tools.wlt:350,1-355,2"
 ]
 
 VerificationTest[
@@ -360,7 +360,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageEvaluator-PrintInLoopCaptured@@Tests/Tools.wlt:323,1-330,2"
+    TestID   -> "WolframLanguageEvaluator-PrintInLoopCaptured@@Tests/Tools.wlt:357,1-364,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -374,14 +374,14 @@ VerificationTest[
     $wolframAlphaTool = $DefaultMCPTools[ "WolframAlpha" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlpha-GetTool@@Tests/Tools.wlt:339,1-344,2"
+    TestID   -> "WolframAlpha-GetTool@@Tests/Tools.wlt:373,1-378,2"
 ]
 
 VerificationTest[
     $waResult = $wolframAlphaTool[ <| "query" -> "population of France" |> ],
     _String? StringQ | KeyValuePattern[ "Content" -> { __Association } ],
     SameTest -> MatchQ,
-    TestID   -> "WolframAlpha-BasicQuery@@Tests/Tools.wlt:346,1-351,2"
+    TestID   -> "WolframAlpha-BasicQuery@@Tests/Tools.wlt:380,1-385,2"
 ]
 
 VerificationTest[
@@ -392,14 +392,14 @@ VerificationTest[
         ],
     _String? StringQ,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlpha-ResultString@@Tests/Tools.wlt:353,1-362,2"
+    TestID   -> "WolframAlpha-ResultString@@Tests/Tools.wlt:387,1-396,2"
 ]
 
 VerificationTest[
     StringLength @ $waResultString > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframAlpha-NonEmptyResult@@Tests/Tools.wlt:364,1-369,2"
+    TestID   -> "WolframAlpha-NonEmptyResult@@Tests/Tools.wlt:398,1-403,2"
 ]
 
 (* TODO: multiple queries aren't supported until the next Chatbook paclet update *)
@@ -428,28 +428,28 @@ VerificationTest[
     $wlContextTool = $DefaultMCPTools[ "WolframLanguageContext" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageContext-GetTool@@Tests/Tools.wlt:393,1-398,2"
+    TestID   -> "WolframLanguageContext-GetTool@@Tests/Tools.wlt:427,1-432,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     $wlContextResult = $wlContextTool[ <| "context" -> "How to create a list of prime numbers in Wolfram Language" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageContext-BasicQuery@@Tests/Tools.wlt:400,23-405,2"
+    TestID   -> "WolframLanguageContext-BasicQuery@@Tests/Tools.wlt:434,23-439,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringLength[ extractToolText @ $wlContextResult ] > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageContext-NonEmptyResult@@Tests/Tools.wlt:407,23-412,2"
+    TestID   -> "WolframLanguageContext-NonEmptyResult@@Tests/Tools.wlt:441,23-446,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringContainsQ[ extractToolText @ $wlContextResult, "Prime" | "prime" | "Table" | "Range", IgnoreCase -> True ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageContext-RelevantContent@@Tests/Tools.wlt:414,23-419,2"
+    TestID   -> "WolframLanguageContext-RelevantContent@@Tests/Tools.wlt:448,23-453,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -463,21 +463,21 @@ VerificationTest[
     $waContextTool = $DefaultMCPTools[ "WolframAlphaContext" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlphaContext-GetTool@@Tests/Tools.wlt:428,1-433,2"
+    TestID   -> "WolframAlphaContext-GetTool@@Tests/Tools.wlt:462,1-467,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     $waContextResult = $waContextTool[ <| "context" -> "What is the distance from Earth to Mars" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlphaContext-BasicQuery@@Tests/Tools.wlt:435,23-440,2"
+    TestID   -> "WolframAlphaContext-BasicQuery@@Tests/Tools.wlt:469,23-474,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringLength[ extractToolText @ $waContextResult ] > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframAlphaContext-NonEmptyResult@@Tests/Tools.wlt:442,23-447,2"
+    TestID   -> "WolframAlphaContext-NonEmptyResult@@Tests/Tools.wlt:476,23-481,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -491,22 +491,166 @@ VerificationTest[
     $wolframContextTool = $DefaultMCPTools[ "WolframContext" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframContext-GetTool@@Tests/Tools.wlt:456,1-461,2"
+    TestID   -> "WolframContext-GetTool@@Tests/Tools.wlt:490,1-495,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     $wolframContextResult = $wolframContextTool[ <| "context" -> "How to compute derivatives symbolically" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframContext-BasicQuery@@Tests/Tools.wlt:463,23-468,2"
+    TestID   -> "WolframContext-BasicQuery@@Tests/Tools.wlt:497,23-502,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringLength[ extractToolText @ $wolframContextResult ] > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframContext-NonEmptyResult@@Tests/Tools.wlt:470,23-475,2"
+    TestID   -> "WolframContext-NonEmptyResult@@Tests/Tools.wlt:504,23-509,2"
 ]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*LLMKit Usage Limit Handling*)
+
+(* These tests mock the Chatbook calls so they exercise the over-limit code path without a live service. *)
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* The Failure that RelatedWolframAlphaResults / RelatedDocumentation return when the user has exceeded
+   their monthly LLMKit credit allotment (HTTP 429). *)
+$usageLimitFailure = Failure[ "APIError", <|
+    "MessageTemplate"   -> "The service returned the following error message: `1`.",
+    "MessageParameters" -> { "credits-per-month-limit-exceeded - User has exceeded credits limit." },
+    "StatusCode"        -> 429,
+    "Body"              -> <|
+        "success" -> False,
+        "error"   -> <|
+            "code"    -> "credits-per-month-limit-exceeded",
+            "message" -> "credits-per-month-limit-exceeded - User has exceeded credits limit."
+        |>
+    |>
+|> ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*RelatedWolframAlphaResults*)
+
+(* An over-limit Failure becomes a useful, actionable message instead of an opaque internal failure. *)
+VerificationTest[
+    $waUsageLimitResult = Block[
+        {
+            Wolfram`AgentTools`Common`chatbookVersionCheck      = ( True & ),
+            Wolfram`Chatbook`RelatedWolframAlphaResults         = ( $usageLimitFailure & )
+        },
+        Wolfram`AgentTools`Common`relatedWolframAlphaResults[ "Print Hello in Wolfram Language", "Error" ]
+    ],
+    _String? (StringContainsQ[ "usage limit" ]),
+    SameTest -> MatchQ,
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitMessage@@Tests/Tools.wlt:540,1-551,2"
+]
+
+(* The service's own error message is surfaced to the agent. *)
+VerificationTest[
+    StringContainsQ[ $waUsageLimitResult, "credits-per-month-limit-exceeded" ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitIncludesServiceMessage@@Tests/Tools.wlt:554,1-559,2"
+]
+
+(* It is NOT a Failure, so the MCP layer will not flag it as an error or emit a bug report. *)
+VerificationTest[
+    FailureQ @ $waUsageLimitResult,
+    False,
+    SameTest -> SameQ,
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitNotFailure@@Tests/Tools.wlt:562,1-567,2"
+]
+
+(* The caller's message level (e.g. "Warning" from the combined WolframContext tool) is honored. *)
+VerificationTest[
+    StringStartsQ[
+        Block[
+            {
+                Wolfram`AgentTools`Common`chatbookVersionCheck = ( True & ),
+                Wolfram`Chatbook`RelatedWolframAlphaResults    = ( $usageLimitFailure & )
+            },
+            Wolfram`AgentTools`Common`relatedWolframAlphaResults[ "Print Hello in Wolfram Language", "Warning" ]
+        ],
+        "Warning:"
+    ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitLevel@@Tests/Tools.wlt:570,1-584,2"
+]
+
+(* A genuine string result is still returned unchanged (regression guard). *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Common`chatbookVersionCheck = ( True & ),
+            Wolfram`Chatbook`RelatedWolframAlphaResults    = ( "Some Wolfram|Alpha context." & )
+        },
+        Wolfram`AgentTools`Common`relatedWolframAlphaResults[ "population of France", "Error" ]
+    ],
+    "Some Wolfram|Alpha context.",
+    SameTest -> SameQ,
+    TestID   -> "RelatedWolframAlphaResults-NormalResultUnchanged@@Tests/Tools.wlt:587,1-598,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*RelatedDocumentation*)
+
+VerificationTest[
+    $docUsageLimitResult = Block[
+        {
+            Wolfram`AgentTools`Common`chatbookVersionCheck = ( True & ),
+            Wolfram`AgentTools`Common`llmKitSubscribedQ    = ( False & ),
+            Wolfram`Chatbook`RelatedDocumentation          = ( $usageLimitFailure & )
+        },
+        Wolfram`AgentTools`Common`relatedDocumentation[ "Print Hello in Wolfram Language" ]
+    ],
+    _String? (StringContainsQ[ "usage limit" ]),
+    SameTest -> MatchQ,
+    TestID   -> "RelatedDocumentation-UsageLimitMessage@@Tests/Tools.wlt:604,1-616,2"
+]
+
+VerificationTest[
+    FailureQ @ $docUsageLimitResult,
+    False,
+    SameTest -> SameQ,
+    TestID   -> "RelatedDocumentation-UsageLimitNotFailure@@Tests/Tools.wlt:618,1-623,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*WolframContext (combined)*)
+
+(* The combined tool calls both sub-tools; a subscribed user who is over their limit still gets a useful
+   message rather than an internal failure. *)
+VerificationTest[
+    $wcUsageLimitResult = Block[
+        {
+            Wolfram`AgentTools`Common`chatbookVersionCheck = ( True & ),
+            Wolfram`AgentTools`Common`llmKitSubscribedQ    = ( True & ),
+            Wolfram`Chatbook`RelatedWolframAlphaResults    = ( $usageLimitFailure & ),
+            Wolfram`Chatbook`RelatedDocumentation          = ( $usageLimitFailure & )
+        },
+        Wolfram`AgentTools`Common`relatedWolframContext[ "Print Hello in Wolfram Language" ]
+    ],
+    _String? (StringContainsQ[ "usage limit" ]),
+    SameTest -> MatchQ,
+    TestID   -> "RelatedWolframContext-UsageLimitMessage@@Tests/Tools.wlt:631,1-644,2"
+]
+
+VerificationTest[
+    FailureQ @ $wcUsageLimitResult,
+    False,
+    SameTest -> SameQ,
+    TestID   -> "RelatedWolframContext-UsageLimitNotFailure@@Tests/Tools.wlt:646,1-651,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -521,14 +665,14 @@ VerificationTest[
     $testReportTool = $DefaultMCPTools[ "TestReport" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "TestReport-GetTool@@Tests/Tools.wlt:486,1-491,2"
+    TestID   -> "TestReport-GetTool@@Tests/Tools.wlt:664,1-669,2"
 ]
 
 VerificationTest[
     $testResourceDirectory = FileNameJoin @ { DirectoryName[ $TestFileName, 2 ], "TestResources" },
     _String? DirectoryQ,
     SameTest -> MatchQ,
-    TestID   -> "TestReport-TestResourceDirectory@@Tests/Tools.wlt:493,1-498,2"
+    TestID   -> "TestReport-TestResourceDirectory@@Tests/Tools.wlt:671,1-676,2"
 ]
 
 VerificationTest[
@@ -538,7 +682,7 @@ VerificationTest[
     |>,
     _String? (StringContainsQ[ "# Test Results Summary"~~__~~"TestFile1.wlt" ]),
     SameTest -> MatchQ,
-    TestID   -> "TestReport-SingleFile@@Tests/Tools.wlt:500,1-508,2"
+    TestID   -> "TestReport-SingleFile@@Tests/Tools.wlt:678,1-686,2"
 ]
 
 VerificationTest[
@@ -552,7 +696,7 @@ VerificationTest[
     |>,
     _String? (StringContainsQ[ "# Test Results Summary"~~__~~"TestFile1.wlt"~~__~~"TestFile2.wlt" ]),
     SameTest -> MatchQ,
-    TestID   -> "TestReport-MultipleFiles@@Tests/Tools.wlt:510,1-522,2"
+    TestID   -> "TestReport-MultipleFiles@@Tests/Tools.wlt:688,1-700,2"
 ]
 
 VerificationTest[
@@ -562,7 +706,7 @@ VerificationTest[
     |>,
     _String? (StringContainsQ[ "# Test Results Summary"~~__~~"TestFile1.wlt"~~__~~"TestFile2.wlt" ]),
     SameTest -> MatchQ,
-    TestID   -> "TestReport-Directory@@Tests/Tools.wlt:524,1-532,2"
+    TestID   -> "TestReport-Directory@@Tests/Tools.wlt:702,1-710,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -598,7 +742,7 @@ skipIfGitHubActions @ VerificationTest[
     ],
     True,
     SameTest -> MatchQ,
-    TestID   -> "TestReport-McpRootRelativePath@@Tests/Tools.wlt:541,23-568,2"
+    TestID   -> "TestReport-McpRootRelativePath@@Tests/Tools.wlt:719,23-746,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -611,7 +755,7 @@ VerificationTest[
     Failure[ "AgentTools::TestFileNotFound", _Association ],
     { AgentTools::TestFileNotFound },
     SameTest -> MatchQ,
-    TestID   -> "TestReport-NonexistentFile-GH#65@@Tests/Tools.wlt:575,1-581,2"
+    TestID   -> "TestReport-NonexistentFile-GH#65@@Tests/Tools.wlt:753,1-759,2"
 ]
 
 VerificationTest[
@@ -619,7 +763,7 @@ VerificationTest[
     _? (FreeQ[ "AgentTools::Internal" ]),
     { AgentTools::TestFileNotFound },
     SameTest -> MatchQ,
-    TestID   -> "TestReport-NoInternalFailure-GH#65@@Tests/Tools.wlt:583,1-589,2"
+    TestID   -> "TestReport-NoInternalFailure-GH#65@@Tests/Tools.wlt:761,1-767,2"
 ]
 
 VerificationTest[
@@ -632,7 +776,7 @@ VerificationTest[
     _? (FreeQ[ "AgentTools::Internal" ]),
     { AgentTools::TestFileNotFound },
     SameTest -> MatchQ,
-    TestID   -> "TestReport-MixedValidInvalidPaths-GH#65@@Tests/Tools.wlt:591,1-602,2"
+    TestID   -> "TestReport-MixedValidInvalidPaths-GH#65@@Tests/Tools.wlt:769,1-780,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -649,7 +793,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "ToolProperties-AllHaveNames@@Tests/Tools.wlt:611,1-619,2"
+    TestID   -> "ToolProperties-AllHaveNames@@Tests/Tools.wlt:789,1-797,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -662,7 +806,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "ToolProperties-AllHaveDescriptions@@Tests/Tools.wlt:624,1-632,2"
+    TestID   -> "ToolProperties-AllHaveDescriptions@@Tests/Tools.wlt:802,1-810,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -675,5 +819,5 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "ToolProperties-AllHaveParameters@@Tests/Tools.wlt:637,1-645,2"
+    TestID   -> "ToolProperties-AllHaveParameters@@Tests/Tools.wlt:815,1-823,2"
 ]

--- a/Tests/Utilities.wlt
+++ b/Tests/Utilities.wlt
@@ -361,4 +361,97 @@ VerificationTest[
     TestID   -> "ToJSRegex-NoLiteralDelimiters@@Tests/Utilities.wlt:357,1-362,2"
 ]
 
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*LLMKit Usage Limits*)
+
+(* A representative Failure of the kind RelatedWolframAlphaResults / RelatedDocumentation return when the
+   user has exhausted their monthly LLMKit credit allotment (HTTP 429). *)
+$usageLimitFailure = Failure[ "APIError", <|
+    "MessageTemplate"   -> "The service returned the following error message: `1`.",
+    "MessageParameters" -> { "credits-per-month-limit-exceeded - User has exceeded credits limit." },
+    "StatusCode"        -> 429,
+    "Body"              -> <|
+        "success" -> False,
+        "error"   -> <|
+            "code"    -> "credits-per-month-limit-exceeded",
+            "message" -> "credits-per-month-limit-exceeded - User has exceeded credits limit."
+        |>
+    |>
+|> ];
+
+(* The same failure as it appears after ConfirmBy has wrapped it, to confirm detection survives nesting. *)
+$wrappedUsageLimitFailure = Enclose[
+    ConfirmBy[ $usageLimitFailure, StringQ, "Prompt" ],
+    ( # & )
+];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*llmKitUsageLimitFailureQ*)
+VerificationTest[
+    Wolfram`AgentTools`Common`llmKitUsageLimitFailureQ[ $usageLimitFailure ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "LLMKitUsageLimitFailureQ-APIError@@Tests/Utilities.wlt:392,1-397,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`llmKitUsageLimitFailureQ[ $wrappedUsageLimitFailure ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "LLMKitUsageLimitFailureQ-Wrapped@@Tests/Utilities.wlt:399,1-404,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`llmKitUsageLimitFailureQ[ "A normal documentation result." ],
+    False,
+    SameTest -> SameQ,
+    TestID   -> "LLMKitUsageLimitFailureQ-PlainString@@Tests/Utilities.wlt:406,1-411,2"
+]
+
+(* An unrelated API failure must NOT be treated as a usage-limit failure (it should remain an internal failure). *)
+VerificationTest[
+    Wolfram`AgentTools`Common`llmKitUsageLimitFailureQ[
+        Failure[ "APIError", <| "StatusCode" -> 500, "Body" -> "Internal Server Error" |> ]
+    ],
+    False,
+    SameTest -> SameQ,
+    TestID   -> "LLMKitUsageLimitFailureQ-UnrelatedFailure@@Tests/Utilities.wlt:414,1-421,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`llmKitUsageLimitFailureQ[ $Failed ],
+    False,
+    SameTest -> SameQ,
+    TestID   -> "LLMKitUsageLimitFailureQ-NonFailure@@Tests/Utilities.wlt:423,1-428,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*llmKitUsageLimitMessage*)
+VerificationTest[
+    Wolfram`AgentTools`Common`llmKitUsageLimitMessage[ $usageLimitFailure ],
+    "credits-per-month-limit-exceeded - User has exceeded credits limit.",
+    SameTest -> SameQ,
+    TestID   -> "LLMKitUsageLimitMessage-ExtractsServiceMessage@@Tests/Utilities.wlt:433,1-438,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`llmKitUsageLimitMessage[ $wrappedUsageLimitFailure ],
+    "credits-per-month-limit-exceeded - User has exceeded credits limit.",
+    SameTest -> SameQ,
+    TestID   -> "LLMKitUsageLimitMessage-ExtractsFromWrapped@@Tests/Utilities.wlt:440,1-445,2"
+]
+
+(* Falls back to a generic message when the service response carries no human-readable message. *)
+VerificationTest[
+    StringQ @ Wolfram`AgentTools`Common`llmKitUsageLimitMessage[
+        Failure[ "APIError", <| "StatusCode" -> 429 |> ]
+    ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "LLMKitUsageLimitMessage-FallbackString@@Tests/Utilities.wlt:448,1-455,2"
+]
+
 (* :!CodeAnalysis::EndBlock:: *)


### PR DESCRIPTION
## Summary

When a user has exceeded their LLMKit credit allotment, the Wolfram context tools surfaced an opaque **internal failure** (an "unexpected error" with a bug-report link) instead of a useful message. Reported by QA (report `476593`).

**Root cause:** `RelatedWolframAlphaResults` / `RelatedDocumentation` return a `Failure["APIError", ...]` (HTTP `429`, error code `credits-per-month-limit-exceeded`) when the limit is hit. That `Failure` flowed into a `ConfirmBy[..., StringQ]` check in `Kernel/Tools/Context.wl`, which failed and triggered `throwInternalFailure` — so the MCP layer rendered it as a bug report rather than an actionable message.

## Changes

- **`Kernel/Utilities.wl`** — new LLMKit helpers (next to the existing subscription checks):
  - `llmKitUsageLimitFailureQ` — detects the over-limit `Failure` via a `429` status code or a credit/quota/limit error code. Searches the whole expression, so it works whether the failure is raw or wrapped (e.g. by `ConfirmBy`). Returns `False` for non-failures, so successful string results are never misclassified, and unrelated failures (e.g. HTTP 500) still become internal failures as before.
  - `llmKitUsageLimitMessage` — extracts the service's own message, with a generic fallback.
- **`Kernel/Tools/Context.wl`** — `relatedWolframAlphaResults`, `relatedDocumentation`, and the combined `WolframContext` tool now return a clear, actionable message (new message templates) instead of throwing, matching the existing graceful-degradation pattern used for missing subscriptions / no cloud connection. The Wolfram|Alpha path threads the caller's message level (`Error` standalone, `Warning` from the combined tool).
- **`Kernel/CommonSymbols.wl`** — declares the two new shared symbols.
- **Tests** — unit tests for the detection helpers (`Tests/Utilities.wlt`) and integration tests that mock the Chatbook calls to exercise the over-limit path without a live service (`Tests/Tools.wlt`), plus a normal-result regression guard.

No tool schemas changed, so no agent-skill rebuild is required.

## Example result

Before: opaque internal failure + bug-report link.

After (Wolfram|Alpha, standalone):
> Error: Unable to generate Wolfram|Alpha context because the LLMKit usage limit has been exceeded. Inform the user that they have exceeded their LLMKit usage limit. The service returned the following message: credits-per-month-limit-exceeded - User has exceeded credits limit.

## Test plan

- [x] Validated the detection/extraction logic against the **actual** failure object from the QA report (raw `APIError`, fully-wrapped `ConfirmationFailed`, plain strings, and an unrelated HTTP 500 failure).
- [x] `Tests/Utilities.wlt` — 54/54 pass (incl. 8 new helper tests).
- [x] `Tests/Tools.wlt` — 72/72 pass (incl. 10 new over-limit/regression tests; existing Context tests still pass).
- [x] CodeInspector clean on all changed files.

## Related issue

No GitHub issue — originated from internal QA report `476593`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcfopHuJr11z3Hcyqe2CLa