### PR TITLE
Fix LLM-only hint rendering and notebook-embed regressions in MCP App viewers

### DIFF
--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -105,6 +105,36 @@
     (function() {
         "use strict";
 
+        // ---- Debug logging ----
+        // Prefixed so it can be filtered in the console (search "evaluator-viewer").
+        // Added to diagnose WolframNotebookEmbedder failures under newer hosts.
+        var LOG_PREFIX = "[evaluator-viewer]";
+        function log() {
+            var a = Array.prototype.slice.call(arguments);
+            a.unshift(LOG_PREFIX);
+            console.log.apply(console, a);
+        }
+        function logError() {
+            var a = Array.prototype.slice.call(arguments);
+            a.unshift(LOG_PREFIX);
+            console.error.apply(console, a);
+        }
+
+        // Surface failures the host console might otherwise hide: uncaught
+        // exceptions, rejected promises, and CSP blocks (a likely cause of the
+        // CDN script or wolframcloud.com iframe failing to load in newer hosts).
+        window.addEventListener("error", function(e) {
+            logError("window error:", e.message, "@",
+                (e.filename || "?") + ":" + e.lineno + ":" + e.colno, e.error || "");
+        });
+        window.addEventListener("unhandledrejection", function(e) {
+            logError("unhandled promise rejection:", e.reason);
+        });
+        document.addEventListener("securitypolicyviolation", function(e) {
+            logError("CSP violation:", e.violatedDirective, "blocked", e.blockedURI,
+                "| policy:", e.originalPolicy);
+        });
+
         // ---- State ----
         var nextId = 1;
         var pending = {};
@@ -115,8 +145,14 @@
             var script = document.createElement("script");
             script.src = "https://unpkg.com/wolfram-notebook-embedder@0.3/dist/wolfram-notebook-embedder.min.js";
             script.crossOrigin = "";
-            script.onload = resolve;
-            script.onerror = function() {
+            log("loading WolframNotebookEmbedder from", script.src);
+            script.onload = function() {
+                log("WolframNotebookEmbedder script loaded; global available:",
+                    typeof WolframNotebookEmbedder !== "undefined");
+                resolve();
+            };
+            script.onerror = function(e) {
+                logError("failed to load WolframNotebookEmbedder from CDN:", script.src, e);
                 reject(new Error("Failed to load WolframNotebookEmbedder library from CDN."));
             };
             document.head.appendChild(script);
@@ -147,8 +183,11 @@
             loadingEl.style.display = "none";
         }
 
-        // ---- Find notebookUrl in top-level _meta or content items ----
-        function findNotebookUrl(content, meta) {
+        // ---- Find notebookUrl in structuredContent, top-level _meta, or content items ----
+        // structuredContent is the spec's UI-only channel (kept out of model context);
+        // _meta is the fallback for spec-compliant hosts and direct tools/call responses.
+        function findNotebookUrl(content, meta, structured) {
+            if (structured && structured.notebookUrl) return structured.notebookUrl;
             if (meta && meta.notebookUrl) return meta.notebookUrl;
             if (!content || !Array.isArray(content)) return null;
             for (var i = 0; i < content.length; i++) {
@@ -175,17 +214,40 @@
             resultsEl.innerHTML = "";
             loadingEl.style.display = "flex";
 
+            var target = url.startsWith("http") ? url : { expr: url };
+            log("embedNotebook: url =", url, "| target =", target);
+
+            // Watchdog: if embed() neither resolves nor rejects, nothing hits the
+            // console. Warn so a blocked iframe / network stall is visible.
+            var settled = false;
+            var watchdog = setTimeout(function() {
+                if (!settled) {
+                    logError("embedNotebook: embed() still pending after 20s for", url,
+                        "- possible blocked wolframcloud.com iframe or network stall");
+                }
+            }, 20000);
+
             embedderLoaded.then(function() {
-                return WolframNotebookEmbedder.embed((url.startsWith("http") ? url : {expr: url}), notebookContainer, {
+                if (typeof WolframNotebookEmbedder === "undefined" || !WolframNotebookEmbedder.embed) {
+                    throw new Error("WolframNotebookEmbedder.embed is unavailable after load");
+                }
+                log("embedNotebook: calling WolframNotebookEmbedder.embed()");
+                return WolframNotebookEmbedder.embed(target, notebookContainer, {
                     allowInteract: true,
                     showRenderProgress: true,
                     width: null,
                     maxHeight: Infinity
                 });
             }).then(function(nb) {
+                settled = true;
+                clearTimeout(watchdog);
+                log("embedNotebook: embed succeeded");
                 embedded = nb;
                 loadingEl.style.display = "none";
             }).catch(function(err) {
+                settled = true;
+                clearTimeout(watchdog);
+                logError("embedNotebook: embed failed for", url, "->", err);
                 loadingEl.style.display = "none";
             });
         }
@@ -246,12 +308,16 @@
         }
 
         // ---- Handle tool result: try notebook embed, or fall back to text+image ----
-        function handleToolResult(content, meta) {
-            var notebookUrl = findNotebookUrl(content, meta);
+        function handleToolResult(content, meta, structured) {
+            var notebookUrl = findNotebookUrl(content, meta, structured);
+            log("handleToolResult: notebookUrl =", notebookUrl, "| meta =", meta,
+                "| structuredContent =", structured,
+                "| content items =", Array.isArray(content) ? content.length : content);
 
             if (notebookUrl) {
                 embedNotebook(notebookUrl);
             } else {
+                log("handleToolResult: no notebookUrl; rendering text/image fallback");
                 detachNotebook();
                 renderContent(content);
             }
@@ -364,9 +430,10 @@
 
                 case "ui/notifications/tool-result":
                     hideLoading();
+                    log("ui/notifications/tool-result: msg =", msg);
                     var params = msg.params || {};
                     if (params.content && Array.isArray(params.content)) {
-                        handleToolResult(params.content, params._meta);
+                        handleToolResult(params.content, params._meta, params.structuredContent);
                     } else if (params.text) {
                         renderPlainText(params.text);
                     }
@@ -408,12 +475,14 @@
                 tools: { listChanged: false }
             }
         }).then(function(result) {
+            log("ui/initialize succeeded; host result:", result);
             sendNotification("ui/notifications/initialized");
             setupAutoResize();
             if (result) {
                 applyTheme(result.hostContext || result.context || result);
             }
         }).catch(function(err) {
+            logError("ui/initialize failed:", err);
             showError("Failed to initialize: " + ((err && err.message) || String(err)));
         });
     })();

--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -208,21 +208,31 @@
             notebookContainer.innerHTML = "";
         }
 
+        // ---- Summarize a notebook target for logging ----
+        // Inline delivery (MCP_APPS_NOTEBOOK_METHOD="Inline") passes the entire
+        // serialized notebook as `url`; logging it verbatim floods the console and
+        // can leak notebook content into host-collected logs, so report only size.
+        function describeUrl(url) {
+            if (typeof url !== "string") return "(non-string: " + (url === null ? "null" : typeof url) + ")";
+            return url.startsWith("http") ? url : "(inline notebook, " + url.length + " chars)";
+        }
+
         // ---- Embed a cloud notebook ----
         function embedNotebook(url) {
             detachNotebook();
             resultsEl.innerHTML = "";
             loadingEl.style.display = "flex";
 
-            var target = url.startsWith("http") ? url : { expr: url };
-            log("embedNotebook: url =", url, "| target =", target);
+            var isHttpUrl = typeof url === "string" && url.startsWith("http");
+            var target = isHttpUrl ? url : { expr: url };
+            log("embedNotebook: target =", describeUrl(url));
 
             // Watchdog: if embed() neither resolves nor rejects, nothing hits the
             // console. Warn so a blocked iframe / network stall is visible.
             var settled = false;
             var watchdog = setTimeout(function() {
                 if (!settled) {
-                    logError("embedNotebook: embed() still pending after 20s for", url,
+                    logError("embedNotebook: embed() still pending after 20s for", describeUrl(url),
                         "- possible blocked wolframcloud.com iframe or network stall");
                 }
             }, 20000);
@@ -247,7 +257,7 @@
             }).catch(function(err) {
                 settled = true;
                 clearTimeout(watchdog);
-                logError("embedNotebook: embed failed for", url, "->", err);
+                logError("embedNotebook: embed failed for", describeUrl(url), "->", err);
                 loadingEl.style.display = "none";
             });
         }

