### PR TITLE
Fix evaluator session state loss between calls and across kernel restarts

### DIFF
--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -594,11 +594,14 @@ sessionFile // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Starting, Saving, and Resuming Sessions*)
-(* The *InKernel companions set up the kernel-side session state ($Context, In/Out history, $Line) via
-   useEvaluatorKernel and return the line seed; the outer functions update the MCP-side $currentSessionID
-   and the file-scoped $line. Note that under the "Local" method useEvaluatorKernel runs these in the
-   controlling kernel (which is what points its $Context at the session so the user's code parses into it);
-   the user's code itself runs in the eval subkernel, whose $Line is set separately via syncEvalKernelLine. *)
+(* The *InKernel companions set up the eval-kernel-side session state ($Context, In/Out history, $Line)
+   via useEvaluatorKernel and return the line seed; the outer functions update the MCP-side
+   $currentSessionID and the file-scoped $line. Under in-process methods parsing, evaluation, and session
+   state all live in this kernel. Under the "Local" method useEvaluatorKernel runs these in the persistent
+   eval subkernel alongside the user's evaluations, whose $Line is seeded separately via
+   syncEvalKernelLine. (Note: under "Local", Chatbook parses code strings in the controlling kernel, so
+   parse-time binding of unqualified new symbols does not see the eval kernel's session contexts \[LongDash]
+   a known limitation of that method.) *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -633,6 +636,15 @@ startSessionInKernel[ id_String ] := (
     DownValues[ Out ]         = { };
     DownValues[ MessageList ] = { };
     Protect[ In, InString, Out, MessageList ];
+    (* Seed $sessionInfo so a continuing call can restore this session's context state even if no
+       save has succeeded yet; every successful save overwrites it (see saveSessionInKernel). *)
+    $sessionInfo = <|
+        "SessionID"       -> id,
+        "KernelSessionID" -> $kernelSessionID,
+        "$Context"        -> $Context,
+        "$ContextPath"    -> $ContextPath,
+        "$ContextAliases" -> $ContextAliases
+    |>;
     $Line = 1; (* seed 1 -> first label Out[1]=, matching the original $line origin *)
     $Line
 );
@@ -642,14 +654,21 @@ startSessionInKernel // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*enterSessionContext*)
-(* Re-point the eval kernel at an already-live session's context (used when continuing the current
-   session). Unlike startSession it does NOT reset In/Out/$Line: the continuing session's history and
-   the file-scoped $line counter persist between calls. *)
+(* Re-point the eval kernel at an already-live session (used when continuing the current session).
+   Unlike startSession it does NOT reset In/Out/$Line: the continuing session's history and the
+   file-scoped $line counter persist between calls. $Context/$ContextPath/$ContextAliases are restored
+   from the state captured by the last save ($sessionInfo) rather than reset to defaults, so context
+   changes made by the session's own evaluations (e.g. Get prepending a package context to the path)
+   survive across calls. Returns $Failed without throwing when the kernel-side state is missing or
+   belongs to a different session (e.g. the eval kernel restarted between calls); the caller then falls
+   back to resuming from the session file. *)
 enterSessionContext // beginDefinition;
 
 enterSessionContext[ id_String ] := Enclose[
-    ConfirmMatch[ useEvaluatorKernel @ enterSessionContextInKernel @ id, Null, "Entered" ];
-    id,
+    Replace[
+        ConfirmMatch[ useEvaluatorKernel @ enterSessionContextInKernel @ id, Null | $Failed, "Entered" ],
+        Null :> id
+    ],
     throwInternalFailure
 ];
 
@@ -660,12 +679,16 @@ enterSessionContext // endDefinition;
 (*enterSessionContextInKernel*)
 enterSessionContextInKernel // beginDefinition;
 
-enterSessionContextInKernel[ id_String ] := (
-    $Context        = "Sessions`" <> id <> "`";
-    $ContextPath    = { $Context, "System`" };
-    $ContextAliases = <| |>;
-    Null
-);
+enterSessionContextInKernel[ id_String ] :=
+    With[ { info = $sessionInfo },
+        If[ AssociationQ @ info && info[ "SessionID" ] === id,
+            $Context        = info[ "$Context" ];
+            $ContextPath    = info[ "$ContextPath" ];
+            $ContextAliases = info[ "$ContextAliases" ];
+            Null,
+            $Failed
+        ]
+    ];
 
 enterSessionContextInKernel // endDefinition;
 
@@ -702,14 +725,42 @@ syncEvalKernelLineSafe // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
+(*$kernelSessionID*)
+(* Identifies the kernel process on each side of the save/resume round-trip: a session file whose saved
+   KernelSessionID differs from the resuming kernel's was written by a kernel process that is gone, so
+   non-session kernel state (loaded packages, etc.) is gone with it and sessionInfoText warns about it.
+   Delayed on purpose: a plain assignment would bake the build kernel's $SessionID into the MX file. *)
+$kernelSessionID := $SessionID;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
 (*saveSession*)
 saveSession // beginDefinition;
 
 saveSession[ id_String ] := Enclose[
-    Module[ { dir, file },
+    Module[ { dir, file, saved },
         dir  = ConfirmBy[ ensureDirectory @ sessionsPath[ ], directoryQ, "Directory" ];
         file = ConfirmBy[ sessionFile @ id, fileQ, "File" ];
-        ConfirmMatch[ useEvaluatorKernel @ saveSessionInKernel[ id, First @ file ], True, "Saved" ];
+        saved = ConfirmMatch[
+            (* With injects the evaluated path and line so the held call ships fully literal: under
+               the "Local" method the eval subkernel cannot resolve this kernel's Module variables
+               (a non-literal call would bounce back unevaluated and run here instead of in the eval
+               kernel, saving the wrong kernel's state), and its copy of the file-scoped $line is
+               meaningless, so the authoritative counter must be passed in. Same idiom as
+               syncEvalKernelLine. *)
+            With[ { path = First @ file, line = $line },
+                useEvaluatorKernel @ saveSessionInKernel[ id, path, line ]
+            ],
+            True | _Association,
+            "Saved"
+        ];
+        (* The eval kernel could not write the file itself (e.g. the "Local" sandbox kernel blocks
+           file writes) and returned its session info instead: persist it from this kernel. Such a
+           file carries no session-context definitions, only the state needed to resume metadata,
+           which is all the eval kernel could capture anyway. *)
+        If[ AssociationQ @ saved,
+            ConfirmMatch[ writeSessionInfoFile[ First @ file, saved ], True, "SavedFallback" ]
+        ];
         cleanupSessions[ ]; (* cleanup-after-write, mirrors Common.wl failure-log handling *)
         file
     ],
@@ -724,30 +775,66 @@ saveSession // endDefinition;
 saveSessionInKernel // beginDefinition;
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
-saveSessionInKernel[ id_String, path_String ] :=
-    Module[ { tmp },
+saveSessionInKernel[ id_String, path_String, line_Integer ] :=
+    Module[ { tmp, written },
         $sessionInfo = <|
+            "SessionID"       -> id, (* lets a continuing call verify $sessionInfo is its own; see enterSessionContextInKernel *)
+            "KernelSessionID" -> $kernelSessionID, (* identifies the saving kernel process; see resumeSessionInKernel *)
             "$Context"        -> $Context,
             "$ContextPath"    -> $ContextPath,
             "$ContextAliases" -> $ContextAliases,
             "$Line"           -> $Line, (* eval kernel's $Line, kept for reference / back-compat *)
-            "$line"           -> $line, (* authoritative per-session counter that drives resume *)
+            "$line"           -> line,  (* authoritative per-session counter that drives resume (injected by saveSession) *)
             "In"              -> DownValues[ In ],
             "InString"        -> DownValues[ InString ],
             "Out"             -> DownValues[ Out ],
             "MessageList"     -> DownValues[ MessageList ]
         |>;
-        tmp = path <> ".tmp";
+        tmp = path <> "." <> CreateUUID[ ] <> ".tmp"; (* unique per attempt, so its existence proves THIS write happened *)
         (* DumpSave the session $Context (all user symbols) plus the held $sessionInfo symbol; the With
-           injects the evaluated context string while DumpSave's HoldRest keeps $sessionInfo a symbol. *)
-        With[ { ctx = $Context },
-            DumpSave[ tmp, { ctx, $sessionInfo }, "SymbolAttributes" -> False ]
+           injects the evaluated context string while DumpSave's HoldRest keeps $sessionInfo a symbol.
+           Writes can fail in this kernel (e.g. the "Local" sandbox kernel blocks file writes) and can
+           do so silently, so verify that the fresh temp file materialized rather than trusting the
+           destination (which a previous successful write may have left behind). *)
+        written = Quiet @ Check[
+            With[ { ctx = $Context },
+                DumpSave[ tmp, { ctx, $sessionInfo }, "SymbolAttributes" -> False ]
+            ];
+            FileExistsQ @ tmp && (
+                RenameFile[ tmp, path, OverwriteTarget -> True ]; (* atomic-ish: never leave a half-written .mx *)
+                FileExistsQ @ path
+            ),
+            False
         ];
-        RenameFile[ tmp, path, OverwriteTarget -> True ]; (* atomic-ish: never leave a half-written .mx *)
-        True
+        If[ TrueQ @ written,
+            True,
+            (* Hand the state back so saveSession can persist it from the controlling kernel. *)
+            Quiet @ DeleteFile @ tmp; (* don't accumulate orphans when DumpSave wrote but the rename failed *)
+            $sessionInfo
+        ]
     ];
 (* :!CodeAnalysis::EndBlock:: *)
 saveSessionInKernel // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*writeSessionInfoFile*)
+(* Fallback writer for when the eval kernel cannot write files itself: persist the session info it
+   returned as the same DumpSave format resumeSessionInKernel reads (the Block gives the held
+   $sessionInfo symbol the eval kernel's value for the duration of the write). *)
+writeSessionInfoFile // beginDefinition;
+
+writeSessionInfoFile[ path_String, info_Association ] :=
+    Module[ { tmp },
+        tmp = path <> "." <> CreateUUID[ ] <> ".tmp";
+        Block[ { $sessionInfo = info },
+            DumpSave[ tmp, $sessionInfo, "SymbolAttributes" -> False ]
+        ];
+        RenameFile[ tmp, path, OverwriteTarget -> True ];
+        FileExistsQ @ path
+    ];
+
+writeSessionInfoFile // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -755,16 +842,28 @@ saveSessionInKernel // endDefinition;
 resumeSession // beginDefinition;
 
 resumeSession[ id_String ] := Enclose[
-    Module[ { file, seed },
+    Module[ { file, res },
         file = ConfirmBy[ sessionFile @ id, fileQ, "File" ];
-        seed = If[ FileExistsQ @ First @ file,
-                   useEvaluatorKernel @ resumeSessionInKernel @ First @ file,
+        res  = If[ FileExistsQ @ First @ file,
+                   (* Inject the literal path for the same reason as in saveSession. *)
+                   With[ { path = First @ file }, useEvaluatorKernel @ resumeSessionInKernel @ path ],
                    $Failed
                ];
-        If[ IntegerQ @ seed,
-            $currentSessionID = id; $line = seed; id,
-            (* Missing or corrupt session file: signal the caller to start fresh (no bug report). *)
-            $Failed
+        Replace[
+            res,
+            {
+                { seed_Integer, sameKernel: True|False } :> (
+                    (* A resume under a new kernel process restored the session's own definitions and
+                       history, but any other kernel state (loaded packages, etc.) died with the old
+                       process; record that so sessionInfoText can warn about it. *)
+                    If[ ! sameKernel, $sessionStatus = "resumedNewKernel" ];
+                    $currentSessionID = id;
+                    $line = seed;
+                    id
+                ),
+                (* Missing or corrupt session file: signal the caller to start fresh (no bug report). *)
+                _ :> $Failed
+            }
         ]
     ],
     throwInternalFailure
@@ -797,7 +896,9 @@ resumeSessionInKernel[ path_String ] :=
             DownValues[ Out ]         = info[ "Out" ];
             DownValues[ MessageList ] = info[ "MessageList" ];
             Protect[ In, InString, Out, MessageList ];
-            line,
+            (* The second element reports whether the file was saved by this same kernel process;
+               files saved before KernelSessionID existed conservatively count as a different kernel. *)
+            { line, info[ "KernelSessionID" ] === $kernelSessionID },
             (* else: malformed payload *)
             $Failed
         ]
@@ -880,10 +981,11 @@ sessionsOverByteBudget // endDefinition;
 (*Session Orchestration*)
 (* The single place that compares the incoming session to $currentSessionID. withSession scopes
    $Context/$ContextPath to the evaluation (Internal`InheritedBlock), so each call must (re-)point the
-   eval kernel at the session context: a continuing session re-enters its context (its definitions and
-   In/Out/$Line history persist in the kernel between calls); a different existing session is resumed
-   from disk; an unknown ID starts a fresh session reusing that ID. The outgoing session is not saved
-   here on a switch because every call already saves its session at the end (see withSession). *)
+   eval kernel at the session context: a continuing session restores its context state from the last
+   save's $sessionInfo (its definitions and In/Out/$Line history persist in the kernel between calls),
+   falling back to a disk resume if the kernel-side state is gone; a different existing session is
+   resumed from disk; an unknown ID starts a fresh session reusing that ID. The outgoing session is not
+   saved here on a switch because every call already saves its session at the end (see withSession). *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -953,7 +1055,10 @@ enterSessionContextSafe // beginDefinition;
 enterSessionContextSafe[ id_String ] :=
     Replace[
         Quiet @ catchAlways @ enterSessionContext @ id,
-        Except[ _String ] :> startSessionSafe @ id
+        (* Kernel-side state for the continuing session is unavailable (e.g. the eval kernel restarted
+           between calls): fall back to restoring from the session file; resumeSessionSafe falls back
+           further to a fresh start if the file is unusable too. *)
+        Except[ _String ] :> ( $sessionStatus = "resumed"; resumeSessionSafe @ id )
     ];
 
 enterSessionContextSafe // endDefinition;
@@ -1028,12 +1133,29 @@ sessionInfoText // beginDefinition;
 
 sessionInfoText[ id_String ] := StringJoin[
     "\n\n<system-reminder>",
-    If[ $sessionStatus === "reused", "No saved state was found for the requested session ID, so a new empty session was started. ", "" ],
+    sessionInfoStatusText @ $sessionStatus,
     "Pass session=\"", id, "\" in future calls to this tool to continue this session.",
     "</system-reminder>"
 ];
 
 sessionInfoText // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*sessionInfoStatusText*)
+sessionInfoStatusText // beginDefinition;
+
+sessionInfoStatusText[ "reused" ] := "\
+No saved state was found for the requested session ID, so a new empty session was started. ";
+
+sessionInfoStatusText[ "resumedNewKernel" ] := "\
+The kernel process for this session has changed (e.g. the server restarted), so the session \
+was restored from its last saved state. Session definitions and history were restored, but other \
+kernel state (e.g. packages loaded with Get or Needs) may be missing and might need to be reloaded. ";
+
+sessionInfoStatusText[ _ ] := "";
+
+sessionInfoStatusText // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -825,13 +825,26 @@ saveSessionInKernel // endDefinition;
 writeSessionInfoFile // beginDefinition;
 
 writeSessionInfoFile[ path_String, info_Association ] :=
-    Module[ { tmp },
+    Module[ { tmp, written },
         tmp = path <> "." <> CreateUUID[ ] <> ".tmp";
-        Block[ { $sessionInfo = info },
-            DumpSave[ tmp, $sessionInfo, "SymbolAttributes" -> False ]
+        (* Same write discipline as saveSessionInKernel: verify the fresh temp file materialized
+           rather than trusting the destination, which a previous successful save may have left
+           behind (FileExistsQ @ path alone would report that stale file as success). *)
+        written = Quiet @ Check[
+            Block[ { $sessionInfo = info },
+                DumpSave[ tmp, $sessionInfo, "SymbolAttributes" -> False ]
+            ];
+            FileExistsQ @ tmp && (
+                RenameFile[ tmp, path, OverwriteTarget -> True ];
+                FileExistsQ @ path
+            ),
+            False
         ];
-        RenameFile[ tmp, path, OverwriteTarget -> True ];
-        FileExistsQ @ path
+        If[ TrueQ @ written,
+            True,
+            Quiet @ DeleteFile @ tmp; (* cleanupSessions only prunes *.mx, so orphaned temps would accumulate *)
+            False
+        ]
     ];
 
 writeSessionInfoFile // endDefinition;

--- a/Tests/EvaluatorSessions.wlt
+++ b/Tests/EvaluatorSessions.wlt
@@ -236,6 +236,28 @@ VerificationTest[
 ]
 
 VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "resumedNewKernel" },
+        With[ { text = Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoText[ "Abc123" ] },
+            {
+                StringContainsQ[ text, "kernel process for this session has changed" ],
+                StringContainsQ[ text, "session=\"Abc123\"" ]
+            }
+        ]
+    ],
+    { True, True },
+    SameTest -> MatchQ,
+    TestID   -> "SessionInfoText-ResumedNewKernelNotice@@Tests/EvaluatorSessions.wlt:238,1-250,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "resumed" },
+        StringContainsQ[ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoText[ "Abc123" ], "kernel process" ]
+    ],
+    False,
+    TestID -> "SessionInfoText-SameKernelResumeHasNoKernelNotice@@Tests/EvaluatorSessions.wlt:252,1-258,2"
+]
+
+VerificationTest[
     Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionStatus = "new" },
         Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`appendSessionInfo[
             <| "Content" -> { <| "type" -> "text", "text" -> "hi" |> } |>,
@@ -249,7 +271,7 @@ VerificationTest[
         }
     ],
     SameTest -> MatchQ,
-    TestID   -> "AppendSessionInfo-AppendsToContent@@Tests/EvaluatorSessions.wlt:238,1-253,2"
+    TestID   -> "AppendSessionInfo-AppendsToContent@@Tests/EvaluatorSessions.wlt:260,1-275,2"
 ]
 
 VerificationTest[
@@ -263,7 +285,7 @@ VerificationTest[
         ]
     ],
     True,
-    TestID -> "AppendSessionInfo-PreservesMeta@@Tests/EvaluatorSessions.wlt:255,1-267,2"
+    TestID -> "AppendSessionInfo-PreservesMeta@@Tests/EvaluatorSessions.wlt:277,1-289,2"
 ]
 
 VerificationTest[
@@ -274,7 +296,7 @@ VerificationTest[
         ]
     ],
     True,
-    TestID -> "AppendSessionInfo-String@@Tests/EvaluatorSessions.wlt:283,1-292,2"
+    TestID -> "AppendSessionInfo-String@@Tests/EvaluatorSessions.wlt:291,1-300,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -287,13 +309,118 @@ VerificationTest[
         Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`syncEvalKernelLine[ 5 ]
     ],
     Null,
-    TestID -> "SyncEvalKernelLine-NoOpForInProcess@@Tests/EvaluatorSessions.wlt:299,1-305,2"
+    TestID -> "SyncEvalKernelLine-NoOpForInProcess@@Tests/EvaluatorSessions.wlt:307,1-313,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`syncEvalKernelLineSafe[ "not an integer" ],
     Null,
-    TestID -> "SyncEvalKernelLineSafe-IgnoresNonInteger@@Tests/EvaluatorSessions.wlt:307,1-311,2"
+    TestID -> "SyncEvalKernelLineSafe-IgnoresNonInteger@@Tests/EvaluatorSessions.wlt:315,1-319,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*enterSessionContextInKernel*)
+(* Continuing a session restores the context state captured by the last save instead of resetting it,
+   so $ContextPath additions made by the session's own evaluations survive across calls. *)
+VerificationTest[
+    Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
+        Block[
+            {
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = <|
+                    "SessionID"       -> "UnitCtxA",
+                    "KernelSessionID" -> 0,
+                    "$Context"        -> "Sessions`UnitCtxA`",
+                    "$ContextPath"    -> { "UnitCtxExtra`", "Sessions`UnitCtxA`", "System`" },
+                    "$ContextAliases" -> <| |>
+                |>
+            },
+            {
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`enterSessionContextInKernel[ "UnitCtxA" ],
+                $Context,
+                MemberQ[ $ContextPath, "UnitCtxExtra`" ]
+            }
+        ]
+    ],
+    { Null, "Sessions`UnitCtxA`", True },
+    SameTest -> MatchQ,
+    TestID   -> "EnterSessionContextInKernel-RestoresSavedContextState@@Tests/EvaluatorSessions.wlt:326,1-348,2"
+]
+
+(* Missing or foreign kernel-side state (e.g. the eval kernel restarted between calls) is reported as
+   $Failed so the caller can fall back to resuming from the session file. *)
+VerificationTest[
+    {
+        Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = $Failed },
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`enterSessionContextInKernel[ "UnitCtxB" ]
+        ],
+        Block[
+            {
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = <|
+                    "SessionID"       -> "SomeOtherSession",
+                    "$Context"        -> "Sessions`SomeOtherSession`",
+                    "$ContextPath"    -> { "Sessions`SomeOtherSession`", "System`" },
+                    "$ContextAliases" -> <| |>
+                |>
+            },
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`enterSessionContextInKernel[ "UnitCtxB" ]
+        ]
+    },
+    { $Failed, $Failed },
+    SameTest -> MatchQ,
+    TestID   -> "EnterSessionContextInKernel-FailsOnMissingOrForeignState@@Tests/EvaluatorSessions.wlt:352,1-372,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Session save fallback*)
+(* When the eval kernel cannot write the session file (e.g. the "Local" sandbox kernel blocks file
+   writes), saveSessionInKernel reports the failure by returning the session info instead of True,
+   with the injected line counter, so saveSession can persist it from the controlling kernel. *)
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = None },
+        Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`saveSessionInKernel[
+            "FbWriteSess",
+            FileNameJoin @ { $TemporaryDirectory, "AgentToolsNoSuchDir_" <> CreateUUID[ ], "x.mx" },
+            7
+        ]
+    ],
+    _Association? (#[ "SessionID" ] === "FbWriteSess" && #[ "$line" ] === 7 &),
+    SameTest -> MatchQ,
+    TestID   -> "SaveSessionInKernel-ReturnsInfoWhenWriteFails@@Tests/EvaluatorSessions.wlt:380,1-391,2"
+]
+
+(* A fallback-written file (info only, no session-context definitions) must round-trip through
+   resumeSessionInKernel: the line seed is recovered and a foreign KernelSessionID is reported. *)
+VerificationTest[
+    Module[ { dir, path, info, res },
+        dir  = CreateDirectory @ FileNameJoin @ { $TemporaryDirectory, "AgentToolsFbWrite_" <> CreateUUID[ ] };
+        path = FileNameJoin @ { dir, "FbRoundTrip.mx" };
+        info = <|
+            "SessionID"       -> "FbRoundTrip",
+            "KernelSessionID" -> -42,
+            "$Context"        -> "Sessions`FbRoundTrip`",
+            "$ContextPath"    -> { "Sessions`FbRoundTrip`", "System`" },
+            "$ContextAliases" -> <| |>,
+            "$Line"           -> 5,
+            "$line"           -> 5,
+            "In"              -> { },
+            "InString"        -> { },
+            "Out"             -> { },
+            "MessageList"     -> { }
+        |>;
+        Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`writeSessionInfoFile[ path, info ];
+        res = Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
+            Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = None },
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`resumeSessionInKernel @ path
+            ]
+        ];
+        Quiet @ DeleteDirectory[ dir, DeleteContents -> True ];
+        res
+    ],
+    { 5, False },
+    SameTest -> MatchQ,
+    TestID   -> "WriteSessionInfoFile-ResumeRoundTrip@@Tests/EvaluatorSessions.wlt:395,1-424,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -321,7 +448,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r3, "42" ]
     ],
     True,
-    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:320,1-339,2"
+    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:433,1-452,2"
 ]
 
 (* Re-passing the same session ID continues it: definitions persist and line numbers advance. *)
@@ -343,7 +470,7 @@ VerificationTest[
         StringContainsQ[ text, "6" ] && StringContainsQ[ text, "Out[2]" ]
     ],
     True,
-    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:342,1-361,2"
+    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:455,1-474,2"
 ]
 
 (* A session resumes from disk after its in-kernel symbols are gone (simulated server restart). *)
@@ -367,7 +494,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r2, "99" ]
     ],
     True,
-    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:364,1-385,2"
+    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:477,1-498,2"
 ]
 
 (* Every result echoes the session ID with resume instructions. *)
@@ -387,7 +514,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "session=\"AppendSession\"" ]
     ],
     True,
-    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:388,1-405,2"
+    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:501,1-518,2"
 ]
 
 (* A fresh session's first evaluation is labeled Out[1]. *)
@@ -407,7 +534,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "Out[1]" ]
     ],
     True,
-    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:408,1-425,2"
+    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:521,1-538,2"
 ]
 
 (* Resuming a session continues its line numbering rather than resetting it: A reaches Out[2], B
@@ -432,7 +559,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "Out[3]" ]
     ],
     True,
-    TestID -> "Integration-ResumeContinuesLineNumbering@@Tests/EvaluatorSessions.wlt:430,1-450,2"
+    TestID -> "Integration-ResumeContinuesLineNumbering@@Tests/EvaluatorSessions.wlt:543,1-563,2"
 ]
 
 (* An unknown / expired session ID starts a fresh session reusing that ID and says so. *)
