### PR TITLE
Fix JSON encoding errors caused by PUA characters in MCP output

### DIFF
--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -113,6 +113,9 @@ BeginPackage[ "Wolfram`AgentTools`Common`" ];
 `writeError;
 `writeLog;
 
+(* Output sanitization: *)
+`sanitizeResponse;
+
 (* MCP client requests / server-to-client traffic: *)
 `$mcpClientRequests;
 `handleClientResponse;

--- a/Kernel/MCPClientRequests.wl
+++ b/Kernel/MCPClientRequests.wl
@@ -30,7 +30,7 @@ sendClientRequest[ method_String, params_, handler_ ] :=
             "request" -> request,
             "handler" -> handler
         |>;
-        WriteLine[ "stdout", Developer`WriteRawJSONString[ request, "Compact" -> True ] ];
+        WriteLine[ "stdout", Developer`WriteRawJSONString[ sanitizeResponse @ request, "Compact" -> True ] ];
         writeLog[ "ClientRequest" -> request ];
         uuid
     ];

--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -990,7 +990,8 @@ toPrintableASCII // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*sanitizeResponse*)
-(* Applies convertPUACharacters to every string in a response before it is encoded as JSON.
+(* Applies convertPUACharacters to every string in an outgoing message (a response or a
+   server-to-client request) before it is encoded as JSON.
    Sanitizing must happen before JSON encoding: the converted output can contain backslash
    sequences or raw control characters, which would corrupt an already-encoded JSON document. *)
 sanitizeResponse // beginDefinition;

--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -958,6 +958,7 @@ safeString[ failure: Failure[ "AgentTools::Internal" | "General::ChatbookInterna
     ];
 
 safeString[ failure_Failure ] := With[ { s = failure[ "Message" ] }, "[Error] " <> safeString @ s /; StringQ @ s ];
+safeString[ string_String ] := convertPUACharacters @ string; (* avoid mangling due to StandardForm strings *)
 safeString[ arg_ ] := convertPUACharacters @ ToString @ Unevaluated @ arg;
 safeString // endDefinition;
 

--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -101,7 +101,7 @@ startMCPServer[ obj_ ] /; $Notebooks :=
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
 startMCPServer[ obj0_MCPServerObject ] := Enclose[
     Block[ { $currentMCPServer = obj0, $mcpEvaluation = True },
-        superQuiet @ Module[ { obj, logFile, llmTools, toolList, promptList, promptLookup, response },
+        superQuiet @ Module[ { obj, logFile, llmTools, toolList, promptList, promptLookup, response, output },
 
         obj = obj0;
 
@@ -155,7 +155,12 @@ startMCPServer[ obj0_MCPServerObject ] := Enclose[
                 response = catchAlways @ processRequest[ ];
                 If[ response =!= EndOfFile, writeLog[ "Response" -> response ] ];
                 If[ AssociationQ @ response,
-                    WriteLine[ "stdout", Developer`WriteRawJSONString[ response, "Compact" -> True ] ];
+                    output = ConfirmBy[
+                        Developer`WriteRawJSONString[ sanitizeResponse @ response, "Compact" -> True ],
+                        StringQ,
+                        "WriteRawJSONString"
+                    ];
+                    WriteLine[ "stdout", output ];
                     If[ TrueQ @ $warmupTools, toolWarmup @ $toolList ],
                     Pause[ 0.1 ]
                 ]
@@ -965,7 +970,11 @@ safeString // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*convertPUACharacters*)
+(* Characters in the Unicode private use area (0xE000-0xF8FF) *)
+$$puaCharacter = RegularExpression[ "[\\x{E000}-\\x{F8FF}]" ];
+
 convertPUACharacters // beginDefinition;
+convertPUACharacters[ str_String ] /; StringFreeQ[ str, $$puaCharacter ] := str;
 convertPUACharacters[ str_String ] := StringJoin[ convertPUACharacters /@ ToCharacterCode @ str ];
 convertPUACharacters[ n_Integer ] /; 57344 <= n <= 63743 := toPrintableASCII @ FromCharacterCode @ n;
 convertPUACharacters[ n_Integer ] := FromCharacterCode @ n;
@@ -977,6 +986,19 @@ convertPUACharacters // endDefinition;
 toPrintableASCII // beginDefinition;
 toPrintableASCII[ expr_ ] := ToString[ Unevaluated @ expr, CharacterEncoding -> "PrintableASCII" ];
 toPrintableASCII // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*sanitizeResponse*)
+(* Applies convertPUACharacters to every string in a response before it is encoded as JSON.
+   Sanitizing must happen before JSON encoding: the converted output can contain backslash
+   sequences or raw control characters, which would corrupt an already-encoded JSON document. *)
+sanitizeResponse // beginDefinition;
+sanitizeResponse[ response_Association ] := sanitizeResponse /@ response;
+sanitizeResponse[ list_List ] := sanitizeResponse /@ list;
+sanitizeResponse[ string_String ] := convertPUACharacters @ string;
+sanitizeResponse[ other_ ] := other;
+sanitizeResponse // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)

--- a/Kernel/StartMCPServer.wl
+++ b/Kernel/StartMCPServer.wl
@@ -994,7 +994,7 @@ toPrintableASCII // endDefinition;
    Sanitizing must happen before JSON encoding: the converted output can contain backslash
    sequences or raw control characters, which would corrupt an already-encoded JSON document. *)
 sanitizeResponse // beginDefinition;
-sanitizeResponse[ response_Association ] := sanitizeResponse /@ response;
+sanitizeResponse[ response_Association ] := KeyMap[ sanitizeResponse, sanitizeResponse /@ response ];
 sanitizeResponse[ list_List ] := sanitizeResponse /@ list;
 sanitizeResponse[ string_String ] := convertPUACharacters @ string;
 sanitizeResponse[ other_ ] := other;

--- a/Tests/MCPClientRequests.wlt
+++ b/Tests/MCPClientRequests.wlt
@@ -86,6 +86,34 @@ VerificationTest[
     TestID   -> "MCPClientRequests-SendUUIDsAreUnique@@Tests/MCPClientRequests.wlt:71,1-87,2"
 ]
 
+(* Requests are sanitized before JSON encoding so PUA characters never reach the wire,
+   matching the response sanitization in StartMCPServer.wl. *)
+VerificationTest[
+    Module[ { written, savedRegistry },
+        savedRegistry = Wolfram`AgentTools`Common`$mcpClientRequests;
+        written = None;
+        WithCleanup[
+            Wolfram`AgentTools`Common`$mcpClientRequests = <| |>,
+            Block[ { WriteLine = Function[ { stream, line }, written = line ] },
+                Wolfram`AgentTools`Common`sendClientRequest[
+                    "test/method",
+                    <| "text" -> FromCharacterCode @ { 97, 32, 57345, 32, 98 } |>,
+                    Identity
+                ]
+            ],
+            Wolfram`AgentTools`Common`$mcpClientRequests = savedRegistry
+        ];
+        {
+            StringQ @ written,
+            Max @ ToCharacterCode @ written < 57344,
+            AssociationQ @ Developer`ReadRawJSONString @ written
+        }
+    ],
+    { True, True, True },
+    SameTest -> MatchQ,
+    TestID   -> "MCPClientRequests-SendSanitizesPUACharacters@@Tests/MCPClientRequests.wlt:91,1-115,2"
+]
+
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*handleClientResponse*)
@@ -117,7 +145,7 @@ VerificationTest[
     ],
     { False, True },
     SameTest -> MatchQ,