--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -139,6 +139,9 @@
         var nextId = 1;
         var pending = {};
         var embedded = null;
+        // Bumped on every embedNotebook() call so a stale embed that resolves
+        // after a newer result can be discarded instead of clobbering it.
+        var embedGeneration = 0;
 
         // ---- Load WolframNotebookEmbedder dynamically ----
         var embedderLoaded = new Promise(function(resolve, reject) {
@@ -235,9 +238,13 @@
         // ---- Embed a cloud notebook ----
         function embedNotebook(url) {
             detachNotebook();
-            resultsEl.innerHTML = "";
+            // Do NOT clear resultsEl here: any text/image fallback rendered by
+            // handleToolResult must stay visible until the embed actually
+            // succeeds, so an embed failure (CSP, CDN, blocked iframe, network
+            // stall) still leaves readable output on screen.
             loadingEl.style.display = "flex";
 
+            var generation = ++embedGeneration;
             var isHttpUrl = typeof url === "string" && url.startsWith("http");
             var target = isHttpUrl ? url : { expr: url };
             log("embedNotebook: target =", describeUrl(url));
@@ -266,12 +273,23 @@
             }).then(function(nb) {
                 settled = true;
                 clearTimeout(watchdog);
+                if (generation !== embedGeneration) {
+                    // A newer result superseded this embed; discard it so it
+                    // can't clear the current fallback or steal `embedded`.
+                    if (nb && nb.detach) nb.detach();
+                    return;
+                }
                 log("embedNotebook: embed succeeded");
                 embedded = nb;
+                // Notebook is on screen now; drop the redundant text/image fallback.
+                resultsEl.innerHTML = "";
                 loadingEl.style.display = "none";
             }).catch(function(err) {
                 settled = true;
                 clearTimeout(watchdog);
+                if (generation !== embedGeneration) return;
+                // Embed failed; leave the text/image fallback rendered by
+                // handleToolResult in place so the user still sees output.
                 logError("embedNotebook: embed failed for", describeUrl(url), "->", err);
                 loadingEl.style.display = "none";
             });
@@ -341,6 +359,10 @@
                 "| content =", describe(content));
 
             if (notebookUrl) {
+                // Render the text/image fallback first so a failed embed still
+                // leaves readable output; embedNotebook() clears it again once
+                // the notebook actually renders.
+                renderContent(content);
                 embedNotebook(notebookUrl);
             } else {
                 log("handleToolResult: no notebookUrl; rendering text/image fallback");

--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -190,6 +190,19 @@
             });
         }
 
