### PR TITLE
Simplify evaluator notebook output with a <result uuid> marker

### DIFF
--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -247,9 +247,9 @@
 
         // ---- Find notebookUrl in _meta, content items, or content marker ----
         // _meta is the UI-only channel (kept out of model context) for spec-compliant hosts and
-        // direct tools/call responses. When a host drops it (ext-apps#696), the tool also embeds
-        // the URL in an <internal>...<url>...</url></internal> marker in the text content (see
-        // extractNotebookUrlMarker), which the host does not strip.
+        // direct tools/call responses. When a host drops it (ext-apps#696), the tool also wraps the
+        // output in a <result uuid="..."> marker in the text content (see extractNotebookUrlMarker),
+        // which the host does not strip.
         function findNotebookUrl(content, meta) {
             if (meta && meta.notebookUrl) return meta.notebookUrl;
             if (!content || !Array.isArray(content)) return null;
@@ -262,29 +262,29 @@
             return extractNotebookUrlMarker(content);
         }
 
-        // ---- Recover the URL from the <internal>...<url>...</url></internal> content marker ----
-        // Fallback for hosts that drop _meta (ext-apps#696). The marker's
-        // wrapper text tells the model the notebook is already shown and the URL is not for it
-        // to use; stripAgentOnlyText removes the whole marker before anything reaches the user.
+        // ---- Recover the URL from the <result uuid="..."> content marker ----
+        // Fallback for hosts that drop _meta (ext-apps#696). The tool wraps its output in a
+        // <result uuid="...">...</result> marker; the uuid identifies the deployed cloud notebook,
+        // from which we reconstruct the cloud URL. stripAgentOnlyText removes the <result> tags
+        // before anything reaches the user.
         function extractNotebookUrlMarker(content) {
             if (!content || !Array.isArray(content)) return null;
-            // Prefer the LAST marker in document order. The server appends its marker as the
-            // final content item (see appendNotebookURLMarker), so the last marker is the
-            // trusted one; scanning for the last match rather than the first keeps a marker
-            // injected earlier via user-controlled tool output text from overriding the
-            // server-appended URL (even if a host concatenates the text items).
-            var re = /<internal>[\s\S]*?<url>([\s\S]*?)<\/url>[\s\S]*?<\/internal>/g;
-            var url = null;
+            // Prefer the FIRST marker in document order. The server prepends its opening
+            // <result uuid="..."> tag as the first content item (see wrapResultTags), so the first
+            // marker is the trusted one; taking the first match keeps a marker injected via
+            // user-controlled tool output text (which can only appear after the server's) from
+            // overriding the server's uuid (even if a host concatenates the text items).
+            var re = /<result\s+uuid="([^"]+)"\s*>/;
             for (var i = 0; i < content.length; i++) {
                 var item = content[i];
                 if (item && item.type === "text" && typeof item.text === "string") {
-                    var m;
-                    while ((m = re.exec(item.text)) !== null) {
-                        if (m[1].trim()) url = m[1].trim();
+                    var m = item.text.match(re);
+                    if (m && m[1].trim()) {
+                        return "https://www.wolframcloud.com/obj/" + m[1].trim();
                     }
                 }
             }
-            return url;
+            return null;
         }
 
         // ---- Detach previous notebook ----
@@ -503,13 +503,15 @@
         // never be surfaced in the widget:
         //   * the Wolfram session-ID <system-reminder> appended to evaluator output
         //   * the interactive-widget notice injected by the host (e.g. Claude Desktop)
-        //   * the <internal>...</internal> notebook-URL marker (see extractNotebookUrlMarker)
+        //   * the <result uuid="...">...</result> notebook marker tags (see extractNotebookUrlMarker);
+        //     only the tags are removed, the wrapped result text is preserved
         function stripAgentOnlyText(text) {
             if (!text) return "";
             return text
                 .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
                 .replace(/\[This tool call rendered an interactive widget[\s\S]*?\]/g, "")
-                .replace(/<internal>[\s\S]*?<\/internal>/g, "")
+                .replace(/<result\s+uuid="[^"]*"\s*>/g, "")
+                .replace(/<\/result>/g, "")
                 .trim();
         }
 

--- a/Assets/Apps/notebook-viewer.html
+++ b/Assets/Apps/notebook-viewer.html
@@ -472,29 +472,29 @@
             return extractNotebookUrlMarker(content);
         }
 
