### PR TITLE
Fix stale server name in quickstart verification instructions

### DIFF
--- a/Documentation/English/Tutorials/QuickStartforAICodingApplications.nb
+++ b/Documentation/English/Tutorials/QuickStartforAICodingApplications.nb
@@ -211,7 +211,7 @@ Notebook[
                CellID -> 223231909
               ],
               Cell[
-               "claude mcp get WolframLanguage",
+               "claude mcp get Wolfram",
                "ExternalLanguage",
                CellEvaluationLanguage -> "Shell",
                CellID -> 40285647
@@ -221,7 +221,7 @@ Notebook[
             ]
            ],
            Cell[
-            "The output should indicate that the \"WolframLanguage\" server is connected.",
+            "The output should indicate that the \"Wolfram\" server is connected.",
             "Text",
             CellID -> 58055741
            ]
@@ -288,7 +288,7 @@ Notebook[
             ]
            ],
            Cell[
-            "The output should indicate that the \"WolframLanguage\" server is configured.",
+            "The output should indicate that the \"Wolfram\" server is configured.",
             "Text",
             CellID -> 243159260
            ]
@@ -330,7 +330,7 @@ Notebook[
             CellID -> 495461010
            ],
            Cell[
-            "Verify that \"WolframLanguage\" is listed under \"Installed MCP Servers\"",
+            "Verify that \"Wolfram\" is listed under \"Installed MCP Servers\"",
             "Item",
             CellID -> 106649718
            ]
@@ -375,7 +375,7 @@ Notebook[
             ]
            ],
            Cell[
-            "The output should indicate that the \"WolframLanguage\" server is configured.",
+            "The output should indicate that the \"Wolfram\" server is configured.",
             "Text",
             CellID -> 238422330
            ]
@@ -422,7 +422,7 @@ Notebook[
             CellID -> 453151772
            ],
            Cell[
-            "Verify that \"WolframLanguage\" is listed under \"Installed MCP Servers\"",
+            "Verify that \"Wolfram\" is listed under \"Installed MCP Servers\"",
             "Item",
             CellID -> 395951229
            ]
@@ -554,7 +554,7 @@ Notebook[
                CellID -> 306930245
               ],
               Cell[
-               "codex mcp get WolframLanguage",
+               "codex mcp get Wolfram",
                "ExternalLanguage",
                CellEvaluationLanguage -> "Shell",
                CellID -> 446582763
@@ -564,7 +564,7 @@ Notebook[
             ]
            ],
            Cell[
-            "The output should indicate that the \"WolframLanguage\" server is enabled.",
+            "The output should indicate that the \"Wolfram\" server is enabled.",
             "Text",
             CellID -> 725136532
            ]
@@ -664,7 +664,7 @@ Notebook[
             ]
            ],
            Cell[
-            "The output should indicate that the \"WolframLanguage\" server is connected. ",
+            "The output should indicate that the \"Wolfram\" server is connected. ",
             "Text",
             CellID -> 145828150
            ]

--- a/Documentation/Japanese/Tutorials/QuickStartforAICodingApplications.nb
+++ b/Documentation/Japanese/Tutorials/QuickStartforAICodingApplications.nb
@@ -382,7 +382,7 @@ Notebook[
                CellID -> 223231909
               ],
               Cell[
-               "claude mcp get WolframLanguage",
+               "claude mcp get Wolfram",
                "ExternalLanguage",
                CellEvaluationLanguage -> "Shell",
                CellID -> 40285647
@@ -392,7 +392,7 @@ Notebook[
             ]
            ],
            Cell[
-            "\:51fa\:529b\:306b\:306f\:300cWolframLanguage\:300d\:30b5\:30fc\:30d0\:306b\:63a5\:7d9a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
+            "\:51fa\:529b\:306b\:306f\:300cWolfram\:300d\:30b5\:30fc\:30d0\:306b\:63a5\:7d9a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
             "Text",
             CellID -> 58055741
            ]