+        // ---- Strip text intended only for the AI, not the user ----
+        // Some tool outputs carry hints meant purely for the model, which should
+        // never be surfaced in the widget:
+        //   * the Wolfram session-ID <system-reminder> appended to evaluator output
+        //   * the interactive-widget notice injected by the host (e.g. Claude Desktop)
+        function stripAgentOnlyText(text) {
+            if (!text) return "";
+            return text
+                .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
+                .replace(/\[This tool call rendered an interactive widget[\s\S]*?\]/g, "")
+                .trim();
+        }
+
         // ---- Render tool result content (text+image fallback) ----
         function renderContent(content) {
             resultsEl.innerHTML = "";
@@ -204,9 +217,11 @@
                 if (item._meta && (!item.text || item.text === "")) continue;
 
                 if (item.type === "text" && item.text) {
+                    var text = stripAgentOnlyText(item.text);
+                    if (!text) continue;
                     var div = document.createElement("div");
                     div.className = "result-text";
-                    div.textContent = item.text;
+                    div.textContent = text;
                     resultsEl.appendChild(div);
                 } else if (item.type === "image" && item.data && item.mimeType) {
                     var imgDiv = document.createElement("div");
@@ -222,10 +237,11 @@
 
         function renderPlainText(text) {
             resultsEl.innerHTML = "";
-            if (!text) return;
+            var clean = stripAgentOnlyText(text);
+            if (!clean) return;
             var div = document.createElement("div");
             div.className = "result-text";
-            div.textContent = text;
+            div.textContent = clean;
             resultsEl.appendChild(div);
         }
 

--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -440,8 +440,9 @@
 
                 case "ui/notifications/tool-result":
                     hideLoading();
-                    log("ui/notifications/tool-result: msg =", msg);
                     var params = msg.params || {};
+                    log("ui/notifications/tool-result: param keys =", Object.keys(params),
+                        "| content items =", Array.isArray(params.content) ? params.content.length : 0);
                     if (params.content && Array.isArray(params.content)) {
                         handleToolResult(params.content, params._meta, params.structuredContent);
                     } else if (params.text) {

--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -217,6 +217,21 @@
             return url.startsWith("http") ? url : "(inline notebook, " + url.length + " chars)";
         }
 
+        // ---- Summarize an arbitrary value for logging ----
+        // object -> its keys, array -> its item types, anything else -> its type.
+        // Never logs values, so large or sensitive payloads (inline notebooks,
+        // base64 image data) carried in meta/structuredContent/content can't flood
+        // the console or leak into host-collected logs.
+        function describe(value) {
+            if (Array.isArray(value)) {
+                return value.map(function(item) {
+                    return item && item.type ? item.type : describe(item);
+                });
+            }
+            if (value && typeof value === "object") return Object.keys(value);
+            return value === null ? "null" : typeof value;
+        }
+
         // ---- Embed a cloud notebook ----
         function embedNotebook(url) {
             detachNotebook();
@@ -320,9 +335,10 @@
         // ---- Handle tool result: try notebook embed, or fall back to text+image ----
         function handleToolResult(content, meta, structured) {
             var notebookUrl = findNotebookUrl(content, meta, structured);
-            log("handleToolResult: notebookUrl =", notebookUrl, "| meta =", meta,
-                "| structuredContent =", structured,
-                "| content items =", Array.isArray(content) ? content.length : content);
+            log("handleToolResult: notebookUrl =", describeUrl(notebookUrl),
+                "| meta =", describe(meta),
+                "| structuredContent =", describe(structured),
+                "| content =", describe(content));
 
             if (notebookUrl) {
                 embedNotebook(notebookUrl);

--- a/Assets/Apps/notebook-viewer.html
+++ b/Assets/Apps/notebook-viewer.html
@@ -81,6 +81,36 @@
     (function() {
         "use strict";
 
+        // ---- Debug logging ----
+        // Prefixed so it can be filtered in the console (search "notebook-viewer").
+        // Added to diagnose WolframNotebookEmbedder failures under newer hosts.
+        var LOG_PREFIX = "[notebook-viewer]";
+        function log() {
+            var a = Array.prototype.slice.call(arguments);
+            a.unshift(LOG_PREFIX);
+            console.log.apply(console, a);
+        }
+        function logError() {
+            var a = Array.prototype.slice.call(arguments);
+            a.unshift(LOG_PREFIX);
+            console.error.apply(console, a);
+        }
+
+        // Surface failures the host console might otherwise hide: uncaught
+        // exceptions, rejected promises, and CSP blocks (a likely cause of the
+        // CDN script or wolframcloud.com iframe failing to load in newer hosts).
+        window.addEventListener("error", function(e) {
+            logError("window error:", e.message, "@",
+                (e.filename || "?") + ":" + e.lineno + ":" + e.colno, e.error || "");
+        });
+        window.addEventListener("unhandledrejection", function(e) {
+            logError("unhandled promise rejection:", e.reason);
+        });
+        document.addEventListener("securitypolicyviolation", function(e) {
+            logError("CSP violation:", e.violatedDirective, "blocked", e.blockedURI,
+                "| policy:", e.originalPolicy);
+        });
+
         // ---- State ----
         var nextId = 1;
         var pending = {};
@@ -91,8 +121,14 @@
             var script = document.createElement("script");
             script.src = "https://unpkg.com/wolfram-notebook-embedder@0.3/dist/wolfram-notebook-embedder.min.js";
             script.crossOrigin = "";
-            script.onload = resolve;
-            script.onerror = function() {
+            log("loading WolframNotebookEmbedder from", script.src);
+            script.onload = function() {
+                log("WolframNotebookEmbedder script loaded; global available:",
+                    typeof WolframNotebookEmbedder !== "undefined");
+                resolve();
+            };
+            script.onerror = function(e) {
+                logError("failed to load WolframNotebookEmbedder from CDN:", script.src, e);
                 reject(new Error("Failed to load WolframNotebookEmbedder library from CDN."));
             };
             document.head.appendChild(script);
@@ -186,7 +222,24 @@
             loadingEl.style.display = "flex";
             errorEl.style.display = "none";
 
+            var target = url.startsWith("http") ? url : { expr: url };
+            log("embedNotebook: url =", url, "| target =", target,
+                "| allowInteract =", allowInteract, "| maxHeight =", maxHeight);
+
+            // Watchdog: if embed() neither resolves nor rejects, nothing hits the
+            // console. Warn so a blocked iframe / network stall is visible.
+            var settled = false;
+            var watchdog = setTimeout(function() {
+                if (!settled) {
+                    logError("embedNotebook: embed() still pending after 20s for", url,
+                        "- possible blocked wolframcloud.com iframe or network stall");
+                }
+            }, 20000);
+
             embedderLoaded.then(function() {
+                if (typeof WolframNotebookEmbedder === "undefined" || !WolframNotebookEmbedder.embed) {
+                    throw new Error("WolframNotebookEmbedder.embed is unavailable after load");
+                }
                 var opts = {
                     allowInteract: allowInteract !== false,
                     showRenderProgress: true,
@@ -194,11 +247,18 @@
                     maxHeight: typeof maxHeight === "number" && maxHeight > 0 ? maxHeight : Infinity
                 };
 
-                return WolframNotebookEmbedder.embed((url.startsWith("http") ? url : {expr: url}), containerEl, opts);
+                log("embedNotebook: calling WolframNotebookEmbedder.embed()");
+                return WolframNotebookEmbedder.embed(target, containerEl, opts);
             }).then(function(nb) {
+                settled = true;
+                clearTimeout(watchdog);
+                log("embedNotebook: embed succeeded");
                 embedded = nb;
                 loadingEl.style.display = "none";
             }).catch(function(err) {
+                settled = true;
+                clearTimeout(watchdog);
+                logError("embedNotebook: embed failed for", url, "->", err);
                 var msg = (err && err.message) ? err.message : String(err);
                 showError(msg);
             });
@@ -237,6 +297,8 @@
                             args.allowInteract,
                             args.maxHeight
                         );
+                    } else {
+                        logError("tool-input received without a url; args =", args);
                     }
                     break;
 
@@ -288,12 +350,14 @@
                 tools: { listChanged: false }
             }
         }).then(function(result) {
+            log("ui/initialize succeeded; host result:", result);
             sendNotification("ui/notifications/initialized");
             setupAutoResize();
             if (result) {
                 applyTheme(result.hostContext || result.context || result);
             }
         }).catch(function(err) {
+            logError("ui/initialize failed:", err);
             showError("Failed to initialize: " + ((err && err.message) || String(err)));
         });
     })();

--- a/Assets/Apps/notebook-viewer.html
+++ b/Assets/Apps/notebook-viewer.html
@@ -217,13 +217,23 @@
             }
         }
 