-        // ---- Recover the URL from the <internal>...<url>...</url></internal> content marker ----
-        // Fallback for hosts that drop _meta (ext-apps#696). The marker's
-        // wrapper text tells the model the notebook is already shown and the URL is not for it
-        // to use. (This viewer renders no text, so there is nothing to strip from the display.)
+        // ---- Recover the URL from the <result uuid="..."> content marker ----
+        // Fallback for hosts that drop _meta (ext-apps#696). The tool wraps its output in a
+        // <result uuid="...">...</result> marker; the uuid identifies the deployed cloud notebook,
+        // from which we reconstruct the cloud URL. (This viewer renders no text, so there is nothing
+        // to strip from the display.)
         function extractNotebookUrlMarker(content) {
             if (!content || !Array.isArray(content)) return null;
-            // Prefer the LAST marker in document order. The server appends its marker as the
-            // final content item (see appendNotebookURLMarker), so the last marker is the
-            // trusted one; scanning for the last match rather than the first keeps a marker
-            // injected earlier via user-controlled tool output text from overriding the
-            // server-appended URL (even if a host concatenates the text items).
-            var re = /<internal>[\s\S]*?<url>([\s\S]*?)<\/url>[\s\S]*?<\/internal>/g;
-            var url = null;
+            // Prefer the FIRST marker in document order. The server prepends its opening
+            // <result uuid="..."> tag as the first content item (see wrapResultTags), so the first
+            // marker is the trusted one; taking the first match keeps a marker injected via
+            // user-controlled tool output text (which can only appear after the server's) from
+            // overriding the server's uuid (even if a host concatenates the text items).
+            var re = /<result\s+uuid="([^"]+)"\s*>/;
             for (var i = 0; i < content.length; i++) {
                 var item = content[i];
                 if (item && item.type === "text" && typeof item.text === "string") {
-                    var m;
-                    while ((m = re.exec(item.text)) !== null) {
-                        if (m[1].trim()) url = m[1].trim();
+                    var m = item.text.match(re);
+                    if (m && m[1].trim()) {
+                        return "https://www.wolframcloud.com/obj/" + m[1].trim();
                     }
                 }
             }
-            return url;
+            return null;
         }
 
         // ---- Recover and embed a notebook from a tool result ----

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -349,41 +349,43 @@
             return extractNotebookUrlMarker(content);
         }
 
-        // ---- Recover the URL from the <internal>...<url>...</url></internal> content marker ----
-        // Fallback for hosts that drop _meta (ext-apps#696). The marker's
-        // wrapper text tells the model the notebook is already shown and the URL is not for it
-        // to use; stripAgentOnlyText removes the whole marker before anything reaches the user.
+        // ---- Recover the URL from the <result uuid="..."> content marker ----
+        // Fallback for hosts that drop _meta (ext-apps#696). The tool wraps its output in a
+        // <result uuid="...">...</result> marker; the uuid identifies the deployed cloud notebook,
+        // from which we reconstruct the cloud URL. stripAgentOnlyText removes the <result> tags
+        // before anything reaches the user.
         function extractNotebookUrlMarker(content) {
             if (!content || !Array.isArray(content)) return null;
-            // Prefer the LAST marker in document order. The server appends its marker as the
-            // final content item (see appendNotebookURLMarker), so the last marker is the
-            // trusted one; scanning for the last match rather than the first keeps a marker
-            // injected earlier via user-controlled tool output text from overriding the
-            // server-appended URL (even if a host concatenates the text items).
-            var re = /<internal>[\s\S]*?<url>([\s\S]*?)<\/url>[\s\S]*?<\/internal>/g;
-            var url = null;
+            // Prefer the FIRST marker in document order. The server prepends its opening
+            // <result uuid="..."> tag as the first content item (see wrapResultTags), so the first
+            // marker is the trusted one; taking the first match keeps a marker injected via
+            // user-controlled tool output text (which can only appear after the server's) from
+            // overriding the server's uuid (even if a host concatenates the text items).
+            var re = /<result\s+uuid="([^"]+)"\s*>/;
             for (var i = 0; i < content.length; i++) {
                 var item = content[i];
                 if (item && item.type === "text" && typeof item.text === "string") {
-                    var m;
-                    while ((m = re.exec(item.text)) !== null) {
-                        if (m[1].trim()) url = m[1].trim();
+                    var m = item.text.match(re);
+                    if (m && m[1].trim()) {
+                        return "https://www.wolframcloud.com/obj/" + m[1].trim();
                     }
                 }
             }
-            return url;
+            return null;
         }
 
         // ---- Strip text intended only for the AI, not the user ----