-    TestID   -> "MCPClientRequests-ResponseCallsHandlerAndRemoves@@Tests/MCPClientRequests.wlt:95,1-121,2"
+    TestID   -> "MCPClientRequests-ResponseCallsHandlerAndRemoves@@Tests/MCPClientRequests.wlt:123,1-149,2"
 ]
 
 (* Unknown response IDs are silently ignored - no handler call, no registry mutation. *)
@@ -136,7 +164,7 @@ VerificationTest[
     ],
     Null,
     SameTest -> MatchQ,
-    TestID   -> "MCPClientRequests-ResponseUnknownIDIsNoOp@@Tests/MCPClientRequests.wlt:124,1-140,2"
+    TestID   -> "MCPClientRequests-ResponseUnknownIDIsNoOp@@Tests/MCPClientRequests.wlt:152,1-168,2"
 ]
 
 (* The handler still fires for error responses - interpretation is the handler's job. *)
@@ -161,7 +189,7 @@ VerificationTest[
     ],
     KeyValuePattern[ "error" -> KeyValuePattern[ "code" -> -32601 ] ],
     SameTest -> MatchQ,
-    TestID   -> "MCPClientRequests-ResponseHandlerFiresOnError@@Tests/MCPClientRequests.wlt:143,1-165,2"
+    TestID   -> "MCPClientRequests-ResponseHandlerFiresOnError@@Tests/MCPClientRequests.wlt:171,1-193,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -173,7 +201,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`handleNotification[ "notifications/cancelled", <| |> ],
     Null,
     SameTest -> MatchQ,
-    TestID   -> "MCPClientRequests-NotificationUnknownIsNoOp@@Tests/MCPClientRequests.wlt:172,1-177,2"
+    TestID   -> "MCPClientRequests-NotificationUnknownIsNoOp@@Tests/MCPClientRequests.wlt:200,1-205,2"
 ]
 
 (* notifications/initialized dispatches to onClientInitialized with the message.
@@ -192,7 +220,7 @@ VerificationTest[
     ],
     <| "method" -> "notifications/initialized" |>,
     SameTest -> MatchQ,
-    TestID   -> "MCPClientRequests-NotificationInitializedDispatch@@Tests/MCPClientRequests.wlt:182,1-196,2"
+    TestID   -> "MCPClientRequests-NotificationInitializedDispatch@@Tests/MCPClientRequests.wlt:210,1-224,2"
 ]
 
 (* notifications/roots/list_changed dispatches to onRootsListChanged with the message. *)