+        // ---- Summarize a notebook target for logging ----
+        // Inline delivery (MCP_APPS_NOTEBOOK_METHOD="Inline") passes the entire
+        // serialized notebook as `url`; logging it verbatim floods the console and
+        // can leak notebook content into host-collected logs, so report only size.
+        function describeUrl(url) {
+            if (typeof url !== "string") return "(non-string: " + (url === null ? "null" : typeof url) + ")";
+            return url.startsWith("http") ? url : "(inline notebook, " + url.length + " chars)";
+        }
+
         // ---- Embed notebook ----
         function embedNotebook(url, allowInteract, maxHeight) {
             loadingEl.style.display = "flex";
             errorEl.style.display = "none";
 
-            var target = url.startsWith("http") ? url : { expr: url };
-            log("embedNotebook: url =", url, "| target =", target,
+            var isHttpUrl = typeof url === "string" && url.startsWith("http");
+            var target = isHttpUrl ? url : { expr: url };
+            log("embedNotebook: target =", describeUrl(url),
                 "| allowInteract =", allowInteract, "| maxHeight =", maxHeight);
 
             // Watchdog: if embed() neither resolves nor rejects, nothing hits the
@@ -231,7 +241,7 @@
             var settled = false;
             var watchdog = setTimeout(function() {
                 if (!settled) {
-                    logError("embedNotebook: embed() still pending after 20s for", url,
+                    logError("embedNotebook: embed() still pending after 20s for", describeUrl(url),
                         "- possible blocked wolframcloud.com iframe or network stall");
                 }
             }, 20000);
@@ -258,7 +268,7 @@
             }).catch(function(err) {
                 settled = true;
                 clearTimeout(watchdog);
-                logError("embedNotebook: embed failed for", url, "->", err);
+                logError("embedNotebook: embed failed for", describeUrl(url), "->", err);
                 var msg = (err && err.message) ? err.message : String(err);
                 showError(msg);
             });

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -220,6 +220,9 @@
         var pending = {};
         var currentQuery = "";
         var embedded = null;
+        // Bumped on every embedNotebook() call so a stale embed that resolves
+        // after a newer result can be discarded instead of clobbering it.
+        var embedGeneration = 0;
 
         // ---- Load WolframNotebookEmbedder dynamically ----
         var embedderLoaded = new Promise(function(resolve, reject) {
@@ -324,9 +327,13 @@
         // ---- Embed a cloud notebook ----
         function embedNotebook(url) {
             detachNotebook();
-            resultsEl.innerHTML = "";
+            // Do NOT clear resultsEl here: any text/image fallback rendered by
+            // handleToolResult must stay visible until the embed actually
+            // succeeds, so an embed failure (CSP, CDN, blocked iframe, network
+            // stall) still leaves readable output on screen.
             loadingEl.style.display = "flex";
 
+            var generation = ++embedGeneration;
             var isHttpUrl = typeof url === "string" && url.startsWith("http");
             var target = isHttpUrl ? url : { expr: url };
             log("embedNotebook: target =", describeUrl(url));
@@ -355,13 +362,23 @@
             }).then(function(nb) {
                 settled = true;
                 clearTimeout(watchdog);
+                if (generation !== embedGeneration) {
+                    // A newer result superseded this embed; discard it so it
+                    // can't clear the current fallback or steal `embedded`.
+                    if (nb && nb.detach) nb.detach();
+                    return;
+                }
                 log("embedNotebook: embed succeeded");
                 embedded = nb;
+                // Notebook is on screen now; drop the redundant text/image fallback.
+                resultsEl.innerHTML = "";
                 loadingEl.style.display = "none";
             }).catch(function(err) {
                 settled = true;
                 clearTimeout(watchdog);
-                // Embedder failed; text+image fallback content is already rendered
+                if (generation !== embedGeneration) return;
+                // Embed failed; the text/image fallback rendered by
+                // handleToolResult is still on screen, so the user sees output.
                 logError("embedNotebook: embed failed for", describeUrl(url), "->", err);
                 loadingEl.style.display = "none";
             });
@@ -406,7 +423,7 @@
             resultsEl.appendChild(div);
         }
 
-        // ---- Handle tool result: try notebook embed, or show error ----
+        // ---- Handle tool result: embed notebook, falling back to text/image ----
         function handleToolResult(content, meta, structured) {
             var notebookUrl = findNotebookUrl(content, meta, structured);
             log("handleToolResult: notebookUrl =", describeUrl(notebookUrl),
@@ -414,13 +431,25 @@
                 "| structuredContent =", describe(structured),
                 "| content =", describe(content));
 
+            // A fresh result supersedes any stale error banner.
+            clearError();
+
             if (notebookUrl) {
+                // Render the text/image fallback first so a failed embed still
+                // leaves readable output; embedNotebook() clears it again once
+                // the notebook actually renders.
+                renderContent(content);
                 embedNotebook(notebookUrl);
             } else {
-                // No notebook URL: show error instead of raw text
-                logError("handleToolResult: no notebookUrl in result; content =", describe(content));
+                // No notebookUrl (e.g. the host dropped _meta/structuredContent):
+                // fall back to the text/image content the result still carries,
+                // and only show an error when there is nothing renderable.
                 detachNotebook();
-                showError("Unable to load notebook. Click Go to retry.");
+                renderContent(content);
+                if (!resultsEl.children.length) {
+                    logError("handleToolResult: no notebookUrl and no renderable content =", describe(content));
+                    showError("Unable to load notebook. Click Go to retry.");
+                }
             }
         }
 

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -185,6 +185,36 @@
     (function() {
         "use strict";
 
+        // ---- Debug logging ----
+        // Prefixed so it can be filtered in the console (search "wolframalpha-viewer").
+        // Added to diagnose WolframNotebookEmbedder failures under newer hosts.
+        var LOG_PREFIX = "[wolframalpha-viewer]";
+        function log() {
+            var a = Array.prototype.slice.call(arguments);
+            a.unshift(LOG_PREFIX);
+            console.log.apply(console, a);
+        }
+        function logError() {
+            var a = Array.prototype.slice.call(arguments);
+            a.unshift(LOG_PREFIX);
+            console.error.apply(console, a);
+        }
+
+        // Surface failures the host console might otherwise hide: uncaught
+        // exceptions, rejected promises, and CSP blocks (a likely cause of the
+        // CDN script or wolframcloud.com iframe failing to load in newer hosts).
+        window.addEventListener("error", function(e) {
+            logError("window error:", e.message, "@",
+                (e.filename || "?") + ":" + e.lineno + ":" + e.colno, e.error || "");
+        });
+        window.addEventListener("unhandledrejection", function(e) {
+            logError("unhandled promise rejection:", e.reason);
+        });
+        document.addEventListener("securitypolicyviolation", function(e) {
+            logError("CSP violation:", e.violatedDirective, "blocked", e.blockedURI,
+                "| policy:", e.originalPolicy);
+        });
+
         // ---- State ----
         var nextId = 1;
         var pending = {};
@@ -196,9 +226,15 @@
             var script = document.createElement("script");
             script.src = "https://unpkg.com/wolfram-notebook-embedder@0.3/dist/wolfram-notebook-embedder.min.js";
             script.crossOrigin = "";
-            script.onload = resolve;
-            script.onerror = function() {
+            log("loading WolframNotebookEmbedder from", script.src);
+            script.onload = function() {
+                log("WolframNotebookEmbedder script loaded; global available:",
+                    typeof WolframNotebookEmbedder !== "undefined");
+                resolve();
+            };
+            script.onerror = function(e) {
                 // Non-fatal: embedder is optional; text+image fallback still works
+                logError("failed to load WolframNotebookEmbedder from CDN:", script.src, e);
                 reject(new Error("Failed to load WolframNotebookEmbedder library from CDN."));
             };
             document.head.appendChild(script);
@@ -236,11 +272,12 @@
             clearBtn.style.display = queryInput.value ? "flex" : "none";
         }
 
-        // ---- Find notebookUrl in top-level _meta or content items ----
-        function findNotebookUrl(content, meta) {
-            // Check top-level _meta first (from tool-result notification)
+        // ---- Find notebookUrl in structuredContent, top-level _meta, or content items ----
+        function findNotebookUrl(content, meta, structured) {
+            // structuredContent is the spec's UI-only channel (kept out of model context)
+            if (structured && structured.notebookUrl) return structured.notebookUrl;
+            // _meta works on direct tools/call responses
             if (meta && meta.notebookUrl) return meta.notebookUrl;
-            // Fall back to checking content items (from tools/call response)
             if (!content || !Array.isArray(content)) return null;
             for (var i = 0; i < content.length; i++) {
                 var item = content[i];
@@ -266,19 +303,42 @@
             resultsEl.innerHTML = "";
             loadingEl.style.display = "flex";
 
+            var target = url.startsWith("http") ? url : { expr: url };
+            log("embedNotebook: url =", url, "| target =", target);
+
+            // Watchdog: if embed() neither resolves nor rejects, nothing hits the
+            // console. Warn so a blocked iframe / network stall is visible.
+            var settled = false;
+            var watchdog = setTimeout(function() {
+                if (!settled) {
+                    logError("embedNotebook: embed() still pending after 20s for", url,
+                        "- possible blocked wolframcloud.com iframe or network stall");
+                }
+            }, 20000);
+
             embedderLoaded.then(function() {
-                return WolframNotebookEmbedder.embed((url.startsWith("http") ? url : {expr: url}), notebookContainer, {
+                if (typeof WolframNotebookEmbedder === "undefined" || !WolframNotebookEmbedder.embed) {
+                    throw new Error("WolframNotebookEmbedder.embed is unavailable after load");
+                }
+                log("embedNotebook: calling WolframNotebookEmbedder.embed()");
+                return WolframNotebookEmbedder.embed(target, notebookContainer, {
                     allowInteract: true,
                     showRenderProgress: true,
                     width: null,
                     maxHeight: Infinity
                 });
             }).then(function(nb) {
+                settled = true;
+                clearTimeout(watchdog);
+                log("embedNotebook: embed succeeded");
                 embedded = nb;
                 loadingEl.style.display = "none";
             }).catch(function(err) {
-                loadingEl.style.display = "none";
+                settled = true;
+                clearTimeout(watchdog);
                 // Embedder failed; text+image fallback content is already rendered
+                logError("embedNotebook: embed failed for", url, "->", err);
+                loadingEl.style.display = "none";
             });
         }
 
@@ -322,13 +382,17 @@
         }
 
         // ---- Handle tool result: try notebook embed, or show error ----
-        function handleToolResult(content, meta) {
-            var notebookUrl = findNotebookUrl(content, meta);
+        function handleToolResult(content, meta, structured) {
+            var notebookUrl = findNotebookUrl(content, meta, structured);
+            log("handleToolResult: notebookUrl =", notebookUrl, "| meta =", meta,
+                "| structuredContent =", structured,
+                "| content items =", Array.isArray(content) ? content.length : content);
 
             if (notebookUrl) {
                 embedNotebook(notebookUrl);
             } else {
                 // No notebook URL: show error instead of raw text
+                logError("handleToolResult: no notebookUrl in result; content =", content);
                 detachNotebook();
                 showError("Unable to load notebook. Click Go to retry.");
             }
@@ -426,13 +490,14 @@
                 hideLoading();
                 goBtn.disabled = false;
                 if (result && result.content) {
-                    handleToolResult(result.content, result._meta);
+                    handleToolResult(result.content, result._meta, result.structuredContent);
                 } else if (result && typeof result === "string") {
                     renderPlainText(result);
                 }
             }).catch(function(err) {
                 hideLoading();
                 goBtn.disabled = false;
+                logError("WolframAlpha tools/call failed:", err);
                 showError("Query failed: " + ((err && err.message) || JSON.stringify(err)));
             });
         }
@@ -506,7 +571,7 @@
                     hideLoading();
                     var params = msg.params || {};
                     if (params.content && Array.isArray(params.content)) {
-                        handleToolResult(params.content, params._meta);
+                        handleToolResult(params.content, params._meta, params.structuredContent);
                     } else if (params.text) {
                         renderPlainText(params.text);
                     }
@@ -548,12 +613,14 @@
                 tools: { listChanged: false }
             }
         }).then(function(result) {
+            log("ui/initialize succeeded; host result:", result);
             sendNotification("ui/notifications/initialized");
             setupAutoResize();
             if (result) {
                 applyTheme(result.hostContext || result.context || result);
             }
         }).catch(function(err) {
+            logError("ui/initialize failed:", err);
             showError("Failed to initialize: " + ((err && err.message) || String(err)));
         });
     })();

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -297,21 +297,31 @@
             notebookContainer.innerHTML = "";
         }
 