@@ -452,7 +579,117 @@ VerificationTest[
         StringContainsQ[ text, "NeverSavedXyz" ] && StringContainsQ[ text, "No saved state" ]
     ],
     True,
-    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:453,1-470,2"
+    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:566,1-583,2"
+]
+
+(* Context-path changes made inside a session (e.g. by Get) survive continued calls: the continuing
+   call restores the last save's $Context/$ContextPath instead of resetting them, so unqualified
+   references to symbols from a prepended context keep working. *)
+VerificationTest[
+    Module[ { root, tool, r2 },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSession_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            tool[ <| "code" -> "CtxKeepTest`ctxKeepF[x_] := x + 100; PrependTo[$ContextPath, \"CtxKeepTest`\"];", "session" -> "CtxKeepSess" |> ];
+            r2 = tool[ <| "code" -> "{ctxKeepF[1], MemberQ[$ContextPath, \"CtxKeepTest`\"]}", "session" -> "CtxKeepSess" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        Quiet @ Remove[ "CtxKeepTest`*", "Sessions`CtxKeepSess`*" ];
+        StringContainsQ[ extractToolText @ r2, "{101, True}" ]
+    ],
+    True,
+    TestID -> "Integration-ContinuePreservesContextPath@@Tests/EvaluatorSessions.wlt:588,1-607,2"
+]
+
+(* Resuming a session saved by a different kernel process restores the saved state and warns that
+   other kernel state (loaded packages, etc.) may be gone. The saving kernel is spoofed by Blocking
+   $kernelSessionID during the save. *)
+VerificationTest[
+    Module[ { root, tool, text },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSession_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$kernelSessionID = -1 },
+                tool[ <| "code" -> "nkVar = 123", "session" -> "NkResumeSess" |> ]
+            ];
+            (* Simulate a server restart: the live session pointer is gone, but the file (saved by
+               the spoofed "previous" kernel process) remains. *)
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None;
+            text = extractToolText @ tool[ <| "code" -> "nkVar", "session" -> "NkResumeSess" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        Quiet @ Remove[ "Sessions`NkResumeSess`*" ];
+        { StringContainsQ[ text, "123" ], StringContainsQ[ text, "kernel process for this session has changed" ] }
+    ],
+    { True, True },
+    SameTest -> MatchQ,
+    TestID   -> "Integration-ResumeFromPreviousKernelWarns@@Tests/EvaluatorSessions.wlt:612,1-637,2"
+]
+
+(* Switching back to an earlier session within the same kernel process resumes silently: no
+   new-kernel warning is appended. *)
+VerificationTest[
+    Module[ { root, tool, text },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSession_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            tool[ <| "code" -> "swVar = 1", "session" -> "SwCtrlA" |> ];
+            tool[ <| "code" -> "0", "session" -> "SwCtrlB" |> ];
+            text = extractToolText @ tool[ <| "code" -> "swVar", "session" -> "SwCtrlA" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        Quiet @ Remove[ "Sessions`SwCtrlA`*", "Sessions`SwCtrlB`*" ];
+        { StringContainsQ[ text, "session=\"SwCtrlA\"" ], StringContainsQ[ text, "kernel process" ] }
+    ],
+    { True, False },
+    SameTest -> MatchQ,
+    TestID   -> "Integration-SameKernelResumeHasNoWarning@@Tests/EvaluatorSessions.wlt:641,1-662,2"
+]
+
+(* If the eval kernel loses its in-memory session state while the session is still current (e.g. the
+   subkernel restarted under the "Local" method), a continued call falls back to restoring from the
+   session file instead of silently resetting: state and line numbering both survive. *)
+VerificationTest[
+    Module[ { root, tool, text },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsSession_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath          = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI  = False,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            tool[ <| "code" -> "fbVar = 55", "session" -> "FbSess" |> ];
+            text = Block[ { Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = $Failed },
+                extractToolText @ tool[ <| "code" -> "fbVar", "session" -> "FbSess" |> ]
+            ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        Quiet @ Remove[ "Sessions`FbSess`*" ];
+        {
+            StringContainsQ[ text, "55" ],
+            StringContainsQ[ text, "Out[2]" ],
+            StringContainsQ[ text, "No saved state" ]
+        }
+    ],
+    { True, True, False },
+    SameTest -> MatchQ,
+    TestID   -> "Integration-ContinueFallsBackToFileWhenKernelStateLost@@Tests/EvaluatorSessions.wlt:667,1-693,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/EvaluatorSessions.wlt
+++ b/Tests/EvaluatorSessions.wlt
@@ -423,6 +423,28 @@ VerificationTest[
     TestID   -> "WriteSessionInfoFile-ResumeRoundTrip@@Tests/EvaluatorSessions.wlt:395,1-424,2"
 ]
 
+(* A failed fallback write must report False without emitting messages and must not leave orphaned
+   temp files behind. The rename target here exists as a directory, so the write fails while
+   FileExistsQ @ path stays True: trusting the destination instead of verifying the fresh write
+   would misreport this as success. *)
+VerificationTest[
+    Module[ { dir, path, res, temps },
+        dir  = CreateDirectory @ FileNameJoin @ { $TemporaryDirectory, "AgentToolsFbFail_" <> CreateUUID[ ] };
+        path = FileNameJoin @ { dir, "FbWriteFail.mx" };
+        CreateDirectory @ path;
+        res = Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`writeSessionInfoFile[
+            path,
+            <| "SessionID" -> "FbWriteFail" |>
+        ];
+        temps = FileNames[ "*.tmp", dir ];
+        Quiet @ DeleteDirectory[ dir, DeleteContents -> True ];
+        { res, temps }
+    ],
+    { False, { } },
+    SameTest -> MatchQ,
+    TestID   -> "WriteSessionInfoFile-FailureReportsFalseAndCleansUp@@Tests/EvaluatorSessions.wlt:430,1-446,2"
+]
+
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Integration: end-to-end session behavior*)
@@ -448,7 +470,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r3, "42" ]
     ],
     True,
-    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:433,1-452,2"
+    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:455,1-474,2"
 ]
 
 (* Re-passing the same session ID continues it: definitions persist and line numbers advance. *)
@@ -470,7 +492,7 @@ VerificationTest[
         StringContainsQ[ text, "6" ] && StringContainsQ[ text, "Out[2]" ]
     ],
     True,
-    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:455,1-474,2"
+    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:477,1-496,2"
 ]
 
 (* A session resumes from disk after its in-kernel symbols are gone (simulated server restart). *)
@@ -494,7 +516,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r2, "99" ]
     ],
     True,
-    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:477,1-498,2"
+    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:499,1-520,2"
 ]
 
 (* Every result echoes the session ID with resume instructions. *)
@@ -514,7 +536,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "session=\"AppendSession\"" ]
     ],
     True,
-    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:501,1-518,2"
+    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:523,1-540,2"
 ]
 
 (* A fresh session's first evaluation is labeled Out[1]. *)
@@ -534,7 +556,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "Out[1]" ]
     ],
     True,
-    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:521,1-538,2"
+    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:543,1-560,2"
 ]
 
 (* Resuming a session continues its line numbering rather than resetting it: A reaches Out[2], B
@@ -559,7 +581,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "Out[3]" ]
     ],
     True,
-    TestID -> "Integration-ResumeContinuesLineNumbering@@Tests/EvaluatorSessions.wlt:543,1-563,2"
+    TestID -> "Integration-ResumeContinuesLineNumbering@@Tests/EvaluatorSessions.wlt:565,1-585,2"
 ]
 
 (* An unknown / expired session ID starts a fresh session reusing that ID and says so. *)
@@ -579,7 +601,7 @@ VerificationTest[
         StringContainsQ[ text, "NeverSavedXyz" ] && StringContainsQ[ text, "No saved state" ]
     ],
     True,
-    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:566,1-583,2"
+    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:588,1-605,2"
 ]
 
 (* Context-path changes made inside a session (e.g. by Get) survive continued calls: the continuing
@@ -603,7 +625,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r2, "{101, True}" ]
     ],
     True,
-    TestID -> "Integration-ContinuePreservesContextPath@@Tests/EvaluatorSessions.wlt:588,1-607,2"
+    TestID -> "Integration-ContinuePreservesContextPath@@Tests/EvaluatorSessions.wlt:610,1-629,2"
 ]
 
 (* Resuming a session saved by a different kernel process restores the saved state and warns that
@@ -633,7 +655,7 @@ VerificationTest[
     ],
     { True, True },
     SameTest -> MatchQ,
-    TestID   -> "Integration-ResumeFromPreviousKernelWarns@@Tests/EvaluatorSessions.wlt:612,1-637,2"
+    TestID   -> "Integration-ResumeFromPreviousKernelWarns@@Tests/EvaluatorSessions.wlt:634,1-659,2"
 ]
 
 (* Switching back to an earlier session within the same kernel process resumes silently: no
@@ -658,7 +680,7 @@ VerificationTest[
     ],
     { True, False },
     SameTest -> MatchQ,
-    TestID   -> "Integration-SameKernelResumeHasNoWarning@@Tests/EvaluatorSessions.wlt:641,1-662,2"
+    TestID   -> "Integration-SameKernelResumeHasNoWarning@@Tests/EvaluatorSessions.wlt:663,1-684,2"
 ]
 
 (* If the eval kernel loses its in-memory session state while the session is still current (e.g. the
@@ -689,7 +711,7 @@ VerificationTest[
     ],
     { True, True, False },
     SameTest -> MatchQ,
-    TestID   -> "Integration-ContinueFallsBackToFileWhenKernelStateLost@@Tests/EvaluatorSessions.wlt:667,1-693,2"
+    TestID   -> "Integration-ContinueFallsBackToFileWhenKernelStateLost@@Tests/EvaluatorSessions.wlt:689,1-715,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)


### PR DESCRIPTION
## Summary

Fixes two reported `WolframLanguageEvaluator` session bugs (context path resetting between calls; package definitions lost after server restarts with no explanation), plus three deeper `"Local"`-method defects discovered while verifying the fixes live.

### Reported bugs

- **`$ContextPath` reset on every continued call.** `enterSessionContextInKernel` hard-reset `$Context`/`$ContextPath`/`$ContextAliases` to defaults on each call, silently dropping package contexts the session's own evaluations had added (e.g. via `Get`), so unqualified package symbols shadowed into empty session-context placeholders. Continued calls now restore the state captured by the last save (`$sessionInfo`), falling back to a file resume — and then a fresh start — when the kernel-side state is gone. `startSessionInKernel` seeds `$sessionInfo` so this works before the first successful save.
- **Kernel state silently lost across server restarts.** Session files are now stamped with the saving kernel's identity (`"KernelSessionID" -> $SessionID`, defined delayed so the MX build can't bake in the build kernel's value). Resuming under a different kernel process appends a system-reminder to the tool result explaining that session definitions/history were restored but other kernel state (e.g. packages loaded with `Get`/`Needs`) may be missing. Same-process session switches stay silent.

### `"Local"`-method defects found during live verification

- **Save/resume silently ran in the wrong kernel.** The held `saveSessionInKernel[ id, First @ file ]` / `resumeSessionInKernel @ First @ file` calls contained server-side `Module` variables the sandbox subkernel cannot resolve, so they bounced back unevaluated and re-evaluated in the server kernel — session files recorded the server's Global context and counters instead of the eval kernel's state. The calls now `With`-inject the literal path and the authoritative `$line` counter (the subkernel's copy of that file-scoped variable is meaningless), the same idiom `syncEvalKernelLine` uses.
- **Silent sandbox write failures produced stale files that reported success.** Sandbox write denials generate no messages, and verifying `FileExistsQ @ path` was fooled by a previous successful write. Saves now write to a unique per-attempt temp file whose existence proves the write happened, then rename into place.
- **No persistence when the eval kernel can't write at all.** When the write fails, the eval kernel returns its session info and `saveSession` persists it from the controlling kernel via the new `writeSessionInfoFile`. With the Chatbook sandbox write-whitelist fix (WolframResearch/Chatbook#1595, shipping before this change), the primary in-kernel save succeeds and the fallback is dormant insurance for custom sandbox path configurations.

Also corrects the session-architecture comment (the `*InKernel` functions run in the eval subkernel under `"Local"`, not the controlling kernel) and documents the known `"Local"` limitation that Chatbook parses code strings in the controlling kernel, so unqualified new symbols don't bind into session contexts under that method.

## Test plan

- [x] `Tests/EvaluatorSessions.wlt`: 44/44 pass — 10 new tests covering context-state restore on continue (unit + integration), `$Failed` on missing/foreign kernel-side state, fallback-to-file-resume when kernel state is lost mid-session, the cross-kernel resume warning (spoofed via `$kernelSessionID`), no warning on same-kernel resume, the save-failure info return, and the fallback-file → `resumeSessionInKernel` round-trip
- [x] `Tests/Tools.wlt` + `Tests/WolframLanguageEvaluator-UI.wlt`: 91/91 pass
- [x] CodeInspector clean on both changed files (only pre-existing FIXME comments)
- [x] Verified live under `"Session"` (the reported environment): unqualified package symbols resolve across continued calls, session variables round-trip through the session file with values, restart warning fires on a genuine kernel change, session switches stay silent
- [x] Verified live under `"Local"`: `$ContextPath` persists across continued calls, session file is written by the eval kernel with correct `KernelSessionID`/`$line` (post-Chatbook-whitelist) and by the server fallback otherwise, resumed line numbering continues correctly

Related: WolframResearch/Chatbook#1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxeokcbQkejqbZz7V7iJDw
