### PR TITLE
Resume automatic version increment once the release artifact exists

### DIFF
--- a/Scripts/IncrementPacletVersion.wls
+++ b/Scripts/IncrementPacletVersion.wls
@@ -64,7 +64,8 @@ versionReleasedQ[ _, _, url_String ] :=
         status = Quiet @ URLRead[
             HTTPRequest[ url, <| "Method" -> "HEAD" |> ],
             "StatusCode",
-            TimeConstraint -> $releaseCheckTimeout
+            FollowRedirects -> True, (* Avoids a 302 response *)
+            TimeConstraint  -> $releaseCheckTimeout
         ];
         Which[
             status === 200,

--- a/Scripts/IncrementPacletVersion.wls
+++ b/Scripts/IncrementPacletVersion.wls
@@ -12,6 +12,81 @@ Needs[ "Wolfram`PacletCICD`" -> "cicd`" ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*githubRepository*)
+githubRepository[ dir_ ] := Enclose[
+    Module[ { env, url },
+        env = Environment[ "GITHUB_REPOSITORY" ];
+        If[ StringQ @ env,
+            env,
+            url = ConfirmBy[ gitCommand[ { "remote", "get-url", "origin" }, dir ], StringQ, "OriginURL" ];
+            ConfirmBy[
+                First[
+                    StringCases[
+                        url,
+                        "github.com" ~~ (":" | "/") ~~ owner: Except[ "/" ].. ~~ "/" ~~ name: Except[ "/" ].. :>
+                            owner <> "/" <> StringDelete[ name, ".git" ~~ EndOfString ]
+                    ],
+                    $Failed
+                ],
+                StringQ,
+                "Repository"
+            ]
+        ]
+    ],
+    $Failed &
+];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*releaseAssetURL*)
+releaseAssetURL[ dir_, version_ ] := Enclose[
+    Module[ { repo, name, file },
+        repo = ConfirmBy[ githubRepository @ dir, StringQ, "Repository" ];
+        name = ConfirmBy[ PacletObject[ Flatten @ File @ dir ][ "Name" ], StringQ, "PacletName" ];
+        file = StringReplace[ name, "/" -> "__" ] <> "-" <> version <> ".paclet";
+        TemplateApply[ "https://github.com/`1`/releases/download/v`2`/`3`", { repo, version, file } ]
+    ],
+    $Failed &
+];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*versionReleasedQ*)
+$releaseCheckTimeout = 30;
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+versionReleasedQ[ dir_, version_ ] :=
+    versionReleasedQ[ dir, version, releaseAssetURL[ dir, version ] ];
+
+versionReleasedQ[ _, _, url_String ] :=
+    Module[ { status },
+        status = Quiet @ URLRead[
+            HTTPRequest[ url, <| "Method" -> "HEAD" |> ],
+            "StatusCode",
+            TimeConstraint -> $releaseCheckTimeout
+        ];
+        Which[
+            status === 200,
+                Print[ "Release artifact found: ", url ];
+                True,
+            status === 404,
+                Print[ "Release artifact not found: ", url ];
+                False,
+            True,
+                Print[ "::warning::Release artifact check failed (", ToString[ status, InputForm ], "): ", url ];
+                False
+        ]
+    ];
+
+versionReleasedQ[ _, version_, _ ] := (
+    Print[ "::warning::Unable to determine release artifact URL for version ", version, "." ];
+    False
+);
+(* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*incrementPacletVersion*)
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
@@ -25,7 +100,7 @@ incrementPacletVersion[ dir_ ] := Enclose[
         string  = cs[ ReadString @ file, "ReadString" ];
         version = cs[ PacletObject[ Flatten @ File @ dir ][ "Version" ], "Version" ];
 
-        If[ StringEndsQ[ version, "." ~~ "0".. ~~ EndOfString ],
+        If[ StringEndsQ[ version, "." ~~ "0".. ~~ EndOfString ] && ! TrueQ @ versionReleasedQ[ dir, version ],
             Print[ "Skipping paclet version update: ", version ];
             Throw @ version
         ];


### PR DESCRIPTION
## Summary

The IncrementPacletVersion workflow skips versions ending in `.0`, since that's the convention for a manually-set release version that shouldn't be bumped before the Release action runs. However, this meant the version had to be incremented manually after each release to get auto-increment working again.

This change makes the skip conditional on whether the release has actually been published. When the version ends in `.0`, the script now sends a HEAD request for the corresponding release artifact (`https://github.com/<repo>/releases/download/v<version>/<paclet-file>.paclet`):

- **200** → the release exists, so auto-increment resumes (e.g. `2.2.0` → `2.2.1`)
- **404** → not yet released, so the version is left alone (previous behavior)
- **anything else** (network failure, unexpected status, undeterminable URL) → logs a `::warning::` annotation and falls back to skipping, so a transient GitHub problem can never wrongly bump a pre-release version or fail the workflow; the check self-heals on the next push to main

### Why check the release artifact rather than the tag or the REST API

- The release download URL is served from the releases CDN, so no `GITHUB_TOKEN` plumbing is needed — unlike `api.github.com`, which rate-limits unauthenticated requests from shared Actions runner IPs.
- `gh release create` in Release.yml creates the tag, release, and assets together, and PacletCICD sets the tag to `"v" <> version` (`BuildPaclet.wl`), so the artifact's existence is the strictest "release actually completed" signal — a bare tag check could pass for a deleted or half-created release.

Nothing is hard-coded: the repository comes from `GITHUB_REPOSITORY` (falling back to parsing the `origin` remote URL for local runs) and the asset name is derived from the paclet's `Name` and version. Non-`.0` versions never make a network call, and no workflow YAML changes are required.

Note: since `PacletInfo.wl` is currently at 2.2.0 and [v2.2.0](https://github.com/WolframResearch/AgentTools/releases/tag/v2.2.0) is already published, the first push to main after this merges should auto-bump the version to 2.2.1.

## Test plan

- [x] Verified in a kernel session using the definitions extracted from the modified script:
  - URL construction produces `.../releases/download/v2.2.0/Wolfram__AgentTools-2.2.0.paclet`
  - Live checks: `versionReleasedQ` returns `True` for released `2.2.0`, `False` for unreleased `2.3.0`
  - End-to-end `incrementPacletVersion` on temp `PacletInfo.wl` copies: `2.2.0` → `2.2.1` (resume case), `2.3.0` → skipped, `2.2.1` → `2.2.2` (normal increment, no network call)
  - Repository detection via both `GITHUB_REPOSITORY` and `git remote get-url origin` parsing
  - Fail-safe paths (no repository determinable, unresolvable host) both warn and skip
- [x] CodeInspector reports no issues for the modified script
- [ ] After merging: confirm the next push to main bumps `2.2.0` → `2.2.1` in the Increment Paclet Version workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BahTo2TcpBswpZVPSRVvJ5