+        // ---- Summarize a notebook target for logging ----
+        // Inline delivery (MCP_APPS_NOTEBOOK_METHOD="Inline") passes the entire
+        // serialized notebook as `url`; logging it verbatim floods the console and
+        // can leak notebook content into host-collected logs, so report only size.
+        function describeUrl(url) {
+            if (typeof url !== "string") return "(non-string: " + (url === null ? "null" : typeof url) + ")";
+            return url.startsWith("http") ? url : "(inline notebook, " + url.length + " chars)";
+        }
+
         // ---- Embed a cloud notebook ----
         function embedNotebook(url) {
             detachNotebook();
             resultsEl.innerHTML = "";
             loadingEl.style.display = "flex";
 
-            var target = url.startsWith("http") ? url : { expr: url };
-            log("embedNotebook: url =", url, "| target =", target);
+            var isHttpUrl = typeof url === "string" && url.startsWith("http");
+            var target = isHttpUrl ? url : { expr: url };
+            log("embedNotebook: target =", describeUrl(url));
 
             // Watchdog: if embed() neither resolves nor rejects, nothing hits the
             // console. Warn so a blocked iframe / network stall is visible.
             var settled = false;
             var watchdog = setTimeout(function() {
                 if (!settled) {
-                    logError("embedNotebook: embed() still pending after 20s for", url,
+                    logError("embedNotebook: embed() still pending after 20s for", describeUrl(url),
                         "- possible blocked wolframcloud.com iframe or network stall");
                 }
             }, 20000);
@@ -337,7 +347,7 @@
                 settled = true;
                 clearTimeout(watchdog);
                 // Embedder failed; text+image fallback content is already rendered
-                logError("embedNotebook: embed failed for", url, "->", err);
+                logError("embedNotebook: embed failed for", describeUrl(url), "->", err);
                 loadingEl.style.display = "none";
             });
         }

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -306,6 +306,21 @@
             return url.startsWith("http") ? url : "(inline notebook, " + url.length + " chars)";
         }
 