@@ -209,7 +237,7 @@ VerificationTest[
     ],
     <| "method" -> "notifications/roots/list_changed" |>,
     SameTest -> MatchQ,
-    TestID   -> "MCPClientRequests-NotificationRootsListChangedDispatch@@Tests/MCPClientRequests.wlt:199,1-213,2"
+    TestID   -> "MCPClientRequests-NotificationRootsListChangedDispatch@@Tests/MCPClientRequests.wlt:227,1-241,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/StartMCPServer.wlt
+++ b/Tests/StartMCPServer.wlt
@@ -1029,7 +1029,7 @@ VerificationTest[
             |>
         |>;
         json = Developer`WriteRawJSONString[
-            Wolfram`AgentTools`StartMCPServer`Private`sanitizeResponse @ response,
+            Wolfram`AgentTools`Common`sanitizeResponse @ response,
             "Compact" -> True
         ];
         {
@@ -1045,7 +1045,7 @@ VerificationTest[
 
 (* Non-string values and association structure pass through sanitization unchanged. *)
 VerificationTest[
-    Wolfram`AgentTools`StartMCPServer`Private`sanitizeResponse @ <| "a" -> { 1, True, Null }, "b" -> <| "c" -> 3.5 |> |>,
+    Wolfram`AgentTools`Common`sanitizeResponse @ <| "a" -> { 1, True, Null }, "b" -> <| "c" -> 3.5 |> |>,
     <| "a" -> { 1, True, Null }, "b" -> <| "c" -> 3.5 |> |>,
     SameTest -> MatchQ,
     TestID   -> "SanitizeResponse-NonStringsUntouched@@Tests/StartMCPServer.wlt:1047,1-1052,2"
@@ -1056,7 +1056,7 @@ VerificationTest[
     Module[ { response, json },
         response = <| "result" -> <| FromCharacterCode @ { 107, 101, 121, 57345 } -> "value" |> |>;
         json = Developer`WriteRawJSONString[
-            Wolfram`AgentTools`StartMCPServer`Private`sanitizeResponse @ response,
+            Wolfram`AgentTools`Common`sanitizeResponse @ response,
             "Compact" -> True
         ];
         {

--- a/Tests/StartMCPServer.wlt
+++ b/Tests/StartMCPServer.wlt
@@ -1015,6 +1015,52 @@ VerificationTest[
     TestID   -> "SafeString-PreservesStandardFormStrings@@Tests/StartMCPServer.wlt:1002,1-1016,2"
 ]
 
+(* Responses are sanitized before JSON encoding so PUA characters never reach the wire.
+   Sanitizing the encoded JSON instead would corrupt it, since convertPUACharacters output
+   can contain backslash sequences or raw control characters. *)
+VerificationTest[
+    Module[ { response, json },
+        response = <|
+            "jsonrpc" -> "2.0",
+            "id"      -> 1,
+            "result"  -> <|
+                "content" -> { <| "type" -> "text", "text" -> FromCharacterCode @ { 97, 32, 57345, 32, 62371, 32, 98 } |> },
+                "isError" -> False
+            |>
+        |>;
+        json = Developer`WriteRawJSONString[
+            Wolfram`AgentTools`StartMCPServer`Private`sanitizeResponse @ response,
+            "Compact" -> True
+        ];
+        {
+            StringQ @ json,
+            Max @ ToCharacterCode @ json < 57344,
+            AssociationQ @ Developer`ReadRawJSONString @ json
+        }
+    ],
+    { True, True, True },
+    SameTest -> MatchQ,
+    TestID   -> "SanitizeResponse-PUACharactersProduceValidJSON@@Tests/StartMCPServer.wlt:1021,1-1044,2"
+]
+
+(* Non-string values and association structure pass through sanitization unchanged. *)
+VerificationTest[
+    Wolfram`AgentTools`StartMCPServer`Private`sanitizeResponse @ <| "a" -> { 1, True, Null }, "b" -> <| "c" -> 3.5 |> |>,
+    <| "a" -> { 1, True, Null }, "b" -> <| "c" -> 3.5 |> |>,
+    SameTest -> MatchQ,
+    TestID   -> "SanitizeResponse-NonStringsUntouched@@Tests/StartMCPServer.wlt:1047,1-1052,2"
+]
+
+(* Strings without PUA characters are returned unchanged. *)
+VerificationTest[
+    With[ { s = "plain ASCII text" },
+        Wolfram`AgentTools`StartMCPServer`Private`convertPUACharacters @ s === s
+    ],
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "ConvertPUACharacters-NoOpWithoutPUA@@Tests/StartMCPServer.wlt:1055,1-1062,2"
+]
+
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Cleanup Mock Paclet*)
@@ -1024,7 +1070,7 @@ VerificationTest[
     True,
     True,
     SameTest -> MatchQ,
-    TestID   -> "PacletCleanup-UnloadMockPaclet@@Tests/StartMCPServer.wlt:1021,1-1028,2"
+    TestID   -> "PacletCleanup-UnloadMockPaclet@@Tests/StartMCPServer.wlt:1067,1-1074,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/StartMCPServer.wlt
+++ b/Tests/StartMCPServer.wlt
@@ -1051,6 +1051,24 @@ VerificationTest[
     TestID   -> "SanitizeResponse-NonStringsUntouched@@Tests/StartMCPServer.wlt:1047,1-1052,2"
 ]
 
+(* Association keys are sanitized too: forwarded associations (e.g. _meta) can carry arbitrary keys. *)
+VerificationTest[
+    Module[ { response, json },
+        response = <| "result" -> <| FromCharacterCode @ { 107, 101, 121, 57345 } -> "value" |> |>;
+        json = Developer`WriteRawJSONString[
+            Wolfram`AgentTools`StartMCPServer`Private`sanitizeResponse @ response,
+            "Compact" -> True
+        ];
+        {
+            Max @ ToCharacterCode @ json < 57344,
+            AssociationQ @ Developer`ReadRawJSONString @ json
+        }
+    ],
+    { True, True },
+    SameTest -> MatchQ,
+    TestID   -> "SanitizeResponse-PUAKeysSanitized@@Tests/StartMCPServer.wlt:1055,1-1070,2"
+]
+
 (* Strings without PUA characters are returned unchanged. *)
 VerificationTest[
     With[ { s = "plain ASCII text" },
@@ -1058,7 +1076,7 @@ VerificationTest[
     ],
     True,
     SameTest -> MatchQ,
-    TestID   -> "ConvertPUACharacters-NoOpWithoutPUA@@Tests/StartMCPServer.wlt:1055,1-1062,2"
+    TestID   -> "ConvertPUACharacters-NoOpWithoutPUA@@Tests/StartMCPServer.wlt:1073,1-1080,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1070,7 +1088,7 @@ VerificationTest[
     True,
     True,
     SameTest -> MatchQ,
-    TestID   -> "PacletCleanup-UnloadMockPaclet@@Tests/StartMCPServer.wlt:1067,1-1074,2"
+    TestID   -> "PacletCleanup-UnloadMockPaclet@@Tests/StartMCPServer.wlt:1085,1-1092,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/StartMCPServer.wlt
+++ b/Tests/StartMCPServer.wlt
@@ -994,6 +994,29 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*Output Sanitization*)
+
+(* Strings containing inline StandardForm content hold PUA linear-syntax markers. safeString
+   must convert these to printable linear syntax on a single line; routing the string through
+   ToString instead would render the boxes as multi-line 2D typesetting and mangle the text. *)
+VerificationTest[
+    Module[ { converted },
+        converted = Wolfram`AgentTools`StartMCPServer`Private`safeString[
+            "inline " <> ToString[ 1/2, StandardForm ] <> " form"
+        ];
+        {
+            StringContainsQ[ converted, "FractionBox" ],
+            StringFreeQ[ converted, "\n" ],
+            Max @ ToCharacterCode @ converted < 57344
+        }
+    ],
+    { True, True, True },
+    SameTest -> MatchQ,
+    TestID   -> "SafeString-PreservesStandardFormStrings@@Tests/StartMCPServer.wlt:1002,1-1016,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*Cleanup Mock Paclet*)
 VerificationTest[
     PacletDirectoryUnload @ FileNameJoin @ { $testResourceDirectory, "MockMCPPacletTest" };
@@ -1001,7 +1024,7 @@ VerificationTest[
     True,
     True,
     SameTest -> MatchQ,
-    TestID   -> "PacletCleanup-UnloadMockPaclet@@Tests/StartMCPServer.wlt:998,1-1005,2"
+    TestID   -> "PacletCleanup-UnloadMockPaclet@@Tests/StartMCPServer.wlt:1021,1-1028,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)


### PR DESCRIPTION
## Summary

Fixes two related issues with MCP wire output:

1. **JSON encoding errors from PUA characters** — Some MCP messages (e.g. error responses and server→client requests like `roots/list`) never went through `safeString`, so Unicode private-use-area characters could reach the wire and trigger JSON encoding errors in clients.
2. **StandardForm strings mangled by `safeString`** — `String` input was routed through `ToString`, which renders embedded linear syntax as multi-line 2D typesetting:

   ```wl
   In[1]:= safeString["This inline StandardForm string " <> ToString[1/2, StandardForm] <> " gets mangled!"]

   Out[1]= "                                1
   This inline StandardForm string - gets mangled!
                                   2"
   ```

   After this change:

   ```wl
   Out[1]= "This inline StandardForm string \!\(\*FractionBox[\"1\", \"2\"]\) gets mangled!"
   ```

## Changes

- `safeString` now passes strings directly to `convertPUACharacters`, preserving inline StandardForm content as single-line printable linear syntax (the linear-syntax markers are themselves PUA characters).
- New `sanitizeResponse` helper recursively applies `convertPUACharacters` to every string in an outgoing message — association values **and keys** (forwarded associations like `_meta` can carry arbitrary keys) — and the server loop now runs every response through it **before** JSON encoding. Sanitizing after encoding would corrupt the JSON: the conversion output can contain backslash sequences (e.g. `\:e001`) that are invalid JSON escape sequences, or raw control characters that also break the line-delimited stdio framing.
- Server→client requests in `MCPClientRequests.wl` get the same sanitization. `sanitizeResponse` is declared in the shared ``Wolfram`AgentTools`Common` `` context so both files use one definition.
- `convertPUACharacters` short-circuits via a single regex scan when a string contains no PUA characters, so large payloads (e.g. base64-encoded images) are no longer candidates for character-by-character rebuilding.

## Test plan

- [x] New regression tests:
  - `SafeString-PreservesStandardFormStrings` — StandardForm strings stay single-line with `FractionBox` text intact and no PUA characters
  - `SanitizeResponse-PUACharactersProduceValidJSON` — PUA characters in response values produce ASCII-only wire output that round-trips through `Developer`ReadRawJSONString`
  - `SanitizeResponse-PUAKeysSanitized` — PUA characters in nested association keys are sanitized
  - `SanitizeResponse-NonStringsUntouched` — non-string values and structure pass through unchanged
  - `ConvertPUACharacters-NoOpWithoutPUA` — PUA-free strings are returned unchanged
  - `MCPClientRequests-SendSanitizesPUACharacters` — captures the actual wire line written by `sendClientRequest` and asserts it is ASCII-only, valid JSON
- [x] Full suites pass: `Tests/StartMCPServer.wlt` (90), `Tests/MCPClientRequests.wlt` (12), `Tests/MCPRoots.wlt` (30) — 132/132, including the end-to-end `roots/list` subprocess tests
- [x] CodeInspector clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)