### PR TITLE
Support overriding the default cloud base via WOLFRAM_CLOUDBASE

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -12,6 +12,7 @@
         "buildx",
         "Chatbook",
         "CICD",
+        "CLOUDBASE",
         "cntrl",
         "CodeInspector",
         "Collatz",

--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -202,6 +202,9 @@
         // auto-sized. The frame starts at this height; the user can drag to resize it.
         var NOTEBOOK_IFRAME_HEIGHT = 200;
 
+        // Default base URL for Wolfram Cloud.
+        var WOLFRAM_CLOUDBASE = "https://www.wolframcloud.com";
+
         // ---- Load WolframNotebookEmbedder dynamically ----
         var embedderLoaded = new Promise(function(resolve, reject) {
             var script = document.createElement("script");
@@ -280,7 +283,7 @@
                 if (item && item.type === "text" && typeof item.text === "string") {
                     var m = item.text.match(re);
                     if (m && m[1].trim()) {
-                        return "https://www.wolframcloud.com/obj/" + m[1].trim();
+                        return WOLFRAM_CLOUDBASE + "/obj/" + m[1].trim();
                     }
                 }
             }
@@ -379,12 +382,16 @@
 
         // ---- Restrict the eval-blocked iframe fallback to Wolfram Cloud URLs ----
         // The fallback frames the URL directly (see embedNotebookViaIframe), so only allow
-        // https Wolfram Cloud hosts. A tampered or attacker-controlled result then can't
-        // cause an arbitrary third-party page to load in the iframe. The embedder path is
-        // left unchanged; it still accepts inline notebooks and other targets.
+        // the configured WOLFRAM_CLOUDBASE origin and https Wolfram Cloud hosts. A tampered
+        // or attacker-controlled result then can't cause an arbitrary third-party page to
+        // load in the iframe. The embedder path is left unchanged; it still accepts inline
+        // notebooks and other targets.
         function isWolframCloudUrl(url) {
             try {
                 var u = new URL(url);
+                if (u.origin === new URL(WOLFRAM_CLOUDBASE).origin) {
+                    return true;
+                }
                 return u.protocol === "https:" &&
                     (u.hostname === "wolframcloud.com" || u.hostname.endsWith(".wolframcloud.com"));
             } catch (err) {

--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -283,7 +283,7 @@
                 if (item && item.type === "text" && typeof item.text === "string") {
                     var m = item.text.match(re);
                     if (m && m[1].trim()) {
-                        return WOLFRAM_CLOUDBASE + "/obj/" + m[1].trim();
+                        return WOLFRAM_CLOUDBASE + "/obj/" + m[1].trim() + "?syntaxMethod=editor";
                     }
                 }
             }

--- a/Assets/Apps/notebook-viewer.html
+++ b/Assets/Apps/notebook-viewer.html
@@ -497,7 +497,7 @@
                 if (item && item.type === "text" && typeof item.text === "string") {
                     var m = item.text.match(re);
                     if (m && m[1].trim()) {
-                        return WOLFRAM_CLOUDBASE + "/obj/" + m[1].trim();
+                        return WOLFRAM_CLOUDBASE + "/obj/" + m[1].trim() + "?syntaxMethod=editor";
                     }
                 }
             }

--- a/Assets/Apps/notebook-viewer.html
+++ b/Assets/Apps/notebook-viewer.html
@@ -179,6 +179,9 @@
         // given; either way the frame starts at this height and the user can drag to resize.
         var NOTEBOOK_IFRAME_HEIGHT = 200;
 
+        // Default base URL for Wolfram Cloud.
+        var WOLFRAM_CLOUDBASE = "https://www.wolframcloud.com";
+
         // ---- Load WolframNotebookEmbedder dynamically ----
         var embedderLoaded = new Promise(function(resolve, reject) {
             var script = document.createElement("script");
@@ -348,12 +351,16 @@
 
         // ---- Restrict the eval-blocked iframe fallback to Wolfram Cloud URLs ----
         // The fallback frames the URL directly (see embedNotebookViaIframe), so only allow
-        // https Wolfram Cloud hosts. A tampered or attacker-controlled result then can't
-        // cause an arbitrary third-party page to load in the iframe. The embedder path is
-        // left unchanged; it still accepts inline notebooks and other targets.
+        // the configured WOLFRAM_CLOUDBASE origin and https Wolfram Cloud hosts. A tampered
+        // or attacker-controlled result then can't cause an arbitrary third-party page to
+        // load in the iframe. The embedder path is left unchanged; it still accepts inline
+        // notebooks and other targets.
         function isWolframCloudUrl(url) {
             try {
                 var u = new URL(url);
+                if (u.origin === new URL(WOLFRAM_CLOUDBASE).origin) {
+                    return true;
+                }
                 return u.protocol === "https:" &&
                     (u.hostname === "wolframcloud.com" || u.hostname.endsWith(".wolframcloud.com"));
             } catch (err) {
@@ -490,7 +497,7 @@
                 if (item && item.type === "text" && typeof item.text === "string") {
                     var m = item.text.match(re);
                     if (m && m[1].trim()) {
-                        return "https://www.wolframcloud.com/obj/" + m[1].trim();
+                        return WOLFRAM_CLOUDBASE + "/obj/" + m[1].trim();
                     }
                 }
             }

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -283,6 +283,9 @@
         // auto-sized. The frame starts at this height; the user can drag to resize it.
         var NOTEBOOK_IFRAME_HEIGHT = 200;
 
+        // Default base URL for Wolfram Cloud.
+        var WOLFRAM_CLOUDBASE = "https://www.wolframcloud.com";
+
         // ---- Load WolframNotebookEmbedder dynamically ----
         var embedderLoaded = new Promise(function(resolve, reject) {
             var script = document.createElement("script");
@@ -367,7 +370,7 @@
                 if (item && item.type === "text" && typeof item.text === "string") {
                     var m = item.text.match(re);
                     if (m && m[1].trim()) {
-                        return "https://www.wolframcloud.com/obj/" + m[1].trim();
+                        return WOLFRAM_CLOUDBASE + "/obj/" + m[1].trim();
                     }
                 }
             }
@@ -481,12 +484,16 @@
 
         // ---- Restrict the eval-blocked iframe fallback to Wolfram Cloud URLs ----
         // The fallback frames the URL directly (see embedNotebookViaIframe), so only allow
-        // https Wolfram Cloud hosts. A tampered or attacker-controlled result then can't
-        // cause an arbitrary third-party page to load in the iframe. The embedder path is
-        // left unchanged; it still accepts inline notebooks and other targets.
+        // the configured WOLFRAM_CLOUDBASE origin and https Wolfram Cloud hosts. A tampered
+        // or attacker-controlled result then can't cause an arbitrary third-party page to
+        // load in the iframe. The embedder path is left unchanged; it still accepts inline
+        // notebooks and other targets.
         function isWolframCloudUrl(url) {
             try {
                 var u = new URL(url);
+                if (u.origin === new URL(WOLFRAM_CLOUDBASE).origin) {
+                    return true;
+                }
                 return u.protocol === "https:" &&
                     (u.hostname === "wolframcloud.com" || u.hostname.endsWith(".wolframcloud.com"));
             } catch (err) {

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -370,7 +370,7 @@
                 if (item && item.type === "text" && typeof item.text === "string") {
                     var m = item.text.match(re);
                     if (m && m[1].trim()) {
-                        return WOLFRAM_CLOUDBASE + "/obj/" + m[1].trim();
+                        return WOLFRAM_CLOUDBASE + "/obj/" + m[1].trim() + "?syntaxMethod=editor";
                     }
                 }
             }

--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -180,7 +180,7 @@ startMCPServer // endDefinition;
 setCloudBaseFromEnvironment // beginDefinition;
 
 setCloudBaseFromEnvironment[ ] := setCloudBaseFromEnvironment @ Environment[ "WOLFRAM_CLOUDBASE" ];
-setCloudBaseFromEnvironment[ base_String ] /; StringTrim @ base =!= "" := $CloudBase = StringTrim @ base;
+setCloudBaseFromEnvironment[ base_String ] /; StringTrim @ base =!= "" := (CloudObject; $CloudBase = StringTrim @ base);
 setCloudBaseFromEnvironment[ _ ] := Null;
 
 setCloudBaseFromEnvironment // endDefinition;

--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -108,6 +108,9 @@ startMCPServer[ obj0_MCPServerObject ] := Enclose[
         SetOptions[ First @ Streams[ "stdout" ], CharacterEncoding -> "UTF-8" ];
         SetOptions[ First @ Streams[ "stderr" ], CharacterEncoding -> "UTF-8" ];
 
+        (* Apply any cloud base override before anything uses the cloud: *)
+        setCloudBaseFromEnvironment[ ];
+
         cleanupOldOutputLogs[ ];
 
         logFile = ConfirmBy[ ensureFilePath @ mcpServerLogFile @ obj, fileQ, "LogFile" ];
@@ -165,6 +168,22 @@ startMCPServer[ obj0_MCPServerObject ] := Enclose[
 (* :!CodeAnalysis::EndBlock:: *)
 
 startMCPServer // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*setCloudBaseFromEnvironment*)
+(* Overrides the default cloud base for the server session when the WOLFRAM_CLOUDBASE environment
+   variable is set, e.g. WOLFRAM_CLOUDBASE="https://www.test.wolframcloud.com" (primarily for
+   internal purposes). All cloud operations (MCP Apps notebook deployments, LLMKit subscription
+   checks, etc.) then target that cloud, and UI resources are rewritten to match as they are
+   loaded (see applyCloudBaseToHTML and applyCloudBaseToMeta in UIResources.wl). *)
+setCloudBaseFromEnvironment // beginDefinition;
+
+setCloudBaseFromEnvironment[ ] := setCloudBaseFromEnvironment @ Environment[ "WOLFRAM_CLOUDBASE" ];
+setCloudBaseFromEnvironment[ base_String ] /; StringTrim @ base =!= "" := $CloudBase = StringTrim @ base;
+setCloudBaseFromEnvironment[ _ ] := Null;
+
+setCloudBaseFromEnvironment // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Kernel/UIResources.wl
+++ b/Kernel/UIResources.wl
@@ -35,6 +35,11 @@ $$notebookUUID =
    These can be enabled via the following environment variable: *)
 $mcpAppsNotebookMethod := $mcpAppsNotebookMethod = Environment[ "MCP_APPS_NOTEBOOK_METHOD" ];
 
+(* The production cloud base assumed by the static app assets in Assets/Apps. When $CloudBase
+   differs (e.g. set from the WOLFRAM_CLOUDBASE environment variable at server startup), the
+   assets are rewritten as they are loaded (see applyCloudBaseToHTML and applyCloudBaseToMeta). *)
+$defaultCloudBase = "https://www.wolframcloud.com";
+
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Cloud Notebooks*)
@@ -283,7 +288,7 @@ loadUIResource[ htmlFile_String ] := Enclose[
     Module[ { baseName, uri, html, metaFile, meta },
         baseName = FileBaseName @ htmlFile;
         uri = "ui://wolfram/" <> baseName;
-        html = ConfirmBy[ ByteArrayToString @ ReadByteArray @ htmlFile, StringQ, "HTML" ];
+        html = ConfirmBy[ applyCloudBaseToHTML @ ByteArrayToString @ ReadByteArray @ htmlFile, StringQ, "HTML" ];
         metaFile = FileNameJoin[ { DirectoryName @ htmlFile, baseName <> ".json" } ];
         meta = If[ FileExistsQ @ metaFile,
             Quiet @ Developer`ReadRawJSONString @ ByteArrayToString @ ReadByteArray @ metaFile,
@@ -294,13 +299,93 @@ loadUIResource[ htmlFile_String ] := Enclose[
             "name"     -> baseName,
             "mimeType" -> "text/html;profile=mcp-app",
             "html"     -> html,
-            "meta"     -> Replace[ meta, Except[ _Association ] :> <| |> ]
+            "meta"     -> applyCloudBaseToMeta @ Replace[ meta, Except[ _Association ] :> <| |> ]
         |>
     ],
     throwInternalFailure
 ];
 
 loadUIResource // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*currentCloudBase*)
+(* The cloud base currently in effect, normalized for use in URLs and CSP origins: no trailing
+   slash and an explicit scheme (https:// is assumed when missing, matching the cloud object
+   framework's normalization). Falls back to $defaultCloudBase when $CloudBase is unusable. *)
+currentCloudBase // beginDefinition;
+
+currentCloudBase[ ] := currentCloudBase @ $CloudBase;
+currentCloudBase[ URL[ base_String ] ] := currentCloudBase @ base;
+
+currentCloudBase[ base0_String ] :=
+    With[ { base = StringDelete[ StringTrim @ base0, "/".. ~~ EndOfString ] },
+        Which[
+            StringMatchQ[ base, ("http"|"https") ~~ "://" ~~ __, IgnoreCase -> True ], base,
+            StringFreeQ[ base, "://" ] && base =!= "", "https://" <> base,
+            True, $defaultCloudBase
+        ]
+    ];
+
+currentCloudBase[ _ ] := $defaultCloudBase;
+
+currentCloudBase // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*applyCloudBaseToHTML*)
+(* The viewers cannot read environment variables from their sandboxed JavaScript, so each one
+   declares the cloud base in a `var WOLFRAM_CLOUDBASE = "..."` assignment (used e.g. to
+   reconstruct notebook URLs from <result uuid="..."> markers). When a custom cloud base is in
+   effect, rewrite that assignment as the HTML is read from disk. *)
+applyCloudBaseToHTML // beginDefinition;
+
+applyCloudBaseToHTML[ html_String ] := applyCloudBaseToHTML[ html, currentCloudBase[ ] ];
+
+applyCloudBaseToHTML[ html_String, base_String ] /; base === $defaultCloudBase := html;
+
+applyCloudBaseToHTML[ html_String, base_String ] := StringReplace[
+    html,
+    "var WOLFRAM_CLOUDBASE = \"" <> $defaultCloudBase <> "\";" ->
+        "var WOLFRAM_CLOUDBASE = \"" <> base <> "\";"
+];
+
+applyCloudBaseToHTML // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*applyCloudBaseToMeta*)
+(* The JSON metadata declares CSP domain lists (connectDomains, resourceDomains, frameDomains)
+   that allow the default cloud base. A custom cloud base must also be allowed by the host's
+   sandbox CSP, so prepend it to every list that already allows the default base. The default
+   entries are intentionally kept: production URLs remain reachable (e.g. wolfr.am frames can
+   redirect to production wolframcloud.com). *)
+applyCloudBaseToMeta // beginDefinition;
+
+applyCloudBaseToMeta[ meta_Association ] := applyCloudBaseToMeta[ meta, currentCloudBase[ ] ];
+
+applyCloudBaseToMeta[ meta_Association, base_String ] /; base === $defaultCloudBase := meta;
+
+applyCloudBaseToMeta[ meta_Association, base_String ] :=
+    applyCloudBaseToMeta[ meta, base, meta[ "ui", "csp" ] ];
+
+applyCloudBaseToMeta[ meta_Association, base_String, csp_Association ] :=
+    Module[ { updated = meta },
+        updated[ "ui", "csp" ] = Map[
+            Function[ domains,
+                If[ MatchQ[ domains, { ___String } ] && MemberQ[ domains, $defaultCloudBase ] && ! MemberQ[ domains, base ],
+                    Prepend[ domains, base ],
+                    domains
+                ]
+            ],
+            csp
+        ];
+        updated
+    ];
+
+applyCloudBaseToMeta[ meta_Association, _String, _ ] := meta;
+
+applyCloudBaseToMeta // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)

--- a/Kernel/UIResources.wl
+++ b/Kernel/UIResources.wl
@@ -332,7 +332,7 @@ loadUIResource // endDefinition;
    framework's normalization). Falls back to $defaultCloudBase when $CloudBase is unusable. *)
 currentCloudBase // beginDefinition;
 
-currentCloudBase[ ] := currentCloudBase @ $CloudBase;
+currentCloudBase[ ] := (CloudObject; currentCloudBase @ $CloudBase);
 currentCloudBase[ URL[ base_String ] ] := currentCloudBase @ base;
 
 currentCloudBase[ base0_String ] :=

--- a/Kernel/UIResources.wl
+++ b/Kernel/UIResources.wl
@@ -108,13 +108,30 @@ makeNotebookUIResult // beginDefinition;
 
 makeNotebookUIResult[ textContent_List, deployed_String ] := <|
     "Content" -> wrapResultTags[ textContent, deployed ],
-    "_meta"   -> <| "notebookUrl" -> deployed |>
+    "_meta"   -> <| "notebookUrl" -> notebookEmbedURL @ deployed |>
 |>;
 
 (* Deployment failed (deployCloudNotebookForMCPApp returned $Failed): no UI result. *)
 makeNotebookUIResult[ _List, _ ] := $Failed;
 
 makeNotebookUIResult // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*notebookEmbedURL*)
+(* The notebookUrl delivered to viewers via _meta: the deployed cloud URL with a
+   syntaxMethod=editor query parameter appended. The viewers append the same parameter when
+   reconstructing a URL from a <result uuid="..."> marker (extractNotebookUrlMarker), so the
+   two delivery paths must stay in sync. Non-URL values (inline serialized notebooks) pass
+   through unchanged. *)
+notebookEmbedURL // beginDefinition;
+
+notebookEmbedURL[ url_String ] /; StringStartsQ[ url, "http" ] :=
+    url <> If[ StringFreeQ[ url, "?" ], "?", "&" ] <> "syntaxMethod=editor";
+
+notebookEmbedURL[ other_ ] := other;
+
+notebookEmbedURL // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Tests/CloudBase.wlt
+++ b/Tests/CloudBase.wlt
@@ -1,0 +1,372 @@
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`AgentToolsTests`", FileNameJoin @ { DirectoryName @ $TestFileName, "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions@@Tests/CloudBase.wlt:7,1-12,2"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`AgentTools`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext@@Tests/CloudBase.wlt:14,1-19,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*setCloudBaseFromEnvironment*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Environment Variable Set*)
+VerificationTest[
+    environmentBlock[ "WOLFRAM_CLOUDBASE" -> "https://www.test.wolframcloud.com",
+        Block[ { $CloudBase },
+            Wolfram`AgentTools`StartMCPServer`Private`setCloudBaseFromEnvironment[ ];
+            $CloudBase
+        ]
+    ],
+    "https://www.test.wolframcloud.com",
+    SameTest -> Equal,
+    TestID   -> "SetCloudBaseFromEnvironment-Set@@Tests/CloudBase.wlt:28,1-38,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Whitespace Is Trimmed*)
+VerificationTest[
+    environmentBlock[ "WOLFRAM_CLOUDBASE" -> "  https://www.test.wolframcloud.com  ",
+        Block[ { $CloudBase },
+            Wolfram`AgentTools`StartMCPServer`Private`setCloudBaseFromEnvironment[ ];
+            $CloudBase
+        ]
+    ],
+    "https://www.test.wolframcloud.com",
+    SameTest -> Equal,
+    TestID   -> "SetCloudBaseFromEnvironment-Trimmed@@Tests/CloudBase.wlt:43,1-53,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Environment Variable Not Set*)
+VerificationTest[
+    environmentBlock[ "WOLFRAM_CLOUDBASE" -> None,
+        Block[ { $CloudBase = "sentinel" },
+            Wolfram`AgentTools`StartMCPServer`Private`setCloudBaseFromEnvironment[ ];
+            $CloudBase
+        ]
+    ],
+    "sentinel",
+    SameTest -> Equal,
+    TestID   -> "SetCloudBaseFromEnvironment-NotSet@@Tests/CloudBase.wlt:58,1-68,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Empty Value Is Ignored*)
+VerificationTest[
+    environmentBlock[ "WOLFRAM_CLOUDBASE" -> "   ",
+        Block[ { $CloudBase = "sentinel" },
+            Wolfram`AgentTools`StartMCPServer`Private`setCloudBaseFromEnvironment[ ];
+            $CloudBase
+        ]
+    ],
+    "sentinel",
+    SameTest -> Equal,
+    TestID   -> "SetCloudBaseFromEnvironment-Empty@@Tests/CloudBase.wlt:73,1-83,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*currentCloudBase*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Default Cloud Base*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`currentCloudBase[ "https://www.wolframcloud.com" ],
+    "https://www.wolframcloud.com",
+    SameTest -> Equal,
+    TestID   -> "CurrentCloudBase-Default@@Tests/CloudBase.wlt:92,1-97,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Trailing Slash Is Stripped*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`currentCloudBase[ "https://www.test.wolframcloud.com/" ],
+    "https://www.test.wolframcloud.com",
+    SameTest -> Equal,
+    TestID   -> "CurrentCloudBase-TrailingSlash@@Tests/CloudBase.wlt:102,1-107,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Scheme Is Added When Missing*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`currentCloudBase[ "www.test.wolframcloud.com" ],
+    "https://www.test.wolframcloud.com",
+    SameTest -> Equal,
+    TestID   -> "CurrentCloudBase-NoScheme@@Tests/CloudBase.wlt:112,1-117,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Non-String Falls Back To Default*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`currentCloudBase[ $Failed ],
+    "https://www.wolframcloud.com",
+    SameTest -> Equal,
+    TestID   -> "CurrentCloudBase-NonString@@Tests/CloudBase.wlt:122,1-127,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`currentCloudBase[ "" ],
+    "https://www.wolframcloud.com",
+    SameTest -> Equal,
+    TestID   -> "CurrentCloudBase-EmptyString@@Tests/CloudBase.wlt:129,1-134,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Reads $CloudBase*)
+VerificationTest[
+    Block[ { $CloudBase = "https://www.test.wolframcloud.com" },
+        Wolfram`AgentTools`UIResources`Private`currentCloudBase[ ]
+    ],
+    "https://www.test.wolframcloud.com",
+    SameTest -> Equal,
+    TestID   -> "CurrentCloudBase-ReadsCloudBase@@Tests/CloudBase.wlt:139,1-146,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*applyCloudBaseToHTML*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Rewrites the Assignment*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`applyCloudBaseToHTML[
+        "<script>var WOLFRAM_CLOUDBASE = \"https://www.wolframcloud.com\";</script>",
+        "https://www.test.wolframcloud.com"
+    ],
+    "<script>var WOLFRAM_CLOUDBASE = \"https://www.test.wolframcloud.com\";</script>",
+    SameTest -> Equal,
+    TestID   -> "ApplyCloudBaseToHTML-Rewrites@@Tests/CloudBase.wlt:155,1-163,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*No-Op For Default Base*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`applyCloudBaseToHTML[
+        "<script>var WOLFRAM_CLOUDBASE = \"https://www.wolframcloud.com\";</script>",
+        "https://www.wolframcloud.com"
+    ],
+    "<script>var WOLFRAM_CLOUDBASE = \"https://www.wolframcloud.com\";</script>",
+    SameTest -> Equal,
+    TestID   -> "ApplyCloudBaseToHTML-DefaultNoOp@@Tests/CloudBase.wlt:168,1-176,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*HTML Without the Assignment Is Unchanged*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`applyCloudBaseToHTML[
+        "<html><body>Test</body></html>",
+        "https://www.test.wolframcloud.com"
+    ],
+    "<html><body>Test</body></html>",
+    SameTest -> Equal,
+    TestID   -> "ApplyCloudBaseToHTML-NoAssignment@@Tests/CloudBase.wlt:181,1-189,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*applyCloudBaseToMeta*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Prepends Custom Base To CSP Lists*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`applyCloudBaseToMeta[
+        <|
+            "ui" -> <|
+                "csp" -> <|
+                    "connectDomains"  -> { "https://www.wolframcloud.com", "data:" },
+                    "resourceDomains" -> { "https://unpkg.com", "https://www.wolframcloud.com" },
+                    "frameDomains"    -> { "https://www.wolframcloud.com", "https://wolfr.am" }
+                |>,
+                "prefersBorder" -> True
+            |>
+        |>,
+        "https://www.test.wolframcloud.com"
+    ],
+    <|
+        "ui" -> <|
+            "csp" -> <|
+                "connectDomains"  -> { "https://www.test.wolframcloud.com", "https://www.wolframcloud.com", "data:" },
+                "resourceDomains" -> { "https://www.test.wolframcloud.com", "https://unpkg.com", "https://www.wolframcloud.com" },
+                "frameDomains"    -> { "https://www.test.wolframcloud.com", "https://www.wolframcloud.com", "https://wolfr.am" }
+            |>,
+            "prefersBorder" -> True
+        |>
+    |>,
+    SameTest -> Equal,
+    TestID   -> "ApplyCloudBaseToMeta-Prepends@@Tests/CloudBase.wlt:198,1-224,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Lists Without the Default Base Are Unchanged*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`applyCloudBaseToMeta[
+        <| "ui" -> <| "csp" -> <| "resourceDomains" -> { "https://unpkg.com" } |> |> |>,
+        "https://www.test.wolframcloud.com"
+    ],
+    <| "ui" -> <| "csp" -> <| "resourceDomains" -> { "https://unpkg.com" } |> |> |>,
+    SameTest -> Equal,
+    TestID   -> "ApplyCloudBaseToMeta-UnrelatedListUnchanged@@Tests/CloudBase.wlt:229,1-237,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*No-Op For Default Base*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`applyCloudBaseToMeta[
+        <| "ui" -> <| "csp" -> <| "connectDomains" -> { "https://www.wolframcloud.com", "data:" } |> |> |>,
+        "https://www.wolframcloud.com"
+    ],
+    <| "ui" -> <| "csp" -> <| "connectDomains" -> { "https://www.wolframcloud.com", "data:" } |> |> |>,
+    SameTest -> Equal,
+    TestID   -> "ApplyCloudBaseToMeta-DefaultNoOp@@Tests/CloudBase.wlt:242,1-250,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Meta Without CSP Is Unchanged*)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`applyCloudBaseToMeta[
+        <| "ui" -> <| "prefersBorder" -> True |> |>,
+        "https://www.test.wolframcloud.com"
+    ],
+    <| "ui" -> <| "prefersBorder" -> True |> |>,
+    SameTest -> Equal,
+    TestID   -> "ApplyCloudBaseToMeta-NoCSP@@Tests/CloudBase.wlt:255,1-263,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`applyCloudBaseToMeta[
+        <| |>,
+        "https://www.test.wolframcloud.com"
+    ],
+    <| |>,
+    SameTest -> Equal,
+    TestID   -> "ApplyCloudBaseToMeta-EmptyMeta@@Tests/CloudBase.wlt:265,1-273,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Idempotent*)
+VerificationTest[
+    Module[ { meta, once },
+        meta = <| "ui" -> <| "csp" -> <| "connectDomains" -> { "https://www.wolframcloud.com", "data:" } |> |> |>;
+        once = Wolfram`AgentTools`UIResources`Private`applyCloudBaseToMeta[ meta, "https://www.test.wolframcloud.com" ];
+        Wolfram`AgentTools`UIResources`Private`applyCloudBaseToMeta[ once, "https://www.test.wolframcloud.com" ] === once
+    ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "ApplyCloudBaseToMeta-Idempotent@@Tests/CloudBase.wlt:278,1-287,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Integration With Bundled App Assets*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Viewers Declare the Default Assignment*)
+(* Guards against the `var WOLFRAM_CLOUDBASE = "..."` declaration drifting out of the viewer
+   HTML files: the string replacement in applyCloudBaseToHTML would then silently stop working. *)
+VerificationTest[
+    Module[ { html }, Block[ { $CloudBase = "https://www.wolframcloud.com", Wolfram`AgentTools`Common`$uiResourceRegistry },
+        Wolfram`AgentTools`Common`initializeUIResources[ ];
+        AllTrue[
+            { "ui://wolfram/evaluator-viewer", "ui://wolfram/notebook-viewer", "ui://wolfram/wolframalpha-viewer" },
+            ( html = Wolfram`AgentTools`Common`$uiResourceRegistry[ #, "html" ];
+              StringContainsQ[ html, "var WOLFRAM_CLOUDBASE = \"https://www.wolframcloud.com\";" ] ) &
+        ]
+    ] ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "CloudBaseIntegration-DefaultAssignmentPresent@@Tests/CloudBase.wlt:298,1-310,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Custom Base Rewrites All Viewers*)
+VerificationTest[
+    Module[ { html }, Block[ { $CloudBase = "https://www.test.wolframcloud.com", Wolfram`AgentTools`Common`$uiResourceRegistry },
+        Wolfram`AgentTools`Common`initializeUIResources[ ];
+        AllTrue[
+            { "ui://wolfram/evaluator-viewer", "ui://wolfram/notebook-viewer", "ui://wolfram/wolframalpha-viewer" },
+            ( html = Wolfram`AgentTools`Common`$uiResourceRegistry[ #, "html" ];
+              StringContainsQ[ html, "var WOLFRAM_CLOUDBASE = \"https://www.test.wolframcloud.com\";" ] &&
+              StringFreeQ[ html, "var WOLFRAM_CLOUDBASE = \"https://www.wolframcloud.com\";" ] ) &
+        ]
+    ] ],
+    True,
+    SameTest -> Equal,
+    TestID   -> "CloudBaseIntegration-CustomBaseRewritesViewers@@Tests/CloudBase.wlt:315,1-328,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Custom Base Augments CSP Metadata*)
+VerificationTest[
+    Block[ { $CloudBase = "https://www.test.wolframcloud.com", Wolfram`AgentTools`Common`$uiResourceRegistry },
+        Wolfram`AgentTools`Common`initializeUIResources[ ];
+        Wolfram`AgentTools`Common`$uiResourceRegistry[
+            "ui://wolfram/evaluator-viewer", "meta", "ui", "csp", "connectDomains"
+        ]
+    ],
+    { "https://www.test.wolframcloud.com", "https://www.wolframcloud.com", "data:" },
+    SameTest -> Equal,
+    TestID   -> "CloudBaseIntegration-CustomBaseConnectDomains@@Tests/CloudBase.wlt:333,1-343,2"
+]
+
+VerificationTest[
+    Block[ { $CloudBase = "https://www.test.wolframcloud.com", Wolfram`AgentTools`Common`$uiResourceRegistry },
+        Wolfram`AgentTools`Common`initializeUIResources[ ];
+        Wolfram`AgentTools`Common`$uiResourceRegistry[
+            "ui://wolfram/evaluator-viewer", "meta", "ui", "csp", "frameDomains"
+        ]
+    ],
+    { "https://www.test.wolframcloud.com", "https://www.wolframcloud.com", "https://wolfr.am" },
+    SameTest -> Equal,
+    TestID   -> "CloudBaseIntegration-CustomBaseFrameDomains@@Tests/CloudBase.wlt:345,1-355,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Default Base Leaves CSP Metadata Unchanged*)
+VerificationTest[
+    Block[ { $CloudBase = "https://www.wolframcloud.com", Wolfram`AgentTools`Common`$uiResourceRegistry },
+        Wolfram`AgentTools`Common`initializeUIResources[ ];
+        Wolfram`AgentTools`Common`$uiResourceRegistry[
+            "ui://wolfram/evaluator-viewer", "meta", "ui", "csp", "connectDomains"
+        ]
+    ],
+    { "https://www.wolframcloud.com", "data:" },
+    SameTest -> Equal,
+    TestID   -> "CloudBaseIntegration-DefaultBaseCSPUnchanged@@Tests/CloudBase.wlt:360,1-370,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/MCPApps.wlt
+++ b/Tests/MCPApps.wlt
@@ -1296,11 +1296,11 @@ VerificationTest[
         True,
         True,
         True,
-        "https://www.wolframcloud.com/obj/e0f29bea-667b-4780-b36b-59de225e660e",
+        "https://www.wolframcloud.com/obj/e0f29bea-667b-4780-b36b-59de225e660e?syntaxMethod=editor",
         False
     },
     SameTest -> MatchQ,
-    TestID   -> "MakeNotebookUIResult-CloudURLWrapsResult"
+    TestID   -> "MakeNotebookUIResult-CloudURLWrapsResult@@Tests/MCPApps.wlt:1272,1-1304,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1329,7 +1329,37 @@ VerificationTest[
         "https://www.wolframcloud.com/obj/e0f29bea-667b-4780-b36b-59de225e660e"
     },
     SameTest -> MatchQ,
-    TestID   -> "MakeNotebookUIResult-MarkerUUIDRecoverable"
+    TestID   -> "MakeNotebookUIResult-MarkerUUIDRecoverable@@Tests/MCPApps.wlt:1312,1-1333,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*notebookEmbedURL Appends the Syntax Method Parameter*)
+(* The parameter must match the one the viewers append when reconstructing a URL from the
+   <result uuid="..."> marker, so both delivery paths open the notebook the same way. *)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`notebookEmbedURL[
+        "https://www.wolframcloud.com/obj/e0f29bea-667b-4780-b36b-59de225e660e"
+    ],
+    "https://www.wolframcloud.com/obj/e0f29bea-667b-4780-b36b-59de225e660e?syntaxMethod=editor",
+    SameTest -> Equal,
+    TestID   -> "NotebookEmbedURL-AppendsParameter@@Tests/MCPApps.wlt:1340,1-1347,2"
+]
+
+(* A URL that already has a query string gets the parameter appended with & *)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`notebookEmbedURL[ "https://www.wolframcloud.com/obj/x?a=1" ],
+    "https://www.wolframcloud.com/obj/x?a=1&syntaxMethod=editor",
+    SameTest -> Equal,
+    TestID   -> "NotebookEmbedURL-AppendsToExistingQuery@@Tests/MCPApps.wlt:1350,1-1355,2"
+]
+
+(* Inline serialized notebooks are not URLs and pass through unchanged *)
+VerificationTest[
+    Wolfram`AgentTools`UIResources`Private`notebookEmbedURL[ "Notebook[{Cell[\"1 + 1\", \"Input\"]}]" ],
+    "Notebook[{Cell[\"1 + 1\", \"Input\"]}]",
+    SameTest -> Equal,
+    TestID   -> "NotebookEmbedURL-InlinePassthrough@@Tests/MCPApps.wlt:1358,1-1363,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1341,7 +1371,7 @@ VerificationTest[
     ],
     "e0f29bea-667b-4780-b36b-59de225e660e",
     SameTest -> MatchQ,
-    TestID   -> "CloudNotebookUUID-ExtractsUUID"
+    TestID   -> "CloudNotebookUUID-ExtractsUUID@@Tests/MCPApps.wlt:1368,1-1375,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1354,7 +1384,7 @@ VerificationTest[
     ],
     $Failed,
     SameTest -> MatchQ,
-    TestID   -> "MakeNotebookUIResult-DeployFailed@@Tests/MCPApps.wlt:1321,1-1329,2"
+    TestID   -> "MakeNotebookUIResult-DeployFailed@@Tests/MCPApps.wlt:1380,1-1388,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1376,7 +1406,7 @@ VerificationTest[
         "Notebook[{Cell[\"1 + 1\", \"Input\"]}]"
     },
     SameTest -> MatchQ,
-    TestID   -> "MakeNotebookUIResult-InlineNoMarker@@Tests/MCPApps.wlt:1336,1-1351,2"
+    TestID   -> "MakeNotebookUIResult-InlineNoMarker@@Tests/MCPApps.wlt:1395,1-1410,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1392,7 +1422,7 @@ VerificationTest[
     ],
     _DynamicModuleBox,
     SameTest -> MatchQ,
-    TestID   -> "DelayedDisplay-InlineWrapsGraphics@@Tests/MCPApps.wlt:1360,1-1367,2"
+    TestID   -> "DelayedDisplay-InlineWrapsGraphics@@Tests/MCPApps.wlt:1419,1-1426,2"
 ]
 
 VerificationTest[
@@ -1401,7 +1431,7 @@ VerificationTest[
     ],
     _DynamicModuleBox,
     SameTest -> MatchQ,
-    TestID   -> "DelayedDisplay-InlineWrapsGraphics3D@@Tests/MCPApps.wlt:1369,1-1376,2"
+    TestID   -> "DelayedDisplay-InlineWrapsGraphics3D@@Tests/MCPApps.wlt:1428,1-1435,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1413,7 +1443,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "DelayedDisplay-InlineSerializesGraphics@@Tests/MCPApps.wlt:1381,1-1388,2"
+    TestID   -> "DelayedDisplay-InlineSerializesGraphics@@Tests/MCPApps.wlt:1440,1-1447,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1425,7 +1455,7 @@ VerificationTest[
     ],
     RowBox @ { "1", "+", "1" },
     SameTest -> MatchQ,
-    TestID   -> "DelayedDisplay-InlineGraphicsFreeUnchanged@@Tests/MCPApps.wlt:1393,1-1400,2"
+    TestID   -> "DelayedDisplay-InlineGraphicsFreeUnchanged@@Tests/MCPApps.wlt:1452,1-1459,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1439,7 +1469,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "DelayedDisplay-NonInlineNoOp@@Tests/MCPApps.wlt:1405,1-1414,2"
+    TestID   -> "DelayedDisplay-NonInlineNoOp@@Tests/MCPApps.wlt:1464,1-1473,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1462,7 +1492,7 @@ VerificationTest[
     ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "EvaluatorViewer-EvalCSPFallbackPresent@@Tests/MCPApps.wlt:1428,1-1437,2"
+    TestID   -> "EvaluatorViewer-EvalCSPFallbackPresent@@Tests/MCPApps.wlt:1487,1-1496,2"
 ]
 
 VerificationTest[
@@ -1473,7 +1503,7 @@ VerificationTest[
     ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "WolframAlphaViewer-EvalCSPFallbackPresent@@Tests/MCPApps.wlt:1439,1-1448,2"
+    TestID   -> "WolframAlphaViewer-EvalCSPFallbackPresent@@Tests/MCPApps.wlt:1498,1-1507,2"
 ]
 
 VerificationTest[
@@ -1484,7 +1514,7 @@ VerificationTest[
     ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "NotebookViewer-EvalCSPFallbackPresent@@Tests/MCPApps.wlt:1450,1-1459,2"
+    TestID   -> "NotebookViewer-EvalCSPFallbackPresent@@Tests/MCPApps.wlt:1509,1-1518,2"
 ]
 
 (* The eval-blocked iframe fallback can't be auto-sized, so each viewer must let the user
@@ -1503,7 +1533,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "NotebookViewers-IframeFallbackResizable@@Tests/MCPApps.wlt:1464,1-1478,2"
+    TestID   -> "NotebookViewers-IframeFallbackResizable@@Tests/MCPApps.wlt:1523,1-1537,2"
 ]
 
 (* The resize drag's move/end listeners live on window, so each viewer must scope them to the
@@ -1522,7 +1552,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "NotebookViewers-ResizeDragScopedToPointer"
+    TestID   -> "NotebookViewers-ResizeDragScopedToPointer@@Tests/MCPApps.wlt:1542,1-1556,2"
 ]
 
 (* The embedder path must remain for hosts whose CSP does permit eval (fit-to-content sizing),
@@ -1540,7 +1570,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "NotebookViewers-EmbedderPathRetained@@Tests/MCPApps.wlt:1482,1-1496,2"
+    TestID   -> "NotebookViewers-EmbedderPathRetained@@Tests/MCPApps.wlt:1560,1-1574,2"
 ]
 
 (* Under strict CSP the fallback frames the notebook URL directly, so each viewer must
@@ -1560,7 +1590,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "NotebookViewers-IframeFallbackCloudAllowlist"
+    TestID   -> "NotebookViewers-IframeFallbackCloudAllowlist@@Tests/MCPApps.wlt:1579,1-1594,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/docs/mcp-apps.md
+++ b/docs/mcp-apps.md
@@ -129,6 +129,19 @@ Notebooks are deployed with `CloudObjectNameFormat -> "UUID"`, so the deployed U
 
 This path applies only to cloud delivery: inline notebooks (`MCP_APPS_NOTEBOOK_METHOD="Inline"`) carry the whole serialized notebook, which is delivered via `_meta` only, so no wrapper is added. The `notebook-viewer` app normally receives its URL through the tool **input** (`arguments.url`), which is unaffected by the dropped-`_meta` issue; it applies the same marker recovery only as a fallback when a result arrives without a prior embed.
 
+### Custom Cloud Base
+
+All cloud URLs above assume the production cloud, `https://www.wolframcloud.com`. Setting the `WOLFRAM_CLOUDBASE` environment variable (primarily for internal purposes) points the server at a different cloud:
+
+```json
+"env": { "WOLFRAM_CLOUDBASE": "https://www.test.wolframcloud.com" }
+```
+
+At server startup, `setCloudBaseFromEnvironment` assigns the value to `$CloudBase`, so notebook deployments (and every other cloud operation) target that cloud. The static app assets are adjusted to match as they are loaded from disk (`loadUIResource`):
+
+- Each viewer declares the cloud base in a `var WOLFRAM_CLOUDBASE = "https://www.wolframcloud.com";` assignment, which it uses to reconstruct notebook URLs from `<result uuid="…">` markers and to accept the configured origin in the iframe-fallback URL check (`isWolframCloudUrl`). The sandboxed JavaScript cannot read environment variables, so `applyCloudBaseToHTML` rewrites this assignment via string replacement when the HTML is read.
+- The JSON metadata's CSP domain lists (`connectDomains`, `resourceDomains`, `frameDomains`) must also allow the custom cloud, so `applyCloudBaseToMeta` prepends the custom base to every list that allows the default base. The default entries are kept so production URLs remain reachable (e.g. `wolfr.am` frames can redirect to production).
+
 ## Available UI Resources
 
 | URI | HTML Asset | Description |
@@ -272,6 +285,9 @@ Add tests in `Tests/` for the new resource. See the existing test files (`Tests/
 | `readUIResource` | `Common` | Handles `resources/read` requests |
 | `toolUIMetadata` | `Common` | Returns `_meta.ui` for a tool name |
 | `withToolUIMetadata` | `Common` | Augments a tool list with UI metadata |
+| `setCloudBaseFromEnvironment` | `StartMCPServer` (private) | Applies the `WOLFRAM_CLOUDBASE` environment variable to `$CloudBase` at server startup |
+| `applyCloudBaseToHTML` | `UIResources` (private) | Rewrites a viewer's `var WOLFRAM_CLOUDBASE = "…"` assignment when a custom cloud base is in effect |
+| `applyCloudBaseToMeta` | `UIResources` (private) | Prepends a custom cloud base to the CSP domain lists in app JSON metadata |
 
 ## Related Documentation
 

--- a/docs/mcp-apps.md
+++ b/docs/mcp-apps.md
@@ -125,7 +125,7 @@ Out[1]= 2543568463
 </result>
 ```
 
-Notebooks are deployed with `CloudObjectNameFormat -> "UUID"`, so the deployed URL is already `https://www.wolframcloud.com/obj/<uuid>` and the `uuid` is recovered from it with no extra round-trip (`cloudNotebookUUID`). When a viewer sees a result with no `notebookUrl` in `_meta`, it falls back to `extractNotebookUrlMarker`, which reads the `uuid` from the marker and reconstructs the same cloud URL as `https://www.wolframcloud.com/obj/<uuid>`. Each text-rendering viewer also strips the surrounding `<result>` tags (via `stripAgentOnlyText`), keeping the wrapped result text, so the tags never reach the user.
+Notebooks are deployed with `CloudObjectNameFormat -> "UUID"`, so the deployed URL is already `https://www.wolframcloud.com/obj/<uuid>` and the `uuid` is recovered from it with no extra round-trip (`cloudNotebookUUID`). When a viewer sees a result with no `notebookUrl` in `_meta`, it falls back to `extractNotebookUrlMarker`, which reads the `uuid` from the marker and reconstructs the same cloud URL as `https://www.wolframcloud.com/obj/<uuid>`. Both delivery paths carry a `syntaxMethod=editor` query parameter on the embedded-notebook URL: the server appends it to `notebookUrl` (`notebookEmbedURL`), and the viewers append the same parameter when reconstructing from the marker — the two must stay in sync. Each text-rendering viewer also strips the surrounding `<result>` tags (via `stripAgentOnlyText`), keeping the wrapped result text, so the tags never reach the user.
 
 This path applies only to cloud delivery: inline notebooks (`MCP_APPS_NOTEBOOK_METHOD="Inline"`) carry the whole serialized notebook, which is delivered via `_meta` only, so no wrapper is added. The `notebook-viewer` app normally receives its URL through the tool **input** (`arguments.url`), which is unaffected by the dropped-`_meta` issue; it applies the same marker recovery only as a fallback when a result arrives without a prior embed.
 
@@ -285,6 +285,7 @@ Add tests in `Tests/` for the new resource. See the existing test files (`Tests/
 | `readUIResource` | `Common` | Handles `resources/read` requests |
 | `toolUIMetadata` | `Common` | Returns `_meta.ui` for a tool name |
 | `withToolUIMetadata` | `Common` | Augments a tool list with UI metadata |
+| `notebookEmbedURL` | `UIResources` (private) | Appends the `syntaxMethod=editor` query parameter to a deployed notebook URL for `_meta.notebookUrl`; inline (non-URL) values pass through |
 | `setCloudBaseFromEnvironment` | `StartMCPServer` (private) | Applies the `WOLFRAM_CLOUDBASE` environment variable to `$CloudBase` at server startup |
 | `applyCloudBaseToHTML` | `UIResources` (private) | Rewrites a viewer's `var WOLFRAM_CLOUDBASE = "…"` assignment when a custom cloud base is in effect |
 | `applyCloudBaseToMeta` | `UIResources` (private) | Prepends a custom cloud base to the CSP domain lists in app JSON metadata |

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -562,6 +562,7 @@ Include these environment variables for proper operation:
 | `APPDATA` | (Windows only) Path to application data (typically `ParentDirectory[$UserBaseDirectory]`) |
 | `MCP_APPS_ENABLED` | Set to `"false"` to disable [MCP Apps](mcp-apps.md) UI resources (optional) |
 | `MCP_APPS_NOTEBOOK_METHOD` | Set to `"Inline"` to embed [MCP Apps](mcp-apps.md) notebooks inline instead of deploying them to the cloud (experimental, optional) |
+| `WOLFRAM_CLOUDBASE` | Set to a cloud base URL (e.g. `"https://www.test.wolframcloud.com"`) to override `$CloudBase` for the server session; cloud URLs in [MCP Apps](mcp-apps.md) assets are rewritten to match (optional, primarily for internal purposes) |
 | `LLMKIT_ENABLED` | Set to `"false"` to make the context tools (`WolframContext`, etc.) behave as if the user has no LLMKit subscription, without emitting subscription warnings (optional) |
 | `MCP_TOOL_OPTIONS` | JSON string of tool option overrides, set automatically by `"ToolOptions"` (optional) |
 


### PR DESCRIPTION
## Summary

Adds support for pointing an MCP server at a non-production Wolfram Cloud (primarily for internal purposes) by setting the `WOLFRAM_CLOUDBASE` environment variable, e.g.:

```json
"env": { "WOLFRAM_CLOUDBASE": "https://www.test.wolframcloud.com" }
```

- **Server startup** (`Kernel/StartMCPServer.wl`): `setCloudBaseFromEnvironment` applies the variable to `$CloudBase` before anything touches the cloud, so notebook deployments for MCP Apps, LLMKit checks, and all other cloud operations target the configured cloud. The name follows `WOLFRAM_USERBASE`/`WOLFRAM_LOCALBASE`.
- **MCP Apps HTML assets** (`Kernel/UIResources.wl`, `Assets/Apps/*.html`): the sandboxed viewer JavaScript cannot read environment variables, so each viewer declares a `var WOLFRAM_CLOUDBASE = "https://www.wolframcloud.com";` constant (used to reconstruct notebook URLs from `<result uuid="...">` markers and to validate iframe-fallback URLs), and `applyCloudBaseToHTML` rewrites that assignment via string replacement as the HTML is loaded from disk. The viewers' `isWolframCloudUrl` check also accepts the configured origin so the eval-blocked iframe fallback works on clouds outside `*.wolframcloud.com`.
- **MCP Apps JSON metadata**: `applyCloudBaseToMeta` prepends the custom base to each CSP domain list (`connectDomains`/`resourceDomains`/`frameDomains`) that allows the default base. Production entries are kept so e.g. `wolfr.am` frames can still redirect to production.
- Cloud base values are normalized (`currentCloudBase`): trailing slashes are stripped and `https://` is assumed when no scheme is given. Notably, the kernel default `$CloudBase` is `"https://www.wolframcloud.com/"` (trailing slash), so normalization is what keeps the default case a no-op.

Also appends a `syntaxMethod=editor` query parameter to embedded cloud notebook URLs on both delivery paths: the viewers add it when reconstructing a URL from a uuid marker, and `notebookEmbedURL` adds it to the URL delivered via `_meta.notebookUrl` (inline serialized notebooks pass through unchanged).

## Test plan

- [x] New `Tests/CloudBase.wlt` (26 tests): `setCloudBaseFromEnvironment` (set/unset/empty/whitespace via `environmentBlock`), `currentCloudBase` normalization, `applyCloudBaseToHTML` rewrite/no-op, `applyCloudBaseToMeta` CSP augmentation (idempotent, default no-op), and integration tests over the real bundled assets verifying all three viewers rewrite and the CSP lists augment under a custom `$CloudBase`
- [x] New `notebookEmbedURL` unit tests and updated `makeNotebookUIResult` expectations in `Tests/MCPApps.wlt`
- [x] Full affected suites green (fresh kernels): `CloudBase`, `MCPApps`, `NotebookViewer`, `StartMCPServer`, `MCPAppsTest`, `WolframAlpha-UI`, `WolframLanguageEvaluator-UI`, `EvaluatorSessions`
- [x] CodeInspector clean on all modified source and test files
- [x] End-to-end check in a live kernel: with `WOLFRAM_CLOUDBASE` set, `initializeUIResources` + `resources/read` return HTML containing the rewritten cloud base assignment (default assignment absent), augmented CSP lists in `_meta`, and the full response serializes to JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VggfYtGCVeTJFxUrMuFHb5