+        // ---- Summarize an arbitrary value for logging ----
+        // object -> its keys, array -> its item types, anything else -> its type.
+        // Never logs values, so large or sensitive payloads (inline notebooks,
+        // base64 image data) carried in meta/structuredContent/content can't flood
+        // the console or leak into host-collected logs.
+        function describe(value) {
+            if (Array.isArray(value)) {
+                return value.map(function(item) {
+                    return item && item.type ? item.type : describe(item);
+                });
+            }
+            if (value && typeof value === "object") return Object.keys(value);
+            return value === null ? "null" : typeof value;
+        }
+
         // ---- Embed a cloud notebook ----
         function embedNotebook(url) {
             detachNotebook();
@@ -394,15 +409,16 @@
         // ---- Handle tool result: try notebook embed, or show error ----
         function handleToolResult(content, meta, structured) {
             var notebookUrl = findNotebookUrl(content, meta, structured);
-            log("handleToolResult: notebookUrl =", notebookUrl, "| meta =", meta,
-                "| structuredContent =", structured,
-                "| content items =", Array.isArray(content) ? content.length : content);
+            log("handleToolResult: notebookUrl =", describeUrl(notebookUrl),
+                "| meta =", describe(meta),
+                "| structuredContent =", describe(structured),
+                "| content =", describe(content));
 
             if (notebookUrl) {
                 embedNotebook(notebookUrl);
             } else {
                 // No notebook URL: show error instead of raw text
-                logError("handleToolResult: no notebookUrl in result; content =", content);
+                logError("handleToolResult: no notebookUrl in result; content =", describe(content));
                 detachNotebook();
                 showError("Unable to load notebook. Click Go to retry.");
             }

--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -917,6 +917,13 @@ evaluateTool[ msg_, req_ ] := Enclose[
             toolResultAssoc[ "_meta" ] = result[ "_meta" ]
         ];
 
+        (* Also forward structuredContent: the MCP Apps spec routes it to the app without
+           adding it to model context. Claude Desktop currently drops it (ext-apps#696),
+           so the app falls back to text/image until that is fixed. *)
+        If[ AssociationQ @ result && AssociationQ @ result[ "StructuredContent" ],
+            toolResultAssoc[ "structuredContent" ] = result[ "StructuredContent" ]
+        ];
+
         toolResultAssoc
     ],
     throwInternalFailure

--- a/Kernel/Tools/WolframAlpha.wl
+++ b/Kernel/Tools/WolframAlpha.wl
@@ -144,7 +144,15 @@ makeUIResult[ as_, KeyValuePattern[ { "Result" -> waResult_, "String" -> stringR
         ];
 
         If[ StringQ @ deployed,
-            <| "Content" -> textContent, "_meta" -> <| "notebookUrl" -> deployed |> |>,
+            (* Carry notebookUrl in _meta (per the MCP Apps spec) and in structuredContent.
+               Both are meant to reach the app without entering model context; some hosts
+               drop _meta but honor structuredContent. Claude Desktop currently drops both
+               (ext-apps#696) and falls back to text/image until that is fixed. *)
+            <|
+                "Content"           -> textContent,
+                "_meta"             -> <| "notebookUrl" -> deployed |>,
+                "StructuredContent" -> <| "notebookUrl" -> deployed |>
+            |>,
             $Failed
         ]
     ],

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -357,7 +357,15 @@ makeEvaluatorUIResult[
         ];
 
         If[ StringQ @ deployed,
-            <| "Content" -> textContent, "_meta" -> <| "notebookUrl" -> deployed |> |>,
+            (* Carry notebookUrl in _meta (per the MCP Apps spec) and in structuredContent.
+               Both are meant to reach the app without entering model context; some hosts
+               drop _meta but honor structuredContent. Claude Desktop currently drops both
+               (ext-apps#696) and falls back to text/image until that is fixed. *)
+            <|
+                "Content"           -> textContent,
+                "_meta"             -> <| "notebookUrl" -> deployed |>,
+                "StructuredContent" -> <| "notebookUrl" -> deployed |>
+            |>,
             $Failed
         ]
     ],

--- a/Tests/EvaluatorSessions.wlt
+++ b/Tests/EvaluatorSessions.wlt
@@ -268,13 +268,27 @@ VerificationTest[
 
 VerificationTest[
     Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "new" },
+        KeyExistsQ[
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`appendSessionInfo[
+                <| "Content" -> { <| "type" -> "text", "text" -> "x" |> }, "StructuredContent" -> <| "notebookUrl" -> "u" |> |>,
+                "Abc123"
+            ],
+            "StructuredContent"
+        ]
+    ],
+    True,
+    TestID -> "AppendSessionInfo-PreservesStructuredContent@@Tests/EvaluatorSessions.wlt:269,1-281,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "new" },
         MatchQ[
             Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`appendSessionInfo[ "plain text", "Abc123" ],
             _String? (StringContainsQ[ #, "plain text" ] && StringContainsQ[ #, "Abc123" ] &)
         ]
     ],
     True,
-    TestID -> "AppendSessionInfo-String@@Tests/EvaluatorSessions.wlt:269,1-278,2"
+    TestID -> "AppendSessionInfo-String@@Tests/EvaluatorSessions.wlt:283,1-292,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -287,13 +301,13 @@ VerificationTest[
         Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`syncEvalKernelLine[ 5 ]
     ],
     Null,
-    TestID -> "SyncEvalKernelLine-NoOpForInProcess@@Tests/EvaluatorSessions.wlt:285,1-291,2"
+    TestID -> "SyncEvalKernelLine-NoOpForInProcess@@Tests/EvaluatorSessions.wlt:299,1-305,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`syncEvalKernelLineSafe[ "not an integer" ],
     Null,
-    TestID -> "SyncEvalKernelLineSafe-IgnoresNonInteger@@Tests/EvaluatorSessions.wlt:293,1-297,2"
+    TestID -> "SyncEvalKernelLineSafe-IgnoresNonInteger@@Tests/EvaluatorSessions.wlt:307,1-311,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -321,7 +335,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r3, "42" ]
     ],
     True,
-    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:306,1-325,2"
+    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:320,1-339,2"
 ]
 
 (* Re-passing the same session ID continues it: definitions persist and line numbers advance. *)
@@ -343,7 +357,7 @@ VerificationTest[
         StringContainsQ[ text, "6" ] && StringContainsQ[ text, "Out[2]" ]
     ],
     True,
-    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:328,1-347,2"
+    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:342,1-361,2"
 ]
 
 (* A session resumes from disk after its in-kernel symbols are gone (simulated server restart). *)
@@ -367,7 +381,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r2, "99" ]
     ],
     True,
-    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:350,1-371,2"
+    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:364,1-385,2"
 ]
 
 (* Every result echoes the session ID with resume instructions. *)
@@ -387,7 +401,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "session=\"AppendSession\"" ]
     ],
     True,