@@ -459,7 +459,7 @@ Notebook[
             ]
            ],
            Cell[
-            "\:51fa\:529b\:306b\:306f\:300cWolframLanguage\:300d\:30b5\:30fc\:30d0\:304c\:8a2d\:5b9a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
+            "\:51fa\:529b\:306b\:306f\:300cWolfram\:300d\:30b5\:30fc\:30d0\:304c\:8a2d\:5b9a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
             "Text",
             CellID -> 243159260
            ]
@@ -531,7 +531,7 @@ Notebook[
             CellID -> 495461010
            ],
            Cell[
-            "\:300cWolframLanguage\:300d\:304c\:300cInstalled MCP Servers\:300d\:306e\:4e0b\:306b\:4e00\:89a7\:8868\:793a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:3092\:78ba\:8a8d\:3059\:308b",
+            "\:300cWolfram\:300d\:304c\:300cInstalled MCP Servers\:300d\:306e\:4e0b\:306b\:4e00\:89a7\:8868\:793a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:3092\:78ba\:8a8d\:3059\:308b",
             "Item",
             TaggingRules -> <|
              "OrignialExpressionUUID" -> "43a9c2c9-14fe-3942-8354-bc82d081de4a",
@@ -540,7 +540,7 @@ Notebook[
              "Date" -> {2026, 5, 20, 18, 5, 16.2102},
              "Model" -> <|"Service" -> "OpenAI", "Name" -> "gpt-5.4"|>,
              "Temperature" -> 1,
-             "OriginalCellString" -> "Cell[\"Verify that \\\"WolframLanguage\\\" is listed under \\\"Installed MCP Servers\\\"\", \"Item\", CellID -> 106649718]"
+             "OriginalCellString" -> "Cell[\"Verify that \\\"Wolfram\\\" is listed under \\\"Installed MCP Servers\\\"\", \"Item\", CellID -> 106649718]"
             |>,
             CellTags -> "Translated",
             CellID -> 106649718
@@ -586,7 +586,7 @@ Notebook[
             ]
            ],
            Cell[
-            "\:51fa\:529b\:306b\:306f\:ff0c\:300cWolframLanguage\:300d\:30b5\:30fc\:30d0\:304c\:8a2d\:5b9a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
+            "\:51fa\:529b\:306b\:306f\:ff0c\:300cWolfram\:300d\:30b5\:30fc\:30d0\:304c\:8a2d\:5b9a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
             "Text",
             TaggingRules -> <|
              "OrignialExpressionUUID" -> "82e48231-b856-4a4e-aefc-cdf39703e62c",
@@ -595,7 +595,7 @@ Notebook[
              "Date" -> {2026, 5, 20, 18, 9, 57.9453},
              "Model" -> <|"Service" -> "OpenAI", "Name" -> "gpt-5.4"|>,
              "Temperature" -> 1,
-             "OriginalCellString" -> "Cell[\"The output should indicate that the \\\"WolframLanguage\\\" server is configured.\", \"Text\", CellID -> 238422330]"
+             "OriginalCellString" -> "Cell[\"The output should indicate that the \\\"Wolfram\\\" server is configured.\", \"Text\", CellID -> 238422330]"
             |>,
             CellTags -> "Translated",
             CellID -> 238422330
@@ -687,7 +687,7 @@ Notebook[
             CellID -> 453151772
            ],
            Cell[
-            "\:300cWolframLanguage\:300d\:304c\:300cInstalled MCP Servers\:300d\:306e\:4e0b\:306b\:4e00\:89a7\:8868\:793a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:3092\:78ba\:8a8d\:3059\:308b",
+            "\:300cWolfram\:300d\:304c\:300cInstalled MCP Servers\:300d\:306e\:4e0b\:306b\:4e00\:89a7\:8868\:793a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:3092\:78ba\:8a8d\:3059\:308b",
             "Item",
             TaggingRules -> <|
              "OrignialExpressionUUID" -> "a4517b58-9085-3c43-b817-f150feb58489",
@@ -696,7 +696,7 @@ Notebook[
              "Date" -> {2026, 5, 20, 18, 10, 46.8188},
              "Model" -> <|"Service" -> "OpenAI", "Name" -> "gpt-5.4"|>,
              "Temperature" -> 1,
-             "OriginalCellString" -> "Cell[\"Verify that \\\"WolframLanguage\\\" is listed under \\\"Installed MCP Servers\\\"\", \"Item\", CellID -> 395951229]"
+             "OriginalCellString" -> "Cell[\"Verify that \\\"Wolfram\\\" is listed under \\\"Installed MCP Servers\\\"\", \"Item\", CellID -> 395951229]"
             |>,
             CellTags -> "Translated",
             CellID -> 395951229
@@ -859,7 +859,7 @@ Notebook[
                CellID -> 306930245
               ],
               Cell[
-               "codex mcp get WolframLanguage",
+               "codex mcp get Wolfram",
                "ExternalLanguage",
                CellEvaluationLanguage -> "Shell",
                CellID -> 446582763
@@ -869,7 +869,7 @@ Notebook[
             ]
            ],
            Cell[
-            "\:51fa\:529b\:306b\:306f\:300cWolframLanguage\:300d\:30b5\:30fc\:30d0\:304c\:6709\:52b9\:3068\:306a\:3063\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
+            "\:51fa\:529b\:306b\:306f\:300cWolfram\:300d\:30b5\:30fc\:30d0\:304c\:6709\:52b9\:3068\:306a\:3063\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
             "Text",
             CellID -> 725136532
            ]
@@ -979,7 +979,7 @@ Notebook[
             ]
            ],
            Cell[
-            "\:51fa\:529b\:306b\:306f\:300cWolframLanguage\:300d\:30b5\:30fc\:30d0\:306b\:63a5\:7d9a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
+            "\:51fa\:529b\:306b\:306f\:300cWolfram\:300d\:30b5\:30fc\:30d0\:306b\:63a5\:7d9a\:3055\:308c\:3066\:3044\:308b\:3053\:3068\:304c\:793a\:3055\:308c\:3066\:3044\:306a\:3051\:308c\:3070\:306a\:3089\:306a\:3044\:ff0e",
             "Text",
             CellID -> 145828150
            ]

--- a/docs/quickstart-coding.md
+++ b/docs/quickstart-coding.md
@@ -17,6 +17,8 @@ For Wolfram Language development, it's recommended to use the **WolframLanguage*
 
 All installation methods use the `InstallMCPServer` function. Open a Wolfram Language session and run the appropriate command for your application.
 
+> **Note:** Regardless of which server you install (e.g. `"WolframLanguage"`), built-in servers are registered in the client's configuration under the name **Wolfram** by default, so that is the server name shown by client UIs and CLI commands. To register under a different name, pass the `"MCPServerName"` option to `InstallMCPServer` (see [MCPServerName](mcp-clients.md#mcpservername)).
+
 ### Amazon Q Developer
 
 Choose whether to install the server globally or project-level. Global installation is available in all projects, while project-level installation is available only in a specific project directory.
@@ -72,10 +74,10 @@ InstallMCPServer[{"ClaudeCode", "/path/to/project"}, "WolframLanguage"]
 Verify the installation from the command line:
 
 ```shell
-claude mcp get WolframLanguage
+claude mcp get Wolfram
 ```
 
-The output should indicate that the "WolframLanguage" server is connected.
+The output should indicate that the "Wolfram" server is connected.
 
 ### Cline
 
@@ -95,7 +97,7 @@ To verify the installation from the command line:
 copilot -i "/mcp show"
 ```
 
-The output should indicate that the "WolframLanguage" server is configured.
+The output should indicate that the "Wolfram" server is configured.
 
 ### Cursor
 
@@ -107,7 +109,7 @@ To verify the installation:
 
 - Navigate to Cursor settings
 - Select the "Tools & MCP" tab
-- Verify that "WolframLanguage" is listed under "Installed MCP Servers"
+- Verify that "Wolfram" is listed under "Installed MCP Servers"
 
 ### Gemini CLI
 
@@ -121,7 +123,7 @@ To verify the installation from the command line:
 gemini -i "/mcp"
 ```
 
-The output should indicate that the "WolframLanguage" server is configured.
+The output should indicate that the "Wolfram" server is configured.
 
 ### Google Antigravity
 
@@ -134,7 +136,7 @@ To verify the installation:
 - In the editor view, click the "..." menu at the top right of the "Agent" panel
 - Select "MCP Servers"
 - Click "Manage MCP Servers" at the top right of the panel
-- Verify that "WolframLanguage" is listed under "Installed MCP Servers"
+- Verify that "Wolfram" is listed under "Installed MCP Servers"
 
 ### Goose
 
@@ -183,10 +185,10 @@ InstallMCPServer[{"Codex", "/path/to/project"}, "WolframLanguage"]
 To verify the installation from the command line:
 
 ```shell
-codex mcp get WolframLanguage
+codex mcp get Wolfram
 ```
 
-If you installed the server project-level, run the command from that project directory. The output should indicate that the "WolframLanguage" server is enabled.
+If you installed the server project-level, run the command from that project directory. The output should indicate that the "Wolfram" server is enabled.
 
 ### OpenCode
 
@@ -210,7 +212,7 @@ To verify the installation from the command line:
 opencode mcp list
 ```
 
-The output should indicate that the "WolframLanguage" server is connected.
+The output should indicate that the "Wolfram" server is connected.
 
 ### Qwen Code
 
@@ -234,7 +236,7 @@ To verify the installation from the command line:
 qwen mcp list
 ```
 
-The output should indicate that the "WolframLanguage" server is configured.
+The output should indicate that the "Wolfram" server is configured.
 
 ### Visual Studio Code
 

--- a/docs/quickstart-coding.md
+++ b/docs/quickstart-coding.md
@@ -17,7 +17,7 @@ For Wolfram Language development, it's recommended to use the **WolframLanguage*
 
 All installation methods use the `InstallMCPServer` function. Open a Wolfram Language session and run the appropriate command for your application.
 
-> **Note:** Regardless of which server you install (e.g. `"WolframLanguage"`), built-in servers are registered in the client's configuration under the name **Wolfram** by default, so that is the server name shown by client UIs and CLI commands. To register under a different name, pass the `"MCPServerName"` option to `InstallMCPServer` (see [MCPServerName](mcp-clients.md#mcpservername)).
+> **Note:** All built-in servers (e.g. "WolframLanguage") are registered in the client's configuration under the name **Wolfram** by default, so that is the server name shown by client UIs and CLI commands. To register under a different name, pass the "MCPServerName" option to `InstallMCPServer` (see [MCPServerName](mcp-clients.md#mcpservername)).
 
 ### Amazon Q Developer
 


### PR DESCRIPTION
## Summary

Follow-up to #224. Since built-in servers gained `"MCPServerName" -> "Wolfram"` (7840647), `InstallMCPServer` registers them in client configs under the shared **Wolfram** key, so client UIs and CLI commands display the server as "Wolfram". The verification steps in the coding quickstart predate that change and still told users to look for "WolframLanguage" — e.g. `claude mcp get WolframLanguage` fails, since the server is registered as `Wolfram`.

## Changes

- `docs/quickstart-coding.md`: verification steps for Claude Code, Copilot CLI, Cursor, Gemini CLI, Google Antigravity, OpenAI Codex, OpenCode, and Qwen Code now reference the "Wolfram" server name (including the `claude mcp get` / `codex mcp get` commands); added a note to the Installation section explaining that built-in servers register under the "Wolfram" name and pointing to the `"MCPServerName"` option.
- `Documentation/English/Tutorials/QuickStartforAICodingApplications.nb`: same corrections in the corresponding cells.
- `Documentation/Japanese/Tutorials/QuickStartforAICodingApplications.nb`: same corrections, including the `OriginalCellString` translation-tracking metadata for the affected cells so they stay marked in sync with the updated English source.

The Goose and Kimi Code sections already used the correct name (the latter fixed in #224).

## Verification

- `grep` confirms no remaining `mcp get WolframLanguage` / `"WolframLanguage" server` / `「WolframLanguage」` verification references in docs or notebooks.
- Both notebooks still `Get` cleanly as `Notebook` expressions, and the affected cells now read "Wolfram" in both languages.

Note: the tutorial notebooks have drifted from the markdown quickstart independently of this fix (the notebooks lack Amazon Q/Augment/Goose/Qwen/Kimi sections but include Kiro, which the markdown lacks). Left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bp9BwBdY9ELjgnxkKqGUM