### PR TITLE
Add LM Studio MCP client support; document rejected clients

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
 	},
 	"metadata":{
 		"description":"A collection of Wolfram agent skills",
-		"version":"2.1.24"
+		"version":"2.1.28"
 	},
 	"plugins":[
 		{

--- a/AgentSkills/References/SetUpWolframMCPServer.md
+++ b/AgentSkills/References/SetUpWolframMCPServer.md
@@ -44,6 +44,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
 | Junie | `"Junie"` |
+| LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/AgentSkills/Skills/wolfram-alpha/SKILL.md
+++ b/AgentSkills/Skills/wolfram-alpha/SKILL.md
@@ -4,7 +4,7 @@ description: Queries Wolfram|Alpha for up-to-date computational results and retr
 compatibility: Requires the Wolfram MCP server or wolframscript on PATH
 metadata:
   author: Wolfram Research
-  version: 2.1.24
+  version: 2.1.28
 ---
 
 # Wolfram|Alpha

--- a/AgentSkills/Skills/wolfram-alpha/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-alpha/references/SetUpWolframMCPServer.md
@@ -39,10 +39,12 @@ Replace `<ClientName>` with one of the supported clients:
 | Claude Desktop | `"ClaudeDesktop"` |
 | Cline | `"Cline"` |
 | Codex CLI | `"Codex"` |
+| Continue | `"Continue"` |
 | Copilot CLI | `"CopilotCLI"` |
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
 | Junie | `"Junie"` |
+| LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/AgentSkills/Skills/wolfram-language/SKILL.md
+++ b/AgentSkills/Skills/wolfram-language/SKILL.md
@@ -4,7 +4,7 @@ description: Evaluates Wolfram Language code, searches documentation, inspects c
 compatibility: Requires the Wolfram MCP server or wolframscript on PATH
 metadata:
   author: Wolfram Research
-  version: 2.1.24
+  version: 2.1.28
 ---
 
 # Wolfram Language

--- a/AgentSkills/Skills/wolfram-language/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-language/references/SetUpWolframMCPServer.md
@@ -39,10 +39,12 @@ Replace `<ClientName>` with one of the supported clients:
 | Claude Desktop | `"ClaudeDesktop"` |
 | Cline | `"Cline"` |
 | Codex CLI | `"Codex"` |
+| Continue | `"Continue"` |
 | Copilot CLI | `"CopilotCLI"` |
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
 | Junie | `"Junie"` |
+| LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/AgentSkills/Skills/wolfram-notebooks/SKILL.md
+++ b/AgentSkills/Skills/wolfram-notebooks/SKILL.md
@@ -4,7 +4,7 @@ description: Reads and writes Wolfram notebook (.nb) files. Use this skill when 
 compatibility: Requires the Wolfram MCP server or wolframscript on PATH
 metadata:
   author: Wolfram Research
-  version: 2.1.24
+  version: 2.1.28
 ---
 
 # Wolfram Notebooks

--- a/AgentSkills/Skills/wolfram-notebooks/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-notebooks/references/SetUpWolframMCPServer.md
@@ -39,10 +39,12 @@ Replace `<ClientName>` with one of the supported clients:
 | Claude Desktop | `"ClaudeDesktop"` |
 | Cline | `"Cline"` |
 | Codex CLI | `"Codex"` |
+| Continue | `"Continue"` |
 | Copilot CLI | `"CopilotCLI"` |
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
 | Junie | `"Junie"` |
+| LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/AgentSkills/Skills/wolfram-paclets/SKILL.md
+++ b/AgentSkills/Skills/wolfram-paclets/SKILL.md
@@ -4,7 +4,7 @@ description: Checks, builds, and submits Wolfram Language paclets. Use this skil
 compatibility: Requires the Wolfram MCP server or wolframscript on PATH
 metadata:
   author: Wolfram Research
-  version: 2.1.24
+  version: 2.1.28
 ---
 
 # Wolfram Paclets

--- a/AgentSkills/Skills/wolfram-paclets/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-paclets/references/SetUpWolframMCPServer.md
@@ -39,10 +39,12 @@ Replace `<ClientName>` with one of the supported clients:
 | Claude Desktop | `"ClaudeDesktop"` |
 | Cline | `"Cline"` |
 | Codex CLI | `"Codex"` |
+| Continue | `"Continue"` |
 | Copilot CLI | `"CopilotCLI"` |
 | Cursor | `"Cursor"` |
 | Gemini CLI | `"GeminiCLI"` |
 | Junie | `"Junie"` |
+| LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |

--- a/Kernel/InstallMCPServer.wl
+++ b/Kernel/InstallMCPServer.wl
@@ -625,6 +625,7 @@ guessClientName[ file_? fileQ ] := Enclose[
             { __, ".junie", "mcp", "mcp.json" }, Throw[ "Junie" ],
             { __, ".continue", "config.yaml" }, Throw[ "Continue" ],
             { __, ".continue", "mcpservers", _ }, Throw[ "Continue" ],
+            { __, ".lmstudio", "mcp.json" }, Throw[ "LMStudio" ],
             { __, "augment.vscode-augment", "augment-global-state", "mcpservers.json" }, Throw[ "AugmentCodeIDE" ]
         ];
 

--- a/Kernel/SupportedClients.wl
+++ b/Kernel/SupportedClients.wl
@@ -192,6 +192,15 @@ $supportedMCPClients = <|
         "ProjectPath"     -> { ".kiro", "settings", "mcp.json" },
         "InstallLocation" :> { $HomeDirectory, ".kiro", "settings", "mcp.json" }
     |>,
+    "LMStudio" -> <|
+        "DisplayName"     -> "LM Studio",
+        "DefaultToolset"  -> "Wolfram",
+        "Aliases"         -> { },
+        "ConfigFormat"    -> "JSON",
+        "ConfigKey"       -> { "mcpServers" },
+        "URL"             -> "https://lmstudio.ai",
+        "InstallLocation" :> { $HomeDirectory, ".lmstudio", "mcp.json" }
+    |>,
     "OpenCode" -> <|
         "DisplayName"     -> "OpenCode",
         "DefaultToolset"  -> "WolframLanguage",

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ AgentTools can be installed into the following MCP client applications:
 | [Goose](https://block.github.io/goose/) | `"Goose"` | No |
 | [Google Antigravity](https://antigravity.google) | `"Antigravity"` | No |
 | [Junie](https://www.jetbrains.com/junie/) (JetBrains IDE plugin + CLI) | `"Junie"` | Yes |
+| [LM Studio](https://lmstudio.ai) | `"LMStudio"` | No |
 | [OpenAI Codex](https://openai.com/codex) | `"Codex"` | Yes |
 | [OpenCode](https://opencode.ai) | `"OpenCode"` | Yes |
 | [Visual Studio Code](https://code.visualstudio.com) | `"VisualStudioCode"` | Yes |

--- a/TODO/more-mcp-clients.md
+++ b/TODO/more-mcp-clients.md
@@ -66,3 +66,42 @@ Continue uses a YAML config file (`~/.continue/config.yaml`) with `mcpServers` a
 
 - [x] Research how MCP servers are added to Continue and write a detailed report in [continue.md](../client-research/continue.md) (revised May 2026 to use native YAML)
 - [x] Implement support for `InstallMCPServer["Continue", ...]` — writes into `~/.continue/config.yaml` (global) and `.continue/mcpServers/wolfram.yaml` (project), reusing the Goose YAML pattern and the AugmentCodeIDE name-based upsert pattern. Covers all three Continue distributions — VS Code extension, JetBrains plugin, and the `cn` CLI (`npm i -g @continuedev/cli`) — because they all read the same config files.
+
+### [LM Studio](https://lmstudio.ai/)
+
+LM Studio is a cross-platform (macOS / Windows / Linux) desktop app for running local LLMs that doubles as an MCP client. It uses a single file-based config at `~/.lmstudio/mcp.json` (`%USERPROFILE%\.lmstudio\mcp.json` on Windows) and explicitly "follows Cursor's `mcp.json` notation" — a top-level `mcpServers` object keyed by name with the standard `command`/`args`/`env` fields. It supports both local stdio and remote MCP servers, has no project scope, and needs no custom `ServerConverter`. This makes it one of the easiest clients to add — effectively a clone of the `Cursor` entry with a different path. See [lmstudio.md](../client-research/lmstudio.md) for the full plan. Fully testable on Windows (a Windows build exists).
+
+- [x] Research how MCP servers are added to LM Studio and write a detailed report in [lmstudio.md](../client-research/lmstudio.md)
+- [x] Implement support for `InstallMCPServer["LMStudio", ...]` — `$supportedMCPClients` entry pointing at `~/.lmstudio/mcp.json` (standard `mcpServers` JSON, no converter, no project scope, default toolset `"Wolfram"`), `guessClientName` path pattern, tests, and docs rows
+
+## Rejected / Not Feasible
+
+These clients were researched and rejected for `InstallMCPServer` support. The common blocker is the same as Cherry Studio: no documented, stable, external configuration file to write to (configuration lives in an in-app UI, an internal database, or hosted state). For each, the manual workaround remains available to users on supported platforms — generate `MCPServerObject["Wolfram"]["JSONConfiguration"]` (or the relevant server) and add it through the client's own UI.
+
+### [Dify](https://dify.ai/)
+
+Web-based LLM-app platform. MCP servers are added entirely through the web UI (Tools → MCP → Add MCP Server (HTTP)), stored in Dify's backend, and only **HTTP** transport is supported (no stdio). There is no on-disk config file, and Dify runs as a hosted/self-hosted web service rather than a local app, so `InstallMCPServer` has nothing to target.
+
+- [x] Research how MCP servers are added to Dify
+- [x] Reject support for `InstallMCPServer["Dify", ...]` — web UI / backend storage, HTTP-only, no local config file
+
+### [RecurseChat](https://recurse.chat/)
+
+Mac App Store app, **Apple-Silicon-only** (macOS Ventura 13.5+, no Intel, no Windows/Linux). MCP servers are configured through the in-app UI ("New Model → New MCP Model → import MCP Server JSON Config"); there is no documented on-disk config file. Cannot be hands-on tested without an Apple Silicon Mac, and there is no config file to write to regardless.
+
+- [x] Research how MCP servers are added to RecurseChat and write a detailed report in [recurse-chat.md](../client-research/recurse-chat.md)
+- [x] Reject support for `InstallMCPServer["RecurseChat", ...]` — in-app UI only, no config file, Mac-only
+
+### [Msty Studio](https://msty.ai/)
+
+Cross-platform desktop app (Windows / macOS / Linux) with MCP support for both stdio and streamable-HTTP. However, MCP servers are configured through the in-app "Add New Tool" UI with inline per-tool JSON (not a `mcpServers`-keyed object), and there is no documented on-disk config file. Testable on Windows, but `InstallMCPServer` has no documented file to target. If a stable config file is later confirmed under `%APPDATA%\Msty`, this could be revisited.
+
+- [x] Research how MCP servers are added to Msty Studio and write a detailed report in [msty.md](../client-research/msty.md)
+- [x] Reject support for `InstallMCPServer["Msty", ...]` — in-app UI only, no documented config file (revisit if one is found)
+
+### [5ire](https://5ire.app/)
+
+Open-source desktop AI assistant / MCP client. Supports both stdio and remote MCP servers, but stores configuration in an internal **pglite** database (migrated from SQLite + LanceDB), managed through the in-app UI — there is no external config file. Additionally, the latest release ships only macOS and Linux binaries (no Windows installer), so it is not hands-on testable on Windows without building from source. Same blocker as Cherry Studio.
+
+- [x] Research how MCP servers are added to 5ire and write a detailed report in [5ire.md](../client-research/5ire.md)
+- [x] Reject support for `InstallMCPServer["5ire", ...]` — internal pglite database, no external config file

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -3318,6 +3318,234 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
+(*LM Studio Support*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Install Location for LM Studio*)
+VerificationTest[
+    Wolfram`AgentTools`Common`installLocation[ "LMStudio", "Windows" ],
+    _File,
+    SameTest -> MatchQ,
+    TestID   -> "InstallLocation-LMStudio-Windows"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`installLocation[ "LMStudio", "MacOSX" ],
+    _File,
+    SameTest -> MatchQ,
+    TestID   -> "InstallLocation-LMStudio-MacOSX"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`installLocation[ "LMStudio", "Unix" ],
+    _File,
+    SameTest -> MatchQ,
+    TestID   -> "InstallLocation-LMStudio-Unix"
+]
+
+(* LM Studio's path is .lmstudio/mcp.json under $HomeDirectory on every OS *)
+VerificationTest[
+    Module[ { file, split },
+        file = Wolfram`AgentTools`Common`installLocation[ "LMStudio", $OperatingSystem ];
+        split = FileNameSplit @ First @ file;
+        Take[ split, -2 ]
+    ],
+    { ".lmstudio", "mcp.json" },
+    SameTest -> Equal,
+    TestID   -> "InstallLocation-LMStudio-PathShape"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Name Normalization*)
+VerificationTest[
+    Wolfram`AgentTools`Common`toInstallName[ "LMStudio" ],
+    "LMStudio",
+    SameTest -> Equal,
+    TestID   -> "ToInstallName-LMStudio"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "LMStudio" ],
+    "LM Studio",
+    SameTest -> Equal,
+    TestID   -> "InstallDisplayName-LMStudio"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*LM Studio Install and Uninstall*)
+VerificationTest[
+    lmStudioConfigFile = testConfigFile[];
+    installResult = InstallMCPServer[ lmStudioConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "LMStudio" ],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-LMStudio-Basic"
+]
+
+VerificationTest[
+    FileExistsQ[ lmStudioConfigFile ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-LMStudio-FileExists"
+]
+
+VerificationTest[
+    Module[ { content },
+        content = Import[ lmStudioConfigFile, "RawJSON" ];
+        KeyExistsQ[ content, "mcpServers" ] && KeyExistsQ[ content[ "mcpServers" ], "Wolfram" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-LMStudio-VerifyContent"
+]
+
+(* LM Studio uses the standard mcpServers format (Cursor notation): no Cline-style
+   disabled/autoApprove fields, no Copilot-style tools field, no OpenCode-style top-level "mcp" key *)
+VerificationTest[
+    Module[ { content, server },
+        content = Import[ lmStudioConfigFile, "RawJSON" ];
+        server = content[ "mcpServers", "Wolfram" ];
+        AssociationQ @ server &&
+        KeyExistsQ[ server, "command" ] &&
+        ! KeyExistsQ[ server, "disabled" ] &&
+        ! KeyExistsQ[ server, "autoApprove" ] &&
+        ! KeyExistsQ[ server, "tools" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-LMStudio-StandardFormat"
+]
+
+VerificationTest[
+    uninstallResult = UninstallMCPServer[ lmStudioConfigFile, "WolframLanguage", "ApplicationName" -> "LMStudio" ],
+    _Success,
+    SameTest -> MatchQ,
+    TestID   -> "UninstallMCPServer-LMStudio-Basic"
+]
+
+VerificationTest[
+    Module[ { content },
+        content = Import[ lmStudioConfigFile, "RawJSON" ];
+        KeyExistsQ[ content, "mcpServers" ] && ! KeyExistsQ[ content[ "mcpServers" ], "Wolfram" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "UninstallMCPServer-LMStudio-VerifyRemoval"
+]
+
+VerificationTest[
+    cleanupTestFiles[ lmStudioConfigFile ],
+    { Null },
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-LMStudio-Cleanup"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*LM Studio Preserves Existing Config*)
+
+(* The mcp.json may contain other servers and unrelated keys; install must preserve them *)
+VerificationTest[
+    lmStudioPreserveFile = testConfigFile[];
+    Export[ lmStudioPreserveFile, <| "mcpServers" -> <| "ExistingServer" -> <| "command" -> "foo" |> |> |>, "JSON" ];
+    InstallMCPServer[ lmStudioPreserveFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "LMStudio" ];
+    Module[ { content },
+        content = Import[ lmStudioPreserveFile, "RawJSON" ];
+        KeyExistsQ[ content[ "mcpServers" ], "ExistingServer" ] &&
+        KeyExistsQ[ content[ "mcpServers" ], "Wolfram" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "InstallMCPServer-LMStudio-PreserveExisting"
+]
+
+VerificationTest[
+    cleanupTestFiles[ lmStudioPreserveFile ],
+    { Null },
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-LMStudio-PreserveExisting-Cleanup"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Auto-Detection from Path*)
+
+(* File at .lmstudio/mcp.json is auto-detected as LMStudio when installing without ApplicationName *)
+VerificationTest[
+    Module[ { dir, file, content },
+        dir = FileNameJoin @ { $TemporaryDirectory, "lmstudio_auto_" <> CreateUUID[], ".lmstudio" };
+        CreateDirectory[ dir, CreateIntermediateDirectories -> True ];
+        file = FileNameJoin @ { dir, "mcp.json" };
+        WithCleanup[
+            InstallMCPServer[ File @ file, "WolframLanguage", "VerifyLLMKit" -> False ];
+            content = Import[ file, "RawJSON" ],
+            Quiet @ DeleteDirectory[ DirectoryName @ dir, DeleteContents -> True ]
+        ];
+        AssociationQ @ content && KeyExistsQ[ content, "mcpServers" ] && KeyExistsQ[ content[ "mcpServers" ], "Wolfram" ]
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "GuessClientName-LMStudio-PathMatch"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*$SupportedMCPClients metadata for LM Studio*)
+VerificationTest[
+    $SupportedMCPClients[ "LMStudio", "DisplayName" ],
+    "LM Studio",
+    SameTest -> Equal,
+    TestID   -> "SupportedMCPClients-LMStudioDisplayName"
+]
+
+VerificationTest[
+    $SupportedMCPClients[ "LMStudio", "ConfigFormat" ],
+    "JSON",
+    SameTest -> Equal,
+    TestID   -> "SupportedMCPClients-LMStudioConfigFormat"
+]
+
+VerificationTest[
+    $SupportedMCPClients[ "LMStudio", "ConfigKey" ],
+    { "mcpServers" },
+    SameTest -> Equal,
+    TestID   -> "SupportedMCPClients-LMStudioConfigKey"
+]
+
+VerificationTest[
+    $SupportedMCPClients[ "LMStudio", "ProjectSupport" ],
+    False,
+    SameTest -> Equal,
+    TestID   -> "SupportedMCPClients-LMStudioProjectSupport"
+]
+
+(* LM Studio is a chat-first client, so its default toolset is "Wolfram" (like Claude Desktop / Goose) *)
+VerificationTest[
+    $SupportedMCPClients[ "LMStudio", "DefaultToolset" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "SupportedMCPClients-LMStudioDefaultToolset"
+]
+
+VerificationTest[
+    StringStartsQ[ $SupportedMCPClients[ "LMStudio", "URL" ], "https://" ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "SupportedMCPClients-LMStudioURL"
+]
+
+(* Confirm the chat-client default flows through defaultToolsetForTarget *)
+VerificationTest[
+    Wolfram`AgentTools`Common`defaultToolsetForTarget[ "LMStudio" ],
+    "Wolfram",
+    SameTest -> Equal,
+    TestID   -> "DefaultToolsetForTarget-LMStudio"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
 (*Amazon Q Developer Support*)
 
 (* ::**************************************************************************************************************:: *)
@@ -3530,14 +3758,14 @@ VerificationTest[
 
 VerificationTest[
     Length @ $SupportedMCPClients,
-    19,
+    20,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-Has19Clients@@Tests/InstallMCPServer.wlt:2991,1-2996,2"
+    TestID   -> "SupportedMCPClients-Has20Clients@@Tests/InstallMCPServer.wlt:2991,1-2996,2"
 ]
 
 VerificationTest[
     Keys @ $SupportedMCPClients,
-    { "AmazonQ", "Antigravity", "AugmentCode", "AugmentCodeIDE", "ClaudeCode", "ClaudeDesktop", "Cline", "Codex", "Continue", "CopilotCLI", "Cursor", "GeminiCLI", "Goose", "Junie", "Kiro", "OpenCode", "VisualStudioCode", "Windsurf", "Zed" },
+    { "AmazonQ", "Antigravity", "AugmentCode", "AugmentCodeIDE", "ClaudeCode", "ClaudeDesktop", "Cline", "Codex", "Continue", "CopilotCLI", "Cursor", "GeminiCLI", "Goose", "Junie", "Kiro", "LMStudio", "OpenCode", "VisualStudioCode", "Windsurf", "Zed" },
     SameTest -> Equal,
     TestID   -> "SupportedMCPClients-KeysSorted@@Tests/InstallMCPServer.wlt:3074,1-3079,2"
 ]

--- a/client-research/5ire.md
+++ b/client-research/5ire.md
@@ -1,0 +1,63 @@
+# 5ire MCP Client Research
+
+## Overview
+
+[5ire](https://5ire.app/) is an open-source ([github.com/nanbingxyz/5ire](https://github.com/nanbingxyz/5ire)) cross-platform desktop AI assistant and MCP client. It supports chatting with major providers plus a local knowledge base and tools via MCP servers.
+
+## Key Findings
+
+### Configuration: internal database (pglite), no external config file
+
+5ire stores its configuration — including MCP server definitions — in an **internal database**. The storage engine was migrated from SQLite + LanceDB to **pglite** (Postgres compiled to WASM). MCP servers are added through the in-app UI (Tools → New/Local for stdio, or remote), and 5ire writes the configuration into its own database; "5ire will create configuration on its own."
+
+There is no documented external, user-editable config file (no `mcp.json`-style file) that `InstallMCPServer` could write to.
+
+### Server configuration shape
+
+A valid 5ire server entry requires a `name` (letters/hyphens/numbers, length > 1, not starting with a number or ending with a hyphen) and either a `url` (remote) or a `command` (local stdio), with optional `args`, `env`, and `headers`. Example stdio entry:
+
+```json
+{
+  "name": "Blender",
+  "description": "A Blender MCP server …",
+  "command": "uvx",
+  "args": ["blender-mcp"]
+}
+```
+
+This is a per-server object, not a `mcpServers`-keyed object, and it is entered through the UI rather than a file.
+
+### Transport
+
+Both local **stdio** (`command`/`args`/`env`) and **remote** (`url`/`headers`) are supported, so the Wolfram stdio server is transport-compatible.
+
+### Platform: no Windows prebuilt binary
+
+Although the README calls 5ire "cross-platform," the latest release (v0.15.4) ships installers only for:
+
+- **macOS** (`.dmg`, `.zip` — arm64 and x86_64)
+- **Linux** (`.AppImage` — x86_64)
+
+There is **no Windows `.exe`/`.msi`** in the release assets. Running it on Windows would require building from source (Node/TypeScript), so it is not realistically hands-on testable on Windows.
+
+## Why InstallMCPServer Cannot Be Implemented
+
+Two independent blockers, either of which is disqualifying:
+
+1. **No external config file.** Configuration lives in an internal pglite database managed by the app — the same architectural blocker as [Cherry Studio](cherry-studio.md). `InstallMCPServer` has nothing to write to, and writing into the app's database is not a supported or stable integration point.
+2. **No Windows build.** The integration cannot be developed or hands-on tested on Windows without building from source.
+
+## Recommendation
+
+**Reject support for `InstallMCPServer["5ire", ...]`** because the configuration is stored in an internal database with no external config file, and there is no Windows binary for testing.
+
+### Manual workaround (Mac/Linux users)
+
+Add the Wolfram server through 5ire's UI (Tools → New/Local) using `command` = the Wolfram executable path and the appropriate `args`/`env`, which can be read off `MCPServerObject["Wolfram"]["JSONConfiguration"]`.
+
+## References
+
+- [5ire docs](https://5ire.app/docs)
+- [5ire GitHub repository](https://github.com/nanbingxyz/5ire)
+- [5ire releases (platform binaries)](https://github.com/nanbingxyz/5ire/releases)
+- [Tools & MCP Servers — DeepWiki](https://deepwiki.com/nanbingxyz/5ire/5-tools-and-mcp-servers)

--- a/client-research/lmstudio.md
+++ b/client-research/lmstudio.md
@@ -1,0 +1,136 @@
+# LM Studio MCP Client Research
+
+## Overview
+
+[LM Studio](https://lmstudio.ai/) is a cross-platform desktop application for discovering, downloading, and running local LLMs, with a built-in chat interface. Since v0.3.17 it also acts as an **MCP client**, letting the local model call tools exposed by MCP servers.
+
+MCP support is file-based and standards-compliant, which makes LM Studio one of the easiest clients to add to AgentTools — effectively a clone of the existing `Cursor` entry with a different path.
+
+## Configuration Details
+
+### Config file location
+
+LM Studio uses a single global config file named `mcp.json`:
+
+| Platform | Path |
+|----------|------|
+| macOS / Linux | `~/.lmstudio/mcp.json` |
+| Windows | `%USERPROFILE%\.lmstudio\mcp.json` |
+
+The same relative path under the home directory on every OS, exactly like Cursor, Claude Code, Kiro, and Junie — so a single delayed `InstallLocation` suffices, with no per-OS branching.
+
+The in-app editor (Program tab → Install → Edit `mcp.json`) opens and writes this same file, so hand-editing it and editing it through the UI are equivalent.
+
+> **Known macOS quirk (testing only):** there is an [open bug](https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/1371) where a *copy* of `mcp.json` also appears under `~/.cache/lm-studio/mcp.json` on macOS. The primary/correct location is `~/.lmstudio/mcp.json` (what we target). Not relevant to Windows; worth a docs note so Mac users don't edit the stray copy.
+
+### JSON format
+
+LM Studio "**follows Cursor's `mcp.json` notation**" — a top-level **`mcpServers`** object keyed by server name, the de-facto standard shared by Claude Desktop, Cursor, Cline, Windsurf, Kiro, and Junie. This is exactly the shape `MCPServerObject["…"]["JSONConfiguration"]` already produces, so **no `ServerConverter` is needed.**
+
+Local (stdio) server entry:
+
+```json
+{
+  "mcpServers": {
+    "Wolfram": {
+      "command": "wolfram",
+      "args": [
+        "-run",
+        "PacletSymbol[\"Wolfram/AgentTools\",\"Wolfram`AgentTools`StartMCPServer\"][]",
+        "-noinit",
+        "-noprompt"
+      ],
+      "env": {
+        "MCP_SERVER_NAME": "WolframLanguage"
+      }
+    }
+  }
+}
+```
+
+Remote server entries use `url` (and an optional `auth`/`headers` object) instead of `command`. LM Studio infers the transport from which fields are present.
+
+### Transport types
+
+LM Studio "supports both local and remote MCP servers" — local **stdio** (via `command`/`args`/`env`) and **remote** (via `url`). The Wolfram MCP server is stdio, which is fully supported.
+
+### Configuration scope
+
+| Scope | Support |
+|-------|---------|
+| Global | Yes (`~/.lmstudio/mcp.json`, single file) |
+| Project | **No** — there is no documented project/workspace-level MCP config |
+
+### Platforms
+
+LM Studio ships desktop builds for **macOS, Windows, and Linux**. A Windows build exists, so the integration is fully hands-on testable on a Windows machine (no Mac required).
+
+## Mapping to AgentTools
+
+### Central definition
+
+Add one entry to `$supportedMCPClients` in [`Kernel/SupportedClients.wl`](../Kernel/SupportedClients.wl). The file is a plain `mcpServers` JSON object, so the standard (non-Codex, non-Goose, non-AugmentCodeIDE, non-Continue) install/uninstall code path handles it with no special overload.
+
+### Proposed `$supportedMCPClients` entry
+
+| Field | Suggested value |
+|-------|------------------|
+| Canonical name   | `"LMStudio"` |
+| Display name     | `"LM Studio"` |
+| `DefaultToolset` | `"Wolfram"` — LM Studio is a chat client for local LLMs, so it follows the chat-client convention (like Claude Desktop and Goose) rather than the coding-client default of `"WolframLanguage"`. **Confirm with maintainer**; debatable. |
+| Aliases          | `{ }` |
+| `ConfigFormat`   | `"JSON"` |
+| `ConfigKey`      | `{ "mcpServers" }` |
+| `URL`            | `"https://lmstudio.ai"` |
+| `InstallLocation`| `:> { $HomeDirectory, ".lmstudio", "mcp.json" }` (single delayed path — same on every OS) |
+| `ProjectPath`    | *None* — no project scope |
+| `ServerConverter`| *None* — Cursor-style notation is valid as-is |
+
+### Other code to update for a full implementation
+
+1. **`guessClientName`** in [`Kernel/InstallMCPServer.wl`](../Kernel/InstallMCPServer.wl): add a `FileNameSplit` tail case for `{ __, ".lmstudio", "mcp.json" }` → `"LMStudio"`, alongside the existing Kiro / Junie / Augment cases. Path-based matching is the right approach because the standard `mcpServers` + `command`/`args`/`env` content is otherwise indistinguishable from Claude Desktop.
+2. **Tests** ([`Tests/InstallMCPServer.wlt`](../Tests/InstallMCPServer.wlt)): follow the Cursor / Junie pattern — `installLocation` per OS, path-shape check (`{".lmstudio", "mcp.json"}`), `toInstallName`, `installDisplayName`, install/uninstall round-trip, standard-format check (no Cline `disabled`/`autoApprove`, no Copilot `tools`), path-based auto-detection, `$SupportedMCPClients` metadata, and the supported-client count bump + sorted-keys update.
+3. **Docs** ([`docs/mcp-clients.md`](../docs/mcp-clients.md)): table row + a short "LM Studio" section with the path table and the macOS stray-copy note.
+4. **README.md**: supported-clients table row.
+5. **AgentSkills** ([`AgentSkills/References/SetUpWolframMCPServer.md`](../AgentSkills/References/SetUpWolframMCPServer.md)): add a row to the **source** reference file only, then run `Scripts/BuildAgentSkills.wls` to regenerate the four `AgentSkills/Skills/*/references/` copies — do **not** edit the generated copies by hand.
+6. **`TODO/more-mcp-clients.md`**: mark the implementation checkbox done.
+
+No changes to `PacletInfo.wl` or `Kernel/Main.wl` are required.
+
+## Implementation Assessment
+
+### Feasibility: **Fully feasible — one of the easiest clients to add**
+
+1. **Documented, file-based JSON** at a stable home-directory path on every OS.
+2. **Standard `mcpServers` notation** ("follows Cursor's `mcp.json`") — identical to the shape we already emit, so **no converter, no dedicated install overload**.
+3. **stdio supported** — the Wolfram MCP server works as-is.
+4. **Single OS-portable path** — no per-OS branching, no `Library/Application Support`, no `%APPDATA%` segment.
+5. **Cross-platform with a Windows build** — fully testable on Windows, no Mac needed.
+
+It is strictly simpler than Junie (no project scope) and far simpler than Continue (no YAML, no array shape) or AugmentCodeIDE (no root-array format).
+
+### Risks / Verification
+
+- **`guessClientName` collisions:** LM Studio's `mcp.json` content is indistinguishable from Cursor/Claude Desktop, so rely on path-based matching via `installLocation` and document `"ApplicationName" -> "LMStudio"` for ad-hoc `File[…]` targets. Mirrors how Kiro/Junie are handled.
+- **macOS stray copy:** the `~/.cache/lm-studio/mcp.json` duplicate (bug #1371) should be mentioned in docs so Mac users edit the right file. We always write the documented `~/.lmstudio/mcp.json`.
+- **Default toolset choice:** `"Wolfram"` (chat-client convention) vs `"WolframLanguage"` (coding-client convention) is a judgment call — LM Studio is chat-first, so `"Wolfram"` is the suggested default, but confirm with the maintainer.
+- **Windows home resolution:** `$HomeDirectory` resolves to `%USERPROFILE%` on Windows, as already relied on for Cursor, Claude Code, Gemini CLI, Codex, Kiro, Copilot CLI, OpenCode, and Junie. No new risk.
+
+### Recommendation
+
+**Implement.** LM Studio is a widely used local-LLM desktop app, its MCP configuration is documented, standards-compliant (Cursor `mcp.json` notation), file-based at a stable path, and stdio-compatible. The implementation is a near-trivial addition to `$supportedMCPClients` plus one `guessClientName` line, tests, and docs — and it is fully verifiable on Windows.
+
+### How to test (Windows)
+
+1. `InstallMCPServer["LMStudio", "WolframLanguage"]` → writes `%USERPROFILE%\.lmstudio\mcp.json`.
+2. Open LM Studio → Program tab (right sidebar) → confirm the Wolfram server appears and connects (stdio), exposing the Wolfram tools.
+3. `UninstallMCPServer["LMStudio", "WolframLanguage"]` → confirm the entry is removed from `mcp.json`.
+
+## References
+
+- [LM Studio — Use MCP Servers](https://lmstudio.ai/docs/app/mcp)
+- [LM Studio — MCP plugin overview](https://lmstudio.ai/docs/app/plugins/mcp)
+- [LM Studio — Remote MCP / auth](https://lmstudio.ai/docs/integrations/mcp-remote)
+- [LM Studio v0.3.17 blog (MCP launch)](https://lmstudio.ai/blog/lmstudio-v0.3.17)
+- [mcp.json path bug tracker issue #1371 (macOS stray copy)](https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/1371)
+- AgentTools precedent: [`Kernel/SupportedClients.wl`](../Kernel/SupportedClients.wl) (Cursor entry — closest analog), [`Kernel/InstallMCPServer.wl`](../Kernel/InstallMCPServer.wl) (`guessClientName` path detection)

--- a/client-research/msty.md
+++ b/client-research/msty.md
@@ -1,0 +1,56 @@
+# Msty Studio MCP Client Research
+
+## Overview
+
+[Msty Studio](https://msty.ai/) is a desktop (and web) AI application for chatting with local and cloud LLMs. The desktop app supports MCP servers via its "Toolbox" feature.
+
+## Key Findings
+
+### Platform: cross-platform (testable on Windows)
+
+Msty Studio Desktop ships prebuilt installers for:
+
+- **Windows** (x64)
+- **macOS** (Apple Silicon M1–M4 and Intel)
+- **Linux** (AppImage and `.deb`)
+
+There is also a "Msty Studio Web" browser version. The Windows build means the manual workflow *is* hands-on testable on a Windows machine — unlike RecurseChat or 5ire.
+
+### Configuration: in-app UI with inline per-tool JSON, no external config file
+
+MCP servers are added through the in-app UI: **Add New Tool** opens a window where the user defines the tool's name, configuration (entered as JSON), and notes. The configuration JSON for a local server uses `command` / `args` / `env`, but it is a **single tool's** configuration entered inline — **not** a `mcpServers`-keyed object like Claude Desktop / Cursor.
+
+The [Toolbox documentation](https://docs.msty.ai/studio/toolbox/tools) does not document any external, user-editable config file path; configuration is managed through the UI and stored internally by the app.
+
+### Transport
+
+Both supported:
+
+- **STDIO / JSON** for local MCP servers and tools
+- **HTTP** for remote (streamable HTTP) MCP servers — the docs note SSE is deprecated in favor of streamable HTTP
+
+So the Wolfram stdio server is transport-compatible.
+
+## Why InstallMCPServer Cannot (Currently) Be Implemented
+
+`InstallMCPServer` writes a known config file at a known path. Msty exposes no documented external config file — MCP tools are added through the "Add New Tool" UI with inline JSON, stored internally. There is also a format mismatch: Msty's tool dialog expects a single tool's `command`/`args`/`env`, whereas `MCPServerObject["Wolfram"]["JSONConfiguration"]` emits a `{"mcpServers": {"Wolfram": {…}}}` wrapper that would need manual extraction.
+
+This is the same blocker as [Cherry Studio](cherry-studio.md): no external configuration file to target.
+
+## Recommendation
+
+**Reject support for `InstallMCPServer["Msty", ...]`** for now, because there is no documented external configuration file to write to.
+
+**Revisit if** a stable, documented config file is later confirmed (e.g. under `%APPDATA%\Msty` on Windows). Because the Windows build is available, this is a quick check for a future contributor: install Msty, add one tool through the UI, and inspect the application-data directory for a human-readable, stable MCP config file. If one exists, Msty becomes implementable and would be treated like any other file-based JSON client.
+
+### Manual workaround
+
+1. Generate the JSON configuration: `MCPServerObject["Wolfram"]["JSONConfiguration"]`
+2. Extract the inner server object's `command` / `args` / `env` (drop the `mcpServers` wrapper).
+3. In Msty: Toolbox → Add New Tool → paste the configuration JSON.
+
+## References
+
+- [Msty Studio — Getting Started](https://docs.msty.ai/studio/getting-started)
+- [Msty Studio — Toolbox / Tools](https://docs.msty.ai/studio/toolbox/tools)
+- [Msty Studio — Download (platform list)](https://docs.msty.ai/studio/getting-started/download)

--- a/client-research/recurse-chat.md
+++ b/client-research/recurse-chat.md
@@ -1,0 +1,47 @@
+# RecurseChat MCP Client Research
+
+## Overview
+
+[RecurseChat](https://recurse.chat/) is a native desktop AI assistant for chatting with local LLMs, Claude, and ChatGPT. It supports MCP as a client.
+
+## Key Findings
+
+### Platform: Apple Silicon Mac only
+
+RecurseChat is distributed exclusively through the **Mac App Store** and requires **Apple Silicon** (M1/M2/M3/M4) on **macOS Ventura 13.5 or later**. It does **not** run on Intel Macs, Windows, or Linux, and the project states no plans to support other operating systems.
+
+This alone makes the integration impossible to develop or hands-on test on a Windows or Linux machine.
+
+### Configuration: in-app UI, no external config file
+
+MCP servers are added through the application UI: **Model Page → New Model → New MCP Model**, where the user can import an "MCP Server JSON Config." Configuration is stored internally by the app; the [MCP documentation](https://recurse.chat/docs/features/mcp/) does not document any external, user-editable config file path.
+
+### Transport
+
+The documentation references an "SSE endpoint" (remote) and does not explicitly document local stdio support. The current Wolfram MCP server is stdio-only.
+
+## Why InstallMCPServer Cannot Be Implemented
+
+`InstallMCPServer` works by writing a known configuration file at a known path that the client reads on startup. RecurseChat provides no such file — MCP servers are added through the in-app UI and stored internally. This is the same blocker as [Cherry Studio](cherry-studio.md): no external configuration file to write to.
+
+The Apple-Silicon-only platform requirement is a secondary blocker: even the manual workflow can only be exercised by users on a recent Apple Silicon Mac.
+
+## Recommendation
+
+**Reject support for `InstallMCPServer["RecurseChat", ...]`** because:
+
+- There is no documented external configuration file to write to (in-app UI / internal storage only).
+- The app is Apple-Silicon-Mac-only, so it cannot be developed or tested on Windows/Linux.
+
+### Manual workaround (Mac users)
+
+Mac users can still connect the Wolfram MCP server manually:
+
+1. Generate the JSON configuration: `MCPServerObject["Wolfram"]["JSONConfiguration"]`
+2. In RecurseChat: Model Page → New Model → New MCP Model → import the JSON config.
+
+## References
+
+- [RecurseChat MCP documentation](https://recurse.chat/docs/features/mcp/)
+- [RecurseChat FAQ (platform requirements)](https://recurse.chat/docs/resources/faq/)
+- [RecurseChat on the Mac App Store](https://apps.apple.com/us/app/recursechat/id6476835702)

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -28,13 +28,14 @@ The following clients have built-in support for automatic configuration via `Ins
 | Antigravity (IDE, desktop + CLI) | `"Antigravity"` | `"GoogleAntigravity"`, `"AntigravityCLI"`, `"GoogleAntigravityCLI"` | JSON | Yes | `"WolframLanguage"` |
 | Junie (IDE + CLI) | `"Junie"` | `"JetBrainsJunie"` | JSON | Yes | `"WolframLanguage"` |
 | Kiro | `"Kiro"` | — | JSON | Yes | `"WolframLanguage"` |
+| LM Studio | `"LMStudio"` | — | JSON | No | `"Wolfram"` |
 | Codex CLI | `"Codex"` | `"OpenAICodex"` | TOML | Yes | `"WolframLanguage"` |
 | OpenCode | `"OpenCode"` | — | JSON | Yes | `"WolframLanguage"` |
 | Visual Studio Code | `"VisualStudioCode"` | `"VSCode"` | JSON | Yes | `"WolframLanguage"` |
 | Windsurf | `"Windsurf"` | `"Codeium"` | JSON | No | `"WolframLanguage"` |
 | Zed | `"Zed"` | — | JSON | Yes | `"WolframLanguage"` |
 
-The **Default Toolset** is the [predefined server](servers.md) used when `InstallMCPServer`/`DeployAgentTools` is called without an explicit server (or with `Automatic`). Coding clients default to `"WolframLanguage"`; chat clients (Claude Desktop, Goose) default to `"Wolfram"`.
+The **Default Toolset** is the [predefined server](servers.md) used when `InstallMCPServer`/`DeployAgentTools` is called without an explicit server (or with `Automatic`). Coding clients default to `"WolframLanguage"`; chat clients (Claude Desktop, Goose, LM Studio) default to `"Wolfram"`.
 
 ## Usage
 
@@ -405,6 +406,21 @@ Junie is JetBrains' AI coding agent. **A single `InstallMCPServer["Junie", ...]`
 ```
 
 Note: Kiro uses the standard `mcpServers` format with optional `disabled` and `autoApprove` fields. `InstallMCPServer` automatically adds these defaults.
+
+### LM Studio
+
+| OS | Config Location |
+|----|----------------|
+| macOS | `~/.lmstudio/mcp.json` |
+| Windows | `%USERPROFILE%\.lmstudio\mcp.json` |
+| Linux | `~/.lmstudio/mcp.json` |
+
+**Format:** Same as Claude Desktop (`mcpServers` key). LM Studio "follows Cursor's `mcp.json` notation," so the standard `command`/`args`/`env` server entry works as-is — no client-specific fields are added.
+
+Notes:
+- LM Studio is a cross-platform (macOS/Windows/Linux) desktop app for running local LLMs that also acts as an MCP client. The same `mcp.json` is used on every OS, under `~/.lmstudio/`. The in-app editor (Program tab → Install → Edit `mcp.json`) opens this same file.
+- It supports both local stdio and remote MCP servers; `InstallMCPServer` writes the stdio form. There is no project-level MCP configuration.
+- **macOS quirk:** there is a [known LM Studio bug](https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/1371) where a stray *copy* of `mcp.json` may also appear at `~/.cache/lm-studio/mcp.json`. The primary, correct file is `~/.lmstudio/mcp.json` (what `InstallMCPServer` writes); ignore the cache copy.
 
 ### Codex CLI
 


### PR DESCRIPTION
Implement InstallMCPServer support for LM Studio: a $supportedMCPClients entry targeting ~/.lmstudio/mcp.json (standard mcpServers JSON / Cursor notation, no converter, no project scope, default toolset "Wolfram" as a chat-first client), plus .lmstudio/mcp.json path detection in guessClientName. Adds tests (count bumped 19 -> 20), docs rows in mcp-clients.md and README.md, and the AgentSkills source reference (generated skill copies regenerated via BuildAgentSkills.wls).

Also document four clients researched and rejected for InstallMCPServer because they have no external config file to write to (Dify, RecurseChat, Msty, 5ire), with research notes and a "Rejected / Not Feasible" section in TODO/more-mcp-clients.md.