-    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:374,1-391,2"
+    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:388,1-405,2"
 ]
 
 (* A fresh session's first evaluation is labeled Out[1]. *)
@@ -407,7 +421,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "Out[1]" ]
     ],
     True,
-    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:394,1-411,2"
+    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:408,1-425,2"
 ]
 
 (* Resuming a session continues its line numbering rather than resetting it: A reaches Out[2], B
@@ -432,7 +446,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "Out[3]" ]
     ],
     True,
-    TestID -> "Integration-ResumeContinuesLineNumbering@@Tests/EvaluatorSessions.wlt:416,1-436,2"
+    TestID -> "Integration-ResumeContinuesLineNumbering@@Tests/EvaluatorSessions.wlt:430,1-450,2"
 ]
 
 (* An unknown / expired session ID starts a fresh session reusing that ID and says so. *)
@@ -452,7 +466,7 @@ VerificationTest[
         StringContainsQ[ text, "NeverSavedXyz" ] && StringContainsQ[ text, "No saved state" ]
     ],
     True,
-    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:439,1-456,2"
+    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:453,1-470,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)


### PR DESCRIPTION
## Summary

Hardens the MCP App notebook viewers (evaluator, WolframAlpha, notebook) after investigating why interactive notebook embedding stopped working in recent Claude Desktop. Three related changes:

### 1. Don't render LLM-only text to the user
The evaluator viewer's text/image fallback was displaying text meant only for the model:
- the Wolfram session-ID `<system-reminder>` appended to evaluator output, and
- the host-injected interactive-widget hint (e.g. from Claude Desktop).

Added `stripAgentOnlyText` to remove both, and skip items that become empty after stripping so no blank result box renders. This fallback matters more now that embedding can fail (below), so it needs to stay readable.

### 2. Embedder diagnostics
The embed failure was invisible because the failure path was a silent `catch`. Added prefixed console logging across all three viewers — embedder load lifecycle, `embed()` success/failure, a pending-embed watchdog, and `window` `error` / `unhandledrejection` / `securitypolicyviolation` listeners — so future failures surface in the console. This is what let us trace the root cause below.

### 3. Deliver `notebookUrl` via `structuredContent`
Root cause: the notebook URL was delivered only in the tool result's top-level `_meta`, which recent Claude Desktop **drops** when relaying `ui/notifications/tool-result` to the app. The URL now also travels in `structuredContent` — the MCP Apps spec's UI-only channel, kept out of model context — forwarded from `evaluateTool`; the viewers read `structuredContent` first, then `_meta`.

## Status / caveat

Claude Desktop currently drops `structuredContent` too, tracked upstream in [modelcontextprotocol/ext-apps#696](https://github.com/modelcontextprotocol/ext-apps/issues/696). Until that ships, the viewers cleanly fall back to text/image (hence change #1). We deliberately did **not** use a `resource_link` content item — Claude Desktop flattens those into text, which would pollute the model's context. `structuredContent` is the spec-correct channel and will embed the notebook *and* stay out of context once the host is fixed. `_meta` already works today for the WolframAlpha viewer's direct `tools/call` response path.

## Test plan

- [x] `CodeInspector` clean on all modified `.wl` files (only pre-existing FIXME warnings remain)
- [x] `TestReport` — `Tests/MCPApps.wlt` and `Tests/EvaluatorSessions.wlt` pass (118/118), including a new `AppendSessionInfo-PreservesStructuredContent` regression test
- [x] JS compile-check of every viewer's inlined script
- [x] End-to-end in a live kernel: `makeEvaluatorUIResult` emits `{Content, _meta, StructuredContent}` with matching URLs (deployed test object cleaned up)
- [ ] Manual: rebuild/restart the Claude Desktop server and confirm the `tool-result` payload carries `structuredContent` once ext-apps#696 is fixed; confirm the text/image fallback in the interim

🤖 Generated with [Claude Code](https://claude.com/claude-code)