-        // The tool result may carry an <internal>...</internal> marker (see
-        // extractNotebookUrlMarker) that must never be surfaced in the widget. The other
-        // patterns match hints some hosts inject, kept in sync with the evaluator viewer.
+        // The tool result may carry a <result uuid="...">...</result> marker (see
+        // extractNotebookUrlMarker) whose tags must never be surfaced in the widget (only the tags
+        // are removed, the wrapped result text is preserved). The other patterns match hints some
+        // hosts inject, kept in sync with the evaluator viewer.
         function stripAgentOnlyText(text) {
             if (!text) return "";
             return text
                 .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
                 .replace(/\[This tool call rendered an interactive widget[\s\S]*?\]/g, "")
-                .replace(/<internal>[\s\S]*?<\/internal>/g, "")
+                .replace(/<result\s+uuid="[^"]*"\s*>/g, "")
+                .replace(/<\/result>/g, "")
                 .trim();
         }
 

--- a/Kernel/Tools/WolframAlpha.wl
+++ b/Kernel/Tools/WolframAlpha.wl
@@ -143,9 +143,9 @@ makeUIResult[ as_, KeyValuePattern[ { "Result" -> waResult_, "String" -> stringR
             "Deployed"
         ];
 
-        (* Build the UI result: notebookUrl in _meta (the UI-only channel), plus the URL inside an
-           <internal>...<url>...</url></internal> marker in the content as a fallback for hosts that
-           drop _meta (ext-apps#696). See makeNotebookUIResult. Returns $Failed if deployment failed. *)
+        (* Build the UI result: notebookUrl in _meta (the UI-only channel), plus a <result uuid="...">
+           wrapper around the content as a fallback for hosts that drop _meta (ext-apps#696). See
+           makeNotebookUIResult. Returns $Failed if deployment failed. *)
         makeNotebookUIResult[ textContent, deployed ]
     ],
     throwInternalFailure

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -356,9 +356,9 @@ makeEvaluatorUIResult[
             "Deployed"
         ];
 
-        (* Build the UI result: notebookUrl in _meta (the UI-only channel), plus the URL inside an
-           <internal>...<url>...</url></internal> marker in the content as a fallback for hosts that
-           drop _meta (ext-apps#696). See makeNotebookUIResult. Returns $Failed if deployment failed. *)
+        (* Build the UI result: notebookUrl in _meta (the UI-only channel), plus a <result uuid="...">
+           wrapper around the content as a fallback for hosts that drop _meta (ext-apps#696). See
+           makeNotebookUIResult. Returns $Failed if deployment failed. *)
         makeNotebookUIResult[ textContent, deployed ]
     ],
     throwInternalFailure
@@ -1018,10 +1018,10 @@ sessionInfoContentItem // endDefinition;
 sessionInfoText // beginDefinition;
 
 sessionInfoText[ id_String ] := StringJoin[
-    "\n\n<system-reminder>Wolfram session ID: ", id, ".",
-    If[ $sessionStatus === "reused", " (No saved state was found for this ID, so a new empty session was started.)", "" ],
-    " To continue this session (its definitions, line numbers, and history) in your next call to this tool, pass session=\"", id,
-    "\". Omit the session parameter only to start a new, empty session.</system-reminder>"
+    "\n\n<system-reminder>",
+    If[ $sessionStatus === "reused", "No saved state was found for the requested session ID, so a new empty session was started. ", "" ],
+    "Pass session=\"", id, "\" in future calls to this tool to continue this session.",
+    "</system-reminder>"
 ];
 
 sessionInfoText // endDefinition;

--- a/Kernel/UIResources.wl
+++ b/Kernel/UIResources.wl
@@ -23,6 +23,14 @@ $includeAppearanceElements = False;
 $deployedNotebookRoot      = "AgentTools/Notebooks";
 $deployCloudNotebooks     := $deployCloudNotebooks = $CloudConnected; (* must be connected to deploy notebooks *)
 
+(* A cloud object UUID (8-4-4-4-12 hexadecimal characters). Notebooks are deployed with
+   CloudObjectNameFormat -> "UUID", so the deployed URL is https://www.wolframcloud.com/obj/<uuid>;
+   cloudNotebookUUID pulls the uuid back out for the <result uuid="..."> marker. *)
+$$notebookUUID =
+    Repeated[ HexadecimalCharacter, { 8 } ] ~~ "-" ~~ Repeated[ HexadecimalCharacter, { 4 } ] ~~ "-" ~~
+    Repeated[ HexadecimalCharacter, { 4 } ] ~~ "-" ~~ Repeated[ HexadecimalCharacter, { 4 } ] ~~ "-" ~~
+    Repeated[ HexadecimalCharacter, { 12 } ];
+
 (* Inline notebooks are not yet the default since there are still some issues to work out.
    These can be enabled via the following environment variable: *)
 $mcpAppsNotebookMethod := $mcpAppsNotebookMethod = Environment[ "MCP_APPS_NOTEBOOK_METHOD" ];
@@ -87,14 +95,14 @@ deployCloudNotebookForMCPApp // endDefinition;
    structuredContent (the MCP Apps spec's other UI-only channel): some clients discard the tool
    result's content (text/images) entirely when structuredContent is present, which we do not
    want. Because some hosts also drop _meta (ext-apps#696) and do not forward app-initiated
-   resources/read, we additionally append the URL to the (non-dropped) text content inside an
-   <internal>...<url>...</url></internal> marker. The wrapper text tells the model the notebook
-   is already shown and the URL is not for it to use; each viewer extracts the URL and strips
-   the whole marker before rendering. *)
+   resources/read, we additionally wrap the (non-dropped) text content in a <result uuid="...">
+   marker whose uuid identifies the deployed cloud notebook. A viewer reconstructs the notebook
+   URL from the uuid (https://www.wolframcloud.com/obj/<uuid>) and strips the surrounding <result>
+   tags before rendering, so they never reach the user. *)
 makeNotebookUIResult // beginDefinition;
 
 makeNotebookUIResult[ textContent_List, deployed_String ] := <|
-    "Content" -> appendNotebookURLMarker[ textContent, deployed ],
+    "Content" -> wrapResultTags[ textContent, deployed ],
     "_meta"   -> <| "notebookUrl" -> deployed |>
 |>;
 
@@ -105,36 +113,37 @@ makeNotebookUIResult // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
-(*appendNotebookURLMarker*)
-appendNotebookURLMarker // beginDefinition;
+(*wrapResultTags*)
+(* Wraps the result content in a <result uuid="..."> ... </result> marker. The uuid identifies the
+   deployed cloud notebook; a viewer that lost _meta reconstructs the URL from it and strips the tags
+   before rendering. The format lives here on the WL side; the viewers' extraction and strip regexes
+   must stay in sync with these tags. *)
+wrapResultTags // beginDefinition;
 
-(* Only cloud URLs are embedded this way. Inline notebooks (MCP_APPS_NOTEBOOK_METHOD="Inline")
+(* Only cloud URLs are wrapped this way. Inline notebooks (MCP_APPS_NOTEBOOK_METHOD="Inline")
    carry the whole serialized notebook as the value and are delivered via _meta only, never
    embedded in the content. *)
-appendNotebookURLMarker[ textContent_List, url_String ] /; StringStartsQ[ url, "http" ] :=
-    Append[ textContent, <| "type" -> "text", "text" -> notebookURLMarkerText[ url ] |> ];
+wrapResultTags[ textContent_List, url_String ] /; StringStartsQ[ url, "http" ] :=
+    Join[
+        { <| "type" -> "text", "text" -> "<result uuid=\"" <> cloudNotebookUUID @ url <> "\">\n" |> },
+        textContent,
+        { <| "type" -> "text", "text" -> "\n</result>" |> }
+    ];
 
-appendNotebookURLMarker[ textContent_List, _ ] := textContent;
+wrapResultTags[ textContent_List, _ ] := textContent;
 
-appendNotebookURLMarker // endDefinition;
+wrapResultTags // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
-(*notebookURLMarkerText*)
-(* Wraps the URL in an instruction the model can read (so it ignores the URL) and in <url> tags
-   the viewer matches. The format lives here on the WL side; the viewers' extraction and strip
-   regexes must stay in sync with these tags. *)
-notebookURLMarkerText // beginDefinition;
-
-notebookURLMarkerText[ url_String ] := StringJoin[
-    "<internal>",
-    "This tool call was displayed to the user as an interactive notebook, which they can already see. ",
-    "The URL below only renders that notebook; you do not need to read, repeat, visit, or otherwise use it. ",
-    "<url>", url, "</url>",
-    "</internal>"
-];
-
-notebookURLMarkerText // endDefinition;
+(*cloudNotebookUUID*)
+(* Notebooks are deployed with CloudObjectNameFormat -> "UUID", so the deployed URL has the form
+   https://www.wolframcloud.com/obj/<uuid>. Pull the uuid back out for the <result uuid="..."> marker;
+   a viewer reconstructs the same URL as https://www.wolframcloud.com/obj/<uuid>. Falls back to the
+   last path segment if the URL is not in UUID form. *)
+cloudNotebookUUID // beginDefinition;
+cloudNotebookUUID[ url_String ] := First[ StringCases[ url, $$notebookUUID ], Last @ StringSplit[ url, "/" ] ];
+cloudNotebookUUID // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
@@ -175,10 +184,14 @@ cloudDeployTryAppearanceElements[ expr_, target_ ] := Quiet[
         CloudDeploy[
             expr,
             target,
-            AppearanceElements -> None,
-            AutoRemove         -> True,
-            IconRules          -> { },
-            Permissions        -> { "All" -> { "Read", "Interact" } }
+            AppearanceElements    -> None,
+            AutoRemove            -> True,
+            (* Deploy to the hashed path (so identical evaluations reuse one object) but return the
+               URL in UUID form (https://www.wolframcloud.com/obj/<uuid>), which cloudNotebookUUID
+               reads for the <result uuid="..."> marker. *)
+            CloudObjectNameFormat -> "UUID",
+            IconRules             -> { },
+            Permissions           -> { "All" -> { "Read", "Interact" } }
         ],
         (* Disable this check for the remainder of the session: *)
         $includeAppearanceElements = True;
@@ -198,9 +211,10 @@ cloudDeployWithAppearanceElements // beginDefinition;
 cloudDeployWithAppearanceElements[ expr_, target_ ] := CloudDeploy[
     expr,
     target,
-    AutoRemove  -> True,
-    IconRules   -> { },
-    Permissions -> { "All" -> { "Read", "Interact" } }
+    AutoRemove            -> True,
+    CloudObjectNameFormat -> "UUID",
+    IconRules             -> { },
+    Permissions           -> { "All" -> { "Read", "Interact" } }
 ];
 
 cloudDeployWithAppearanceElements // endDefinition;

--- a/Tests/MCPApps.wlt
+++ b/Tests/MCPApps.wlt
@@ -1268,52 +1268,80 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
-(*Cloud URL Appends URL Marker*)
+(*Cloud URL Wraps Result In Marker*)
 VerificationTest[
-    Module[ { url, result, marker },
-        url    = "https://www.wolframcloud.com/obj/user/AgentTools/Notebooks/deadbeef12345678.nb";
-        result = Wolfram`AgentTools`Common`makeNotebookUIResult[
+    Module[ { uuid, url, result, content, joined },
+        uuid    = "e0f29bea-667b-4780-b36b-59de225e660e";
+        url     = "https://www.wolframcloud.com/obj/" <> uuid;
+        result  = Wolfram`AgentTools`Common`makeNotebookUIResult[
             { <| "type" -> "text", "text" -> "1 + 1 = 2" |> },
             url
         ];
-        marker = Last[ result[ "Content" ] ][ "text" ];
+        content = result[ "Content" ];
+        joined  = StringJoin[ #[ "text" ] & /@ content ];
         {
-            Length @ result[ "Content" ],
-            StringContainsQ[ marker, "<internal>" ] && StringContainsQ[ marker, "</internal>" ],
-            StringContainsQ[ marker, "<url>" <> url <> "</url>" ],
+            (* The single text item is wrapped by an opening and a closing tag item *)
+            Length @ content,
+            StringContainsQ[ joined, "<result uuid=\"" <> uuid <> "\">" ],
+            StringContainsQ[ joined, "</result>" ],
+            (* The original result text is preserved between the tags *)
+            StringContainsQ[ joined, "1 + 1 = 2" ],
             result[ "_meta", "notebookUrl" ],
             (* structuredContent must not be produced: some clients drop content when it is present *)
             KeyExistsQ[ result, "StructuredContent" ]
         }
     ],
     {
-        2,
+        3,
         True,
         True,
-        "https://www.wolframcloud.com/obj/user/AgentTools/Notebooks/deadbeef12345678.nb",
+        True,
+        "https://www.wolframcloud.com/obj/e0f29bea-667b-4780-b36b-59de225e660e",
         False
     },
     SameTest -> MatchQ,
-    TestID   -> "MakeNotebookUIResult-CloudURLAppendsMarker@@Tests/MCPApps.wlt:1272,1-1297,2"
+    TestID   -> "MakeNotebookUIResult-CloudURLWrapsResult"
 ]
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
-(*Marker URL Is Extractable*)
-(* Mirrors the viewers' extraction: the URL must sit inside <url>...</url> within the marker so
-   the client regex <internal>...<url>(...)</url>...</internal> can recover it. *)
+(*Marker UUID Is Recoverable*)
+(* Mirrors the viewers' extraction: the uuid must sit inside <result uuid="..."> in the wrapped
+   content so the client regex <result uuid="(...)"> can recover it and rebuild the cloud URL as
+   https://www.wolframcloud.com/obj/<uuid>. *)
 VerificationTest[
-    Module[ { url, marker },
-        url    = "https://www.wolframcloud.com/obj/u/AgentTools/Notebooks/deadbeef12345678.nb";
-        marker = Wolfram`AgentTools`UIResources`Private`notebookURLMarkerText[ url ];
-        First[
-            StringCases[ marker, "<internal>" ~~ ___ ~~ "<url>" ~~ u: Except[ "<" ].. ~~ "</url>" ~~ ___ ~~ "</internal>" :> u ],
+    Module[ { uuid, url, result, joined, recovered },
+        uuid      = "e0f29bea-667b-4780-b36b-59de225e660e";
+        url       = "https://www.wolframcloud.com/obj/" <> uuid;
+        result    = Wolfram`AgentTools`Common`makeNotebookUIResult[
+            { <| "type" -> "text", "text" -> "x" |> },
+            url
+        ];
+        joined    = StringJoin[ #[ "text" ] & /@ result[ "Content" ] ];
+        recovered = First[
+            StringCases[ joined, "<result uuid=\"" ~~ u: Except[ "\"" ].. ~~ "\">" :> u ],
             None
-        ]
+        ];
+        { recovered, "https://www.wolframcloud.com/obj/" <> recovered }
     ],
-    "https://www.wolframcloud.com/obj/u/AgentTools/Notebooks/deadbeef12345678.nb",
+    {
+        "e0f29bea-667b-4780-b36b-59de225e660e",
+        "https://www.wolframcloud.com/obj/e0f29bea-667b-4780-b36b-59de225e660e"
+    },
     SameTest -> MatchQ,
-    TestID   -> "NotebookURLMarkerText-URLIsExtractable@@Tests/MCPApps.wlt:1304,1-1316,2"
+    TestID   -> "MakeNotebookUIResult-MarkerUUIDRecoverable"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*cloudNotebookUUID Extracts UUID From Deployed URL*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`cloudNotebookUUID[
+        "https://www.wolframcloud.com/obj/e0f29bea-667b-4780-b36b-59de225e660e"
+    ],
+    "e0f29bea-667b-4780-b36b-59de225e660e",
+    SameTest -> MatchQ,
+    TestID   -> "CloudNotebookUUID-ExtractsUUID"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1332,8 +1360,8 @@ VerificationTest[
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*Inline (Non-http) Value Omits Marker*)
-(* Inline notebooks have no reconstructable id, so no marker is appended; the value is still
-   carried in _meta. *)
+(* Inline notebooks carry the whole serialized notebook, so no <result uuid="..."> wrapper is
+   added; the value is still carried in _meta. *)
 VerificationTest[
     Module[ { serialized, result },
         serialized = "Notebook[{Cell[\"1 + 1\", \"Input\"]}]";

--- a/docs/mcp-apps.md
+++ b/docs/mcp-apps.md
@@ -117,15 +117,17 @@ The fallback is additive — nothing changes on eval-permitting hosts. Two const
 
 The `notebookUrl` is delivered to the app through `_meta`, which is meant to reach the app without entering model context. (The MCP Apps spec also defines `structuredContent` for this, but the server deliberately does **not** send it: some clients discard a tool result's `content` — text and images — entirely when `structuredContent` is present, which we do not want.) Some hosts, however, drop `_meta` from tool results ([ext-apps#696](https://github.com/modelcontextprotocol/ext-apps/issues/696)), so the app never receives the URL directly and can only render the text/image fallback. Those same hosts also do not forward app-initiated `resources/read` (they answer it with JSON-RPC `-32601 "Method not found"`), so the app cannot ask the server for the URL either.
 
-The one channel that does survive is the tool result's `content`. So for cloud-notebook results, `makeNotebookUIResult` appends the URL to the content inside a self-describing marker (a separate text item):
+The one channel that does survive is the tool result's `content`. So for cloud-notebook results, `makeNotebookUIResult` wraps the content in a `<result uuid="…">…</result>` marker whose `uuid` identifies the deployed cloud notebook (a text item before and after the result text):
 
 ```
-<internal>This tool call was displayed to the user as an interactive notebook, which they can already see. The URL below only renders that notebook; you do not need to read, repeat, visit, or otherwise use it. <url>https://www.wolframcloud.com/obj/.../56a24661be6b3368.nb</url></internal>
+<result uuid="e0f29bea-667b-4780-b36b-59de225e660e">
+Out[1]= 2543568463
+</result>
 ```
 
-The wrapper text is addressed to the model — it explains that the notebook is already shown and the URL is not for it to act on — while the `<url>` tags let the viewer extract it. When a viewer sees a result with no `notebookUrl` in `_meta`, it falls back to `extractNotebookUrlMarker`, which pulls the URL straight out of the marker (no server round-trip). Each text-rendering viewer also strips the whole `<internal>…</internal>` block (via `stripAgentOnlyText`) so it never reaches the user.
+Notebooks are deployed with `CloudObjectNameFormat -> "UUID"`, so the deployed URL is already `https://www.wolframcloud.com/obj/<uuid>` and the `uuid` is recovered from it with no extra round-trip (`cloudNotebookUUID`). When a viewer sees a result with no `notebookUrl` in `_meta`, it falls back to `extractNotebookUrlMarker`, which reads the `uuid` from the marker and reconstructs the same cloud URL as `https://www.wolframcloud.com/obj/<uuid>`. Each text-rendering viewer also strips the surrounding `<result>` tags (via `stripAgentOnlyText`), keeping the wrapped result text, so the tags never reach the user.
 
-This path applies only to cloud delivery: inline notebooks (`MCP_APPS_NOTEBOOK_METHOD="Inline"`) carry the whole serialized notebook, which is delivered via `_meta` only, so no marker is appended. The `notebook-viewer` app normally receives its URL through the tool **input** (`arguments.url`), which is unaffected by the dropped-`_meta` issue; it applies the same marker recovery only as a fallback when a result arrives without a prior embed.
+This path applies only to cloud delivery: inline notebooks (`MCP_APPS_NOTEBOOK_METHOD="Inline"`) carry the whole serialized notebook, which is delivered via `_meta` only, so no wrapper is added. The `notebook-viewer` app normally receives its URL through the tool **input** (`arguments.url`), which is unaffected by the dropped-`_meta` issue; it applies the same marker recovery only as a fallback when a result arrives without a prior embed.
 
 ## Available UI Resources
 
@@ -261,7 +263,7 @@ Add tests in `Tests/` for the new resource. See the existing test files (`Tests/
 | `$toolUIAssociations` | `Common` | Mapping of tool names to UI resource URIs (entries may be `RuleDelayed` to gate on `$deployCloudNotebooks`) |
 | `$deployCloudNotebooks` | `Common` | Session flag gating cloud notebook deployment; initialized from `$CloudConnected` and set to `False` after a deployment failure |
 | `deployCloudNotebookForMCPApp` | `Common` | Shared helper that delivers a notebook for a UI-enhanced tool result — deploys to the cloud and returns a URL, or returns the serialized notebook when `MCP_APPS_NOTEBOOK_METHOD` is `"Inline"`; disables `$deployCloudNotebooks` on a deploy failure |
-| `makeNotebookUIResult` | `Common` | Builds the UI-enhanced tool result from the text content and the delivered notebook value: carries `notebookUrl` in `_meta` (not `structuredContent`, which some clients treat as a replacement for `content`), and for cloud URLs appends the `<internal>…<url>…</url></internal>` content marker (the dropped-`_meta` workaround); returns `$Failed` when deployment failed |
+| `makeNotebookUIResult` | `Common` | Builds the UI-enhanced tool result from the text content and the delivered notebook value: carries `notebookUrl` in `_meta` (not `structuredContent`, which some clients treat as a replacement for `content`), and for cloud URLs wraps the content in a `<result uuid="…">…</result>` marker (the dropped-`_meta` workaround); returns `$Failed` when deployment failed |
 | `delayedDisplay` | `Common` | Wraps `WolframLanguageEvaluator` output boxes so graphics reconstruct asynchronously when notebooks are embedded inline; a no-op outside inline mode or for graphics-free output |
 | `clientSupportsUIQ` | `Common` | Checks if an `initialize` message advertises UI support |
 | `mcpAppsEnabledQ` | `Common` | Checks the `MCP_APPS_ENABLED` environment variable |


### PR DESCRIPTION
## Summary

Cleans up the `WolframLanguageEvaluator` (and `WolframAlpha`) UI-path tool output when a notebook is embedded. The verbose agent-facing marker is replaced with a compact `<result uuid="…">` wrapper around the output, and the session reminder is shortened to one line.

**Before**

```
Out[1]= 2543568463<internal>This tool call was displayed to the user as an interactive notebook, which they can already see. The URL below only renders that notebook; you do not need to read, repeat, visit, or otherwise use it. <url>https://www.wolframcloud.com/obj/rhennigan/AgentTools/Notebooks/68f8eee5773a415e.nb</url></internal>

<system-reminder>Wolfram session ID: Ei685Jkk. To continue this session (its definitions, line numbers, and history) in your next call to this tool, pass session="Ei685Jkk". Omit the session parameter only to start a new, empty session.</system-reminder>
```

**After**

```
<result uuid="e0f29bea-667b-4780-b36b-59de225e660e">
Out[1]= 2543568463
</result>

<system-reminder>Pass session="Ei685Jkk" in future calls to this tool to continue this session.</system-reminder>
```

## How it works

- Notebooks deploy with `CloudObjectNameFormat -> "UUID"`, so the deployed URL is already `https://www.wolframcloud.com/obj/<uuid>` — no extra `Information` round-trip. The hashed deploy path is kept, so identical evaluations still dedup to one stable object (same path → same UUID).
- `makeNotebookUIResult` wraps the content in `<result uuid="…">…</result>` (`wrapResultTags`); `cloudNotebookUUID` pulls the uuid out of the deployed URL.
- Each viewer (`evaluator`, `wolframalpha`, `notebook`) reconstructs the identical cloud URL from the marker's uuid when a host drops `_meta` ([ext-apps#696](https://github.com/modelcontextprotocol/ext-apps/issues/696)), and `stripAgentOnlyText` removes the `<result>` tags while **preserving the inner result text**.
- URL recovery prefers the **first** marker (the server prepends the opening tag), so a `<result uuid="…">` string appearing in user evaluation output — which can only come after the server's tag — can't hijack the embedded URL.

## Test plan

- [x] `TestReport` on `MCPApps.wlt`, `EvaluatorSessions.wlt`, `WolframLanguageEvaluator-UI.wlt`, `WolframAlpha-UI.wlt` — **158/158 pass**. Includes the rewritten marker tests and a new `cloudNotebookUUID` test.
- [x] `CodeInspector` clean on the changed `.wl` files (only pre-existing `FIXME` warnings remain).
- [x] Real end-to-end deploy of `Prime[123456789]` through the updated pipeline produces exactly the "After" output, with `_meta.notebookUrl`'s uuid matching the marker.
- [x] Viewer JS extracted from the shipped HTML and executed: recovers the URL matching `_meta`, resists the injection case (server's real uuid wins), strips to clean `Out[1]= 2543568463`, and returns `null` when no marker is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXQ4f3K8pZyuMtV2aii21q
