### PR TITLE
Work around false messages in WolframLanguageEvaluator tool results

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: wolframresearch/wolframengine:14.3
+      image: wolframresearch/wolframengine:15.0
       options: --user root
 
     env:

--- a/.github/workflows/ExperimentalRelease.yml
+++ b/.github/workflows/ExperimentalRelease.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 15
 
     container:
-      image: wolframresearch/wolframengine:14.3
+      image: wolframresearch/wolframengine:15.0
       options: --user root
 
     steps:

--- a/.github/workflows/IncrementPacletVersion.yml
+++ b/.github/workflows/IncrementPacletVersion.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
 
     container:
-      image: wolframresearch/wolframengine:14.3
+      image: wolframresearch/wolframengine:15.0
       options: --user root
 
     steps:

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: wolframresearch/wolframengine:14.3
+      image: wolframresearch/wolframengine:15.0
       options: --user root
 
     env:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: wolframresearch/wolframengine:14.3
+      image: wolframresearch/wolframengine:15.0
       options: --user root
 
     env:
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: wolframresearch/wolframengine:14.3
+      image: wolframresearch/wolframengine:15.0
       options: --user root
 
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #     -e MCP_SERVER_NAME=Wolfram \
 #     ghcr.io/wolframresearch/mcpserver:latest
 
-FROM wolframresearch/wolframengine:14.3
+FROM wolframresearch/wolframengine:15.0
 
 LABEL org.opencontainers.image.title="Wolfram MCP Server"
 LABEL org.opencontainers.image.description="Model Context Protocol server for Wolfram Language"

--- a/Kernel/Tools/Context.wl
+++ b/Kernel/Tools/Context.wl
@@ -321,10 +321,10 @@ relatedWolframAlphaResults // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*documentationProvidedOptions*)
 
-(* Chatbook 2.7.2+ (targeting 15.0) supports a "DocumentationProvided" option for RelatedWolframAlphaResults,
+(* Chatbook 2.7.2+ supports a "DocumentationProvided" option for RelatedWolframAlphaResults,
    which indicates that RelatedDocumentation results are being provided separately so that it can skip
-   Wolfram|Alpha queries that are better answered by documentation. AgentTools only requires Chatbook 2.3.0
-   (14.3), so the option is only passed when it's both relevant (the combined WolframContext tool, which
+   Wolfram|Alpha queries that are better answered by documentation. AgentTools only requires Chatbook 2.7.0,
+   so the option is only passed when it's both relevant (the combined WolframContext tool, which
    provides documentation alongside the Wolfram|Alpha results) and supported by the loaded Chatbook version. *)
 documentationProvidedOptions // beginDefinition;
 

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -151,10 +151,11 @@ evaluateWolframLanguage0[ code_String, timeConstraint_Integer ] :=
             code,
             "String",
             "Line"                  -> $line++,
-            "MaxCharacterCount"     -> $maxCharacterCount,
             "AppendRetryNotice"     -> False,
             "AppendURIInstructions" -> False,
+            "MaxCharacterCount"     -> $maxCharacterCount,
             "Method"                -> getEvaluatorMethod[ ],
+            "PropagateMessages"     -> True,
             "TimeConstraint"        -> timeConstraint
         ]
     ];
@@ -304,10 +305,11 @@ evaluateWolframLanguageForUI[ code_String, timeConstraint_Integer ] :=
             code,
             { "String", "Result" },
             "Line"                  -> $line++,
-            "MaxCharacterCount"     -> $maxCharacterCount,
             "AppendRetryNotice"     -> False,
             "AppendURIInstructions" -> False,
+            "MaxCharacterCount"     -> $maxCharacterCount,
             "Method"                -> getEvaluatorMethod[ ],
+            "PropagateMessages"     -> True,
             "TimeConstraint"        -> timeConstraint
         ]
     ];

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -274,8 +274,11 @@ evaluateWolframLanguageUI // beginDefinition;
 evaluateWolframLanguageUI[ code_String, _Missing ] :=
     evaluateWolframLanguageUI[ code, toolOptionValue[ "WolframLanguageEvaluator", "TimeConstraint" ] ];
 
-evaluateWolframLanguageUI[ code_String, timeConstraint_Integer ] :=
+evaluateWolframLanguageUI[ code_String, timeConstraint_Integer ] := Enclose[
     Module[ { savedLine, result, uiResult },
+        (* Same guard as the non-UI path: WolframLanguageToolEvaluate options like "PropagateMessages"
+           require the minimum Chatbook version, and older versions silently ignore unknown options. *)
+        ConfirmMatch[ chatbookVersionCheck[ ], True, "ChatbookVersionCheck" ];
         savedLine = $line;
         result = evaluateWolframLanguageForUI[ code, timeConstraint ];
         uiResult = Quiet @ UsingFrontEnd @ makeEvaluatorUIResult[ code, result ];
@@ -289,7 +292,9 @@ evaluateWolframLanguageUI[ code_String, timeConstraint_Integer ] :=
                 evaluateWolframLanguage[ code, timeConstraint ]
             ]
         ]
-    ];
+    ],
+    throwInternalFailure
+];
 
 evaluateWolframLanguageUI // endDefinition;
 

--- a/Kernel/Utilities.wl
+++ b/Kernel/Utilities.wl
@@ -233,7 +233,7 @@ llmKitUsageLimitMessage // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Dependencies*)
-$minimumChatbookVersion = "2.7.0"; (* available in cloud and on public paclet server *)
+$minimumChatbookVersion = "2.7.0"; (* requires WL 15.0+; available in cloud and on public paclet server *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)

--- a/Kernel/Utilities.wl
+++ b/Kernel/Utilities.wl
@@ -233,7 +233,7 @@ llmKitUsageLimitMessage // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Dependencies*)
-$minimumChatbookVersion = "2.3.0";
+$minimumChatbookVersion = "2.7.0"; (* available in cloud and on public paclet server *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)

--- a/MCPB/Description.md
+++ b/MCPB/Description.md
@@ -1,5 +1,5 @@
 Implements a Model Context Protocol (MCP) server using Wolfram Language, enabling LLMs to access Wolfram Language computation capabilities.
 
-**Important:** This requires [Wolfram Engine](https://www.wolfram.com/engine/) or [Mathematica](https://www.wolfram.com/mathematica/) (version 14.3 or later) to be installed in order to run.
+**Important:** This requires [Wolfram Engine](https://www.wolfram.com/engine/) or [Mathematica](https://www.wolfram.com/mathematica/) (version 15.0 or later) to be installed in order to run.
 
 For full functionality, you will also need an [LLMKit subscription](https://www.wolfram.com/notebook-assistant-llm-kit).

--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -3,7 +3,7 @@ PacletObject[ <|
     "Description"      -> "Provides tools and integrations for connecting Wolfram Language to AI agents and LLMs",
     "Creator"          -> "Richard Hennigan (Wolfram Research)",
     "Version"          -> "2.2.2",
-    "WolframVersion"   -> "14.3+",
+    "WolframVersion"   -> "15.0+",
     "PublisherID"      -> "Wolfram",
     "License"          -> "MIT",
     "ReleaseID"        -> "$RELEASE_ID$",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Wolfram/AgentTools](https://paclets.com/Wolfram/AgentTools)
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Wolfram Version](https://img.shields.io/badge/Wolfram-14.3%2B-red.svg)](https://www.wolfram.com/language/)
+[![Wolfram Version](https://img.shields.io/badge/Wolfram-15.0%2B-red.svg)](https://www.wolfram.com/language/)
 
 A Wolfram Language toolkit for integrating with AI agents and LLMs — providing [MCP](https://modelcontextprotocol.io) servers, agent skills, and other standard interfaces that give AI systems access to Wolfram's computational capabilities.
 
@@ -36,7 +36,7 @@ A Wolfram Language toolkit for integrating with AI agents and LLMs — providing
 
 ## Requirements
 
-- Wolfram Language 14.3 or higher
+- Wolfram Language 15.0 or higher
 - An MCP-compatible client application (see [Supported Clients](#supported-clients))
 - Optional: [LLMKit subscription](https://www.wolfram.com/notebook-assistant-llm-kit) for enhanced semantic search capabilities
 

--- a/ResourceDefinition.nb
+++ b/ResourceDefinition.nb
@@ -16675,7 +16675,7 @@ Notebook[
                },
                CellID -> 389299396
               ],
-              Cell["14.3+", "Text", CellID -> 450354368]
+              Cell["15.0+", "Text", CellID -> 450354368]
              },
              Open
             ]

--- a/Tests/Tools.wlt
+++ b/Tests/Tools.wlt
@@ -427,6 +427,60 @@ VerificationTest[
 ]
 
 (* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*UI Evaluation Path*)
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* The UI path passes WolframLanguageToolEvaluate options (e.g. "PropagateMessages") that require the
+   minimum Chatbook version, and older Chatbook versions silently ignore unknown options, so it must run
+   the same version check as the non-UI path. Downstream functions are mocked so no front end, cloud
+   deployment, or sandbox evaluation is involved. *)
+VerificationTest[
+    Module[ { checked = False },
+        Block[
+            {
+                Wolfram`AgentTools`Common`chatbookVersionCheck =
+                    Function[ checked = True; True ],
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`evaluateWolframLanguageForUI =
+                    Function[ <| "String" -> "Out[1]= 2", "Result" -> HoldForm[ 2 ] |> ],
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`makeEvaluatorUIResult =
+                    Function[ <| "Content" -> { <| "type" -> "text", "text" -> "ok" |> } |> ],
+                UsingFrontEnd = # &
+            },
+            {
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`evaluateWolframLanguageUI[ "1 + 1", 10 ],
+                checked
+            }
+        ]
+    ],
+    { KeyValuePattern[ "Content" -> { __Association } ], True },
+    SameTest -> MatchQ,
+    TestID   -> "WolframLanguageEvaluator-UIPathVersionCheck@@Tests/Tools.wlt:440,1-461,2"
+]
+
+(* A failing version check aborts the UI path before any evaluation is attempted: *)
+VerificationTest[
+    Module[ { evaluated = False, result },
+        result = Quiet @ Wolfram`AgentTools`Common`catchAlways @ Block[
+            {
+                Wolfram`AgentTools`Common`chatbookVersionCheck = Function[ $Failed ],
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`evaluateWolframLanguageForUI =
+                    Function[ evaluated = True; <| "String" -> "Out[1]= 2", "Result" -> HoldForm[ 2 ] |> ]
+            },
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`evaluateWolframLanguageUI[ "1 + 1", 10 ]
+        ];
+        { FailureQ @ result, evaluated }
+    ],
+    { True, False },
+    SameTest -> SameQ,
+    TestID   -> "WolframLanguageEvaluator-UIPathVersionCheckFailure@@Tests/Tools.wlt:464,1-479,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*WolframAlpha*)
 
@@ -437,14 +491,14 @@ VerificationTest[
     $wolframAlphaTool = $DefaultMCPTools[ "WolframAlpha" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlpha-GetTool@@Tests/Tools.wlt:436,1-441,2"
+    TestID   -> "WolframAlpha-GetTool@@Tests/Tools.wlt:490,1-495,2"
 ]
 
 VerificationTest[
     $waResult = $wolframAlphaTool[ <| "query" -> "population of France" |> ],
     _String? StringQ | KeyValuePattern[ "Content" -> { __Association } ],
     SameTest -> MatchQ,
-    TestID   -> "WolframAlpha-BasicQuery@@Tests/Tools.wlt:443,1-448,2"
+    TestID   -> "WolframAlpha-BasicQuery@@Tests/Tools.wlt:497,1-502,2"
 ]
 
 VerificationTest[
@@ -455,14 +509,14 @@ VerificationTest[
         ],
     _String? StringQ,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlpha-ResultString@@Tests/Tools.wlt:450,1-459,2"
+    TestID   -> "WolframAlpha-ResultString@@Tests/Tools.wlt:504,1-513,2"
 ]
 
 VerificationTest[
     StringLength @ $waResultString > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframAlpha-NonEmptyResult@@Tests/Tools.wlt:461,1-466,2"
+    TestID   -> "WolframAlpha-NonEmptyResult@@Tests/Tools.wlt:515,1-520,2"
 ]
 
 (* TODO: multiple queries aren't supported until the next Chatbook paclet update *)
@@ -491,28 +545,28 @@ VerificationTest[
     $wlContextTool = $DefaultMCPTools[ "WolframLanguageContext" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageContext-GetTool@@Tests/Tools.wlt:490,1-495,2"
+    TestID   -> "WolframLanguageContext-GetTool@@Tests/Tools.wlt:544,1-549,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     $wlContextResult = $wlContextTool[ <| "context" -> "How to create a list of prime numbers in Wolfram Language" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageContext-BasicQuery@@Tests/Tools.wlt:497,23-502,2"
+    TestID   -> "WolframLanguageContext-BasicQuery@@Tests/Tools.wlt:551,23-556,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringLength[ extractToolText @ $wlContextResult ] > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageContext-NonEmptyResult@@Tests/Tools.wlt:504,23-509,2"
+    TestID   -> "WolframLanguageContext-NonEmptyResult@@Tests/Tools.wlt:558,23-563,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringContainsQ[ extractToolText @ $wlContextResult, "Prime" | "prime" | "Table" | "Range", IgnoreCase -> True ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageContext-RelevantContent@@Tests/Tools.wlt:511,23-516,2"
+    TestID   -> "WolframLanguageContext-RelevantContent@@Tests/Tools.wlt:565,23-570,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -526,21 +580,21 @@ VerificationTest[
     $waContextTool = $DefaultMCPTools[ "WolframAlphaContext" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlphaContext-GetTool@@Tests/Tools.wlt:525,1-530,2"
+    TestID   -> "WolframAlphaContext-GetTool@@Tests/Tools.wlt:579,1-584,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     $waContextResult = $waContextTool[ <| "context" -> "What is the distance from Earth to Mars" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlphaContext-BasicQuery@@Tests/Tools.wlt:532,23-537,2"
+    TestID   -> "WolframAlphaContext-BasicQuery@@Tests/Tools.wlt:586,23-591,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringLength[ extractToolText @ $waContextResult ] > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframAlphaContext-NonEmptyResult@@Tests/Tools.wlt:539,23-544,2"
+    TestID   -> "WolframAlphaContext-NonEmptyResult@@Tests/Tools.wlt:593,23-598,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -554,21 +608,21 @@ VerificationTest[
     $wolframContextTool = $DefaultMCPTools[ "WolframContext" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframContext-GetTool@@Tests/Tools.wlt:553,1-558,2"
+    TestID   -> "WolframContext-GetTool@@Tests/Tools.wlt:607,1-612,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     $wolframContextResult = $wolframContextTool[ <| "context" -> "How to compute derivatives symbolically" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframContext-BasicQuery@@Tests/Tools.wlt:560,23-565,2"
+    TestID   -> "WolframContext-BasicQuery@@Tests/Tools.wlt:614,23-619,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringLength[ extractToolText @ $wolframContextResult ] > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframContext-NonEmptyResult@@Tests/Tools.wlt:567,23-572,2"
+    TestID   -> "WolframContext-NonEmptyResult@@Tests/Tools.wlt:621,23-626,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -610,7 +664,7 @@ VerificationTest[
     ],
     _String? (StringContainsQ[ "usage limit" ]),
     SameTest -> MatchQ,
-    TestID   -> "RelatedWolframAlphaResults-UsageLimitMessage@@Tests/Tools.wlt:603,1-614,2"
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitMessage@@Tests/Tools.wlt:657,1-668,2"
 ]
 
 (* The service's own error message is surfaced to the agent. *)
@@ -618,7 +672,7 @@ VerificationTest[
     StringContainsQ[ $waUsageLimitResult, "credits-per-month-limit-exceeded" ],
     True,
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframAlphaResults-UsageLimitIncludesServiceMessage@@Tests/Tools.wlt:617,1-622,2"
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitIncludesServiceMessage@@Tests/Tools.wlt:671,1-676,2"
 ]
 
 (* It is NOT a Failure, so the MCP layer will not flag it as an error or emit a bug report. *)
@@ -626,7 +680,7 @@ VerificationTest[
     FailureQ @ $waUsageLimitResult,
     False,
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframAlphaResults-UsageLimitNotFailure@@Tests/Tools.wlt:625,1-630,2"
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitNotFailure@@Tests/Tools.wlt:679,1-684,2"
 ]
 
 (* The caller's message level (e.g. "Warning" from the combined WolframContext tool) is honored. *)
@@ -643,7 +697,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframAlphaResults-UsageLimitLevel@@Tests/Tools.wlt:633,1-647,2"
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitLevel@@Tests/Tools.wlt:687,1-701,2"
 ]
 
 (* A genuine string result is still returned unchanged (regression guard). *)
@@ -657,7 +711,7 @@ VerificationTest[
     ],
     "Some Wolfram|Alpha context.",
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframAlphaResults-NormalResultUnchanged@@Tests/Tools.wlt:650,1-661,2"
+    TestID   -> "RelatedWolframAlphaResults-NormalResultUnchanged@@Tests/Tools.wlt:704,1-715,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -675,14 +729,14 @@ VerificationTest[
     ],
     _String? (StringContainsQ[ "usage limit" ]),
     SameTest -> MatchQ,
-    TestID   -> "RelatedDocumentation-UsageLimitMessage@@Tests/Tools.wlt:667,1-679,2"
+    TestID   -> "RelatedDocumentation-UsageLimitMessage@@Tests/Tools.wlt:721,1-733,2"
 ]
 
 VerificationTest[
     FailureQ @ $docUsageLimitResult,
     False,
     SameTest -> SameQ,
-    TestID   -> "RelatedDocumentation-UsageLimitNotFailure@@Tests/Tools.wlt:681,1-686,2"
+    TestID   -> "RelatedDocumentation-UsageLimitNotFailure@@Tests/Tools.wlt:735,1-740,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -703,14 +757,14 @@ VerificationTest[
     ],
     _String? (StringContainsQ[ "usage limit" ]),
     SameTest -> MatchQ,
-    TestID   -> "RelatedWolframContext-UsageLimitMessage@@Tests/Tools.wlt:694,1-707,2"
+    TestID   -> "RelatedWolframContext-UsageLimitMessage@@Tests/Tools.wlt:748,1-761,2"
 ]
 
 VerificationTest[
     FailureQ @ $wcUsageLimitResult,
     False,
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframContext-UsageLimitNotFailure@@Tests/Tools.wlt:709,1-714,2"
+    TestID   -> "RelatedWolframContext-UsageLimitNotFailure@@Tests/Tools.wlt:763,1-768,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -739,7 +793,7 @@ VerificationTest[
     ],
     { True, False, True },
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframContext-LLMKitDisabledNoWarning@@Tests/Tools.wlt:723,1-743,2"
+    TestID   -> "RelatedWolframContext-LLMKitDisabledNoWarning@@Tests/Tools.wlt:777,1-797,2"
 ]
 
 (* Regression guard: a genuinely unsubscribed user (LLMKit still enabled) DOES get the subscription
@@ -766,7 +820,7 @@ VerificationTest[
     ],
     { True, True, True },
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframContext-UnsubscribedStillWarns@@Tests/Tools.wlt:748,1-770,2"
+    TestID   -> "RelatedWolframContext-UnsubscribedStillWarns@@Tests/Tools.wlt:802,1-824,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)
@@ -776,7 +830,7 @@ VerificationTest[
 (*DocumentationProvided Option*)
 
 (* Chatbook 2.7.2+ supports a "DocumentationProvided" option for RelatedWolframAlphaResults indicating that
-   RelatedDocumentation results are provided separately. AgentTools only requires Chatbook 2.3.0, so the
+   RelatedDocumentation results are provided separately. AgentTools only requires Chatbook 2.7.0, so the
    option must only be passed when the loaded Chatbook actually supports it, and only from the combined
    WolframContext tool, where documentation results actually accompany the Wolfram|Alpha results. *)
 
@@ -793,7 +847,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`documentationProvidedAvailableQ @ mockRelatedWAResultsNew,
     True,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedAvailableQ-Supported@@Tests/Tools.wlt:791,1-797,2"
+    TestID   -> "DocumentationProvidedAvailableQ-Supported@@Tests/Tools.wlt:845,1-851,2"
 ]
 
 (* An older Chatbook without the option is reported as unsupported: *)
@@ -802,7 +856,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`documentationProvidedAvailableQ @ mockRelatedWAResultsOld,
     False,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedAvailableQ-Unsupported@@Tests/Tools.wlt:800,1-806,2"
+    TestID   -> "DocumentationProvidedAvailableQ-Unsupported@@Tests/Tools.wlt:854,1-860,2"
 ]
 
 (* A Block-mocked RelatedWolframAlphaResults (as used elsewhere in this file) evaluates to a Function;
@@ -811,7 +865,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`documentationProvidedAvailableQ[ "mocked" & ],
     False,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedAvailableQ-NonSymbol@@Tests/Tools.wlt:810,1-815,2"
+    TestID   -> "DocumentationProvidedAvailableQ-NonSymbol@@Tests/Tools.wlt:864,1-869,2"
 ]
 
 (* The zero-argument form probes the Chatbook in use and returns a definite boolean: *)
@@ -819,7 +873,7 @@ VerificationTest[
     BooleanQ @ Wolfram`AgentTools`Common`documentationProvidedAvailableQ[ ],
     True,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedAvailableQ-Boolean@@Tests/Tools.wlt:818,1-823,2"
+    TestID   -> "DocumentationProvidedAvailableQ-Boolean@@Tests/Tools.wlt:872,1-877,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -833,7 +887,7 @@ VerificationTest[
     ],
     { },
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedOptions-NotProvided@@Tests/Tools.wlt:830,1-837,2"
+    TestID   -> "DocumentationProvidedOptions-NotProvided@@Tests/Tools.wlt:884,1-891,2"
 ]
 
 (* From the combined tool with a supporting Chatbook, the option is included: *)
@@ -843,7 +897,7 @@ VerificationTest[
     ],
     { "DocumentationProvided" -> True },
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedOptions-Supported@@Tests/Tools.wlt:840,1-847,2"
+    TestID   -> "DocumentationProvidedOptions-Supported@@Tests/Tools.wlt:894,1-901,2"
 ]
 
 (* From the combined tool with an older Chatbook, the option is omitted: *)
@@ -853,7 +907,7 @@ VerificationTest[
     ],
     { },
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedOptions-Unsupported@@Tests/Tools.wlt:850,1-857,2"
+    TestID   -> "DocumentationProvidedOptions-Unsupported@@Tests/Tools.wlt:904,1-911,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -875,14 +929,14 @@ VerificationTest[
     ],
     "Some Wolfram|Alpha context.",
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvided-StandaloneResultUnchanged@@Tests/Tools.wlt:865,1-879,2"
+    TestID   -> "DocumentationProvided-StandaloneResultUnchanged@@Tests/Tools.wlt:919,1-933,2"
 ]
 
 VerificationTest[
     MemberQ[ $capturedWAArguments, "DocumentationProvided" -> _ ],
     False,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvided-NotPassedStandalone@@Tests/Tools.wlt:881,1-886,2"
+    TestID   -> "DocumentationProvided-NotPassedStandalone@@Tests/Tools.wlt:935,1-940,2"
 ]
 
 (* The combined WolframContext tool passes the option when the loaded Chatbook supports it: *)
@@ -901,14 +955,14 @@ VerificationTest[
     ],
     _String? (StringContainsQ[ "Some Wolfram|Alpha context." ]),
     SameTest -> MatchQ,
-    TestID   -> "DocumentationProvided-CombinedResult@@Tests/Tools.wlt:889,1-905,2"
+    TestID   -> "DocumentationProvided-CombinedResult@@Tests/Tools.wlt:943,1-959,2"
 ]
 
 VerificationTest[
     MemberQ[ $capturedWAArguments, "DocumentationProvided" -> True ],
     True,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvided-PassedFromCombined@@Tests/Tools.wlt:907,1-912,2"
+    TestID   -> "DocumentationProvided-PassedFromCombined@@Tests/Tools.wlt:961,1-966,2"
 ]
 
 (* The combined tool must not pass the option to an older Chatbook that does not support it: *)
@@ -928,7 +982,7 @@ VerificationTest[
     MemberQ[ $capturedWAArguments, "DocumentationProvided" -> _ ],
     False,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvided-NotPassedUnsupported@@Tests/Tools.wlt:915,1-932,2"
+    TestID   -> "DocumentationProvided-NotPassedUnsupported@@Tests/Tools.wlt:969,1-986,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)
@@ -946,14 +1000,14 @@ VerificationTest[
     $testReportTool = $DefaultMCPTools[ "TestReport" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "TestReport-GetTool@@Tests/Tools.wlt:945,1-950,2"
+    TestID   -> "TestReport-GetTool@@Tests/Tools.wlt:999,1-1004,2"
 ]
 
 VerificationTest[
     $testResourceDirectory = FileNameJoin @ { DirectoryName[ $TestFileName, 2 ], "TestResources" },
     _String? DirectoryQ,
     SameTest -> MatchQ,
-    TestID   -> "TestReport-TestResourceDirectory@@Tests/Tools.wlt:952,1-957,2"
+    TestID   -> "TestReport-TestResourceDirectory@@Tests/Tools.wlt:1006,1-1011,2"
 ]
 
 VerificationTest[
@@ -963,7 +1017,7 @@ VerificationTest[
     |>,
     _String? (StringContainsQ[ "# Test Results Summary"~~__~~"TestFile1.wlt" ]),
     SameTest -> MatchQ,
-    TestID   -> "TestReport-SingleFile@@Tests/Tools.wlt:959,1-967,2"
+    TestID   -> "TestReport-SingleFile@@Tests/Tools.wlt:1013,1-1021,2"
 ]
 
 VerificationTest[
@@ -977,7 +1031,7 @@ VerificationTest[
     |>,
     _String? (StringContainsQ[ "# Test Results Summary"~~__~~"TestFile1.wlt"~~__~~"TestFile2.wlt" ]),
     SameTest -> MatchQ,
-    TestID   -> "TestReport-MultipleFiles@@Tests/Tools.wlt:969,1-981,2"
+    TestID   -> "TestReport-MultipleFiles@@Tests/Tools.wlt:1023,1-1035,2"
 ]
 
 VerificationTest[
@@ -987,7 +1041,7 @@ VerificationTest[
     |>,
     _String? (StringContainsQ[ "# Test Results Summary"~~__~~"TestFile1.wlt"~~__~~"TestFile2.wlt" ]),
     SameTest -> MatchQ,
-    TestID   -> "TestReport-Directory@@Tests/Tools.wlt:983,1-991,2"
+    TestID   -> "TestReport-Directory@@Tests/Tools.wlt:1037,1-1045,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1023,7 +1077,7 @@ skipIfGitHubActions @ VerificationTest[
     ],
     True,
     SameTest -> MatchQ,
-    TestID   -> "TestReport-McpRootRelativePath@@Tests/Tools.wlt:1000,23-1027,2"
+    TestID   -> "TestReport-McpRootRelativePath@@Tests/Tools.wlt:1054,23-1081,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1036,7 +1090,7 @@ VerificationTest[
     Failure[ "AgentTools::TestFileNotFound", _Association ],
     { AgentTools::TestFileNotFound },
     SameTest -> MatchQ,
-    TestID   -> "TestReport-NonexistentFile-GH#65@@Tests/Tools.wlt:1034,1-1040,2"
+    TestID   -> "TestReport-NonexistentFile-GH#65@@Tests/Tools.wlt:1088,1-1094,2"
 ]
 
 VerificationTest[
@@ -1044,7 +1098,7 @@ VerificationTest[
     _? (FreeQ[ "AgentTools::Internal" ]),
     { AgentTools::TestFileNotFound },
     SameTest -> MatchQ,
-    TestID   -> "TestReport-NoInternalFailure-GH#65@@Tests/Tools.wlt:1042,1-1048,2"
+    TestID   -> "TestReport-NoInternalFailure-GH#65@@Tests/Tools.wlt:1096,1-1102,2"
 ]
 
 VerificationTest[
@@ -1057,7 +1111,7 @@ VerificationTest[
     _? (FreeQ[ "AgentTools::Internal" ]),
     { AgentTools::TestFileNotFound },
     SameTest -> MatchQ,
-    TestID   -> "TestReport-MixedValidInvalidPaths-GH#65@@Tests/Tools.wlt:1050,1-1061,2"
+    TestID   -> "TestReport-MixedValidInvalidPaths-GH#65@@Tests/Tools.wlt:1104,1-1115,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1074,7 +1128,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "ToolProperties-AllHaveNames@@Tests/Tools.wlt:1070,1-1078,2"
+    TestID   -> "ToolProperties-AllHaveNames@@Tests/Tools.wlt:1124,1-1132,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1087,7 +1141,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "ToolProperties-AllHaveDescriptions@@Tests/Tools.wlt:1083,1-1091,2"
+    TestID   -> "ToolProperties-AllHaveDescriptions@@Tests/Tools.wlt:1137,1-1145,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1100,5 +1154,5 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "ToolProperties-AllHaveParameters@@Tests/Tools.wlt:1096,1-1104,2"
+    TestID   -> "ToolProperties-AllHaveParameters@@Tests/Tools.wlt:1150,1-1158,2"
 ]

--- a/Tests/Tools.wlt
+++ b/Tests/Tools.wlt
@@ -364,6 +364,69 @@ VerificationTest[
 ]
 
 (* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Messages*)
+
+(* Messages issued during evaluation are captured in the tool result text. With "PropagateMessages" -> True,
+   they also fire normally at top level (where StartMCPServer handles them when running as a server), which
+   is why this test declares First::nofirst as an expected message. *)
+VerificationTest[
+    $evalResultMsg1 = $evaluatorTool[ <| "code" -> "First[{}]" |> ],
+    _String | _Association,
+    { First::nofirst },
+    SameTest -> MatchQ,
+    TestID   -> "WolframLanguageEvaluator-GenuineMessage@@Tests/Tools.wlt:373,1-379,2"
+]
+
+VerificationTest[
+    StringContainsQ[ extractToolText @ $evalResultMsg1, "First::nofirst" ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "WolframLanguageEvaluator-GenuineMessageCaptured@@Tests/Tools.wlt:381,1-386,2"
+]
+
+(* Messages quieted by the evaluated code do not appear in the tool result: *)
+VerificationTest[
+    StringFreeQ[ extractToolText @ $evaluatorTool[ <| "code" -> "Quiet[First[{}]]" |> ], "First::nofirst" ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "WolframLanguageEvaluator-QuietedMessageNotReported@@Tests/Tools.wlt:389,1-394,2"
+]
+
+(* Messages suppressed by kernel-internal mechanisms do not appear in the tool result: *)
+VerificationTest[
+    StringFreeQ[
+        extractToolText @ $evaluatorTool[ <| "code" -> "Internal`DeactivateMessages[First[{}], First::nofirst]" |> ],
+        "First::nofirst"
+    ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "WolframLanguageEvaluator-DeactivatedMessageNotReported@@Tests/Tools.wlt:397,1-405,2"
+]
+
+(* Messages that internal kernel code issues and suppresses during evaluation (e.g. inside FullSimplify)
+   were previously misreported in tool results as false "-- Message text not found --" entries.
+   "PropagateMessages" -> True makes the sandbox report only messages that actually surface: *)
+VerificationTest[
+    $evalResultMsg2 = extractToolText @ $evaluatorTool[
+        <|
+            "code"           -> "FullSimplify[Integrate[a + b Log[c Log[d x^n]^p], x], {d>0, x>0, n!=0}]",
+            "timeConstraint" -> 120
+        |>
+    ],
+    _String? (StringContainsQ[ "ExpIntegralEi" ]),
+    SameTest -> MatchQ,
+    TestID   -> "WolframLanguageEvaluator-InternallySuppressedMessages@@Tests/Tools.wlt:410,1-420,2"
+]
+
+VerificationTest[
+    StringFreeQ[ $evalResultMsg2, { "Message text not found", "::ivar", "General::messages" } ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "WolframLanguageEvaluator-InternallySuppressedMessagesNotReported@@Tests/Tools.wlt:422,1-427,2"
+]
+
+(* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*WolframAlpha*)
 
@@ -374,14 +437,14 @@ VerificationTest[
     $wolframAlphaTool = $DefaultMCPTools[ "WolframAlpha" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlpha-GetTool@@Tests/Tools.wlt:373,1-378,2"
+    TestID   -> "WolframAlpha-GetTool@@Tests/Tools.wlt:436,1-441,2"
 ]
 
 VerificationTest[
     $waResult = $wolframAlphaTool[ <| "query" -> "population of France" |> ],
     _String? StringQ | KeyValuePattern[ "Content" -> { __Association } ],
     SameTest -> MatchQ,
-    TestID   -> "WolframAlpha-BasicQuery@@Tests/Tools.wlt:380,1-385,2"
+    TestID   -> "WolframAlpha-BasicQuery@@Tests/Tools.wlt:443,1-448,2"
 ]
 
 VerificationTest[
@@ -392,14 +455,14 @@ VerificationTest[
         ],
     _String? StringQ,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlpha-ResultString@@Tests/Tools.wlt:387,1-396,2"
+    TestID   -> "WolframAlpha-ResultString@@Tests/Tools.wlt:450,1-459,2"
 ]
 
 VerificationTest[
     StringLength @ $waResultString > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframAlpha-NonEmptyResult@@Tests/Tools.wlt:398,1-403,2"
+    TestID   -> "WolframAlpha-NonEmptyResult@@Tests/Tools.wlt:461,1-466,2"
 ]
 
 (* TODO: multiple queries aren't supported until the next Chatbook paclet update *)
@@ -428,28 +491,28 @@ VerificationTest[
     $wlContextTool = $DefaultMCPTools[ "WolframLanguageContext" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageContext-GetTool@@Tests/Tools.wlt:427,1-432,2"
+    TestID   -> "WolframLanguageContext-GetTool@@Tests/Tools.wlt:490,1-495,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     $wlContextResult = $wlContextTool[ <| "context" -> "How to create a list of prime numbers in Wolfram Language" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframLanguageContext-BasicQuery@@Tests/Tools.wlt:434,23-439,2"
+    TestID   -> "WolframLanguageContext-BasicQuery@@Tests/Tools.wlt:497,23-502,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringLength[ extractToolText @ $wlContextResult ] > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageContext-NonEmptyResult@@Tests/Tools.wlt:441,23-446,2"
+    TestID   -> "WolframLanguageContext-NonEmptyResult@@Tests/Tools.wlt:504,23-509,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringContainsQ[ extractToolText @ $wlContextResult, "Prime" | "prime" | "Table" | "Range", IgnoreCase -> True ],
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframLanguageContext-RelevantContent@@Tests/Tools.wlt:448,23-453,2"
+    TestID   -> "WolframLanguageContext-RelevantContent@@Tests/Tools.wlt:511,23-516,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -463,21 +526,21 @@ VerificationTest[
     $waContextTool = $DefaultMCPTools[ "WolframAlphaContext" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlphaContext-GetTool@@Tests/Tools.wlt:462,1-467,2"
+    TestID   -> "WolframAlphaContext-GetTool@@Tests/Tools.wlt:525,1-530,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     $waContextResult = $waContextTool[ <| "context" -> "What is the distance from Earth to Mars" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframAlphaContext-BasicQuery@@Tests/Tools.wlt:469,23-474,2"
+    TestID   -> "WolframAlphaContext-BasicQuery@@Tests/Tools.wlt:532,23-537,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringLength[ extractToolText @ $waContextResult ] > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframAlphaContext-NonEmptyResult@@Tests/Tools.wlt:476,23-481,2"
+    TestID   -> "WolframAlphaContext-NonEmptyResult@@Tests/Tools.wlt:539,23-544,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -491,21 +554,21 @@ VerificationTest[
     $wolframContextTool = $DefaultMCPTools[ "WolframContext" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "WolframContext-GetTool@@Tests/Tools.wlt:490,1-495,2"
+    TestID   -> "WolframContext-GetTool@@Tests/Tools.wlt:553,1-558,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     $wolframContextResult = $wolframContextTool[ <| "context" -> "How to compute derivatives symbolically" |> ],
     _String | _Association,
     SameTest -> MatchQ,
-    TestID   -> "WolframContext-BasicQuery@@Tests/Tools.wlt:497,23-502,2"
+    TestID   -> "WolframContext-BasicQuery@@Tests/Tools.wlt:560,23-565,2"
 ]
 
 skipIfGitHubActions @ VerificationTest[
     StringLength[ extractToolText @ $wolframContextResult ] > 0,
     True,
     SameTest -> SameQ,
-    TestID   -> "WolframContext-NonEmptyResult@@Tests/Tools.wlt:504,23-509,2"
+    TestID   -> "WolframContext-NonEmptyResult@@Tests/Tools.wlt:567,23-572,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -547,7 +610,7 @@ VerificationTest[
     ],
     _String? (StringContainsQ[ "usage limit" ]),
     SameTest -> MatchQ,
-    TestID   -> "RelatedWolframAlphaResults-UsageLimitMessage@@Tests/Tools.wlt:540,1-551,2"
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitMessage@@Tests/Tools.wlt:603,1-614,2"
 ]
 
 (* The service's own error message is surfaced to the agent. *)
@@ -555,7 +618,7 @@ VerificationTest[
     StringContainsQ[ $waUsageLimitResult, "credits-per-month-limit-exceeded" ],
     True,
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframAlphaResults-UsageLimitIncludesServiceMessage@@Tests/Tools.wlt:554,1-559,2"
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitIncludesServiceMessage@@Tests/Tools.wlt:617,1-622,2"
 ]
 
 (* It is NOT a Failure, so the MCP layer will not flag it as an error or emit a bug report. *)
@@ -563,7 +626,7 @@ VerificationTest[
     FailureQ @ $waUsageLimitResult,
     False,
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframAlphaResults-UsageLimitNotFailure@@Tests/Tools.wlt:562,1-567,2"
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitNotFailure@@Tests/Tools.wlt:625,1-630,2"
 ]
 
 (* The caller's message level (e.g. "Warning" from the combined WolframContext tool) is honored. *)
@@ -580,7 +643,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframAlphaResults-UsageLimitLevel@@Tests/Tools.wlt:570,1-584,2"
+    TestID   -> "RelatedWolframAlphaResults-UsageLimitLevel@@Tests/Tools.wlt:633,1-647,2"
 ]
 
 (* A genuine string result is still returned unchanged (regression guard). *)
@@ -594,7 +657,7 @@ VerificationTest[
     ],
     "Some Wolfram|Alpha context.",
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframAlphaResults-NormalResultUnchanged@@Tests/Tools.wlt:587,1-598,2"
+    TestID   -> "RelatedWolframAlphaResults-NormalResultUnchanged@@Tests/Tools.wlt:650,1-661,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -612,14 +675,14 @@ VerificationTest[
     ],
     _String? (StringContainsQ[ "usage limit" ]),
     SameTest -> MatchQ,
-    TestID   -> "RelatedDocumentation-UsageLimitMessage@@Tests/Tools.wlt:604,1-616,2"
+    TestID   -> "RelatedDocumentation-UsageLimitMessage@@Tests/Tools.wlt:667,1-679,2"
 ]
 
 VerificationTest[
     FailureQ @ $docUsageLimitResult,
     False,
     SameTest -> SameQ,
-    TestID   -> "RelatedDocumentation-UsageLimitNotFailure@@Tests/Tools.wlt:618,1-623,2"
+    TestID   -> "RelatedDocumentation-UsageLimitNotFailure@@Tests/Tools.wlt:681,1-686,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -640,14 +703,14 @@ VerificationTest[
     ],
     _String? (StringContainsQ[ "usage limit" ]),
     SameTest -> MatchQ,
-    TestID   -> "RelatedWolframContext-UsageLimitMessage@@Tests/Tools.wlt:631,1-644,2"
+    TestID   -> "RelatedWolframContext-UsageLimitMessage@@Tests/Tools.wlt:694,1-707,2"
 ]
 
 VerificationTest[
     FailureQ @ $wcUsageLimitResult,
     False,
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframContext-UsageLimitNotFailure@@Tests/Tools.wlt:646,1-651,2"
+    TestID   -> "RelatedWolframContext-UsageLimitNotFailure@@Tests/Tools.wlt:709,1-714,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -676,7 +739,7 @@ VerificationTest[
     ],
     { True, False, True },
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframContext-LLMKitDisabledNoWarning@@Tests/Tools.wlt:660,1-680,2"
+    TestID   -> "RelatedWolframContext-LLMKitDisabledNoWarning@@Tests/Tools.wlt:723,1-743,2"
 ]
 
 (* Regression guard: a genuinely unsubscribed user (LLMKit still enabled) DOES get the subscription
@@ -703,7 +766,7 @@ VerificationTest[
     ],
     { True, True, True },
     SameTest -> SameQ,
-    TestID   -> "RelatedWolframContext-UnsubscribedStillWarns@@Tests/Tools.wlt:685,1-707,2"
+    TestID   -> "RelatedWolframContext-UnsubscribedStillWarns@@Tests/Tools.wlt:748,1-770,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)
@@ -730,7 +793,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`documentationProvidedAvailableQ @ mockRelatedWAResultsNew,
     True,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedAvailableQ-Supported@@Tests/Tools.wlt:728,1-734,2"
+    TestID   -> "DocumentationProvidedAvailableQ-Supported@@Tests/Tools.wlt:791,1-797,2"
 ]
 
 (* An older Chatbook without the option is reported as unsupported: *)
@@ -739,7 +802,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`documentationProvidedAvailableQ @ mockRelatedWAResultsOld,
     False,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedAvailableQ-Unsupported@@Tests/Tools.wlt:737,1-743,2"
+    TestID   -> "DocumentationProvidedAvailableQ-Unsupported@@Tests/Tools.wlt:800,1-806,2"
 ]
 
 (* A Block-mocked RelatedWolframAlphaResults (as used elsewhere in this file) evaluates to a Function;
@@ -748,7 +811,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`documentationProvidedAvailableQ[ "mocked" & ],
     False,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedAvailableQ-NonSymbol@@Tests/Tools.wlt:747,1-752,2"
+    TestID   -> "DocumentationProvidedAvailableQ-NonSymbol@@Tests/Tools.wlt:810,1-815,2"
 ]
 
 (* The zero-argument form probes the Chatbook in use and returns a definite boolean: *)
@@ -756,7 +819,7 @@ VerificationTest[
     BooleanQ @ Wolfram`AgentTools`Common`documentationProvidedAvailableQ[ ],
     True,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedAvailableQ-Boolean@@Tests/Tools.wlt:755,1-760,2"
+    TestID   -> "DocumentationProvidedAvailableQ-Boolean@@Tests/Tools.wlt:818,1-823,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -770,7 +833,7 @@ VerificationTest[
     ],
     { },
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedOptions-NotProvided@@Tests/Tools.wlt:767,1-774,2"
+    TestID   -> "DocumentationProvidedOptions-NotProvided@@Tests/Tools.wlt:830,1-837,2"
 ]
 
 (* From the combined tool with a supporting Chatbook, the option is included: *)
@@ -780,7 +843,7 @@ VerificationTest[
     ],
     { "DocumentationProvided" -> True },
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedOptions-Supported@@Tests/Tools.wlt:777,1-784,2"
+    TestID   -> "DocumentationProvidedOptions-Supported@@Tests/Tools.wlt:840,1-847,2"
 ]
 
 (* From the combined tool with an older Chatbook, the option is omitted: *)
@@ -790,7 +853,7 @@ VerificationTest[
     ],
     { },
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvidedOptions-Unsupported@@Tests/Tools.wlt:787,1-794,2"
+    TestID   -> "DocumentationProvidedOptions-Unsupported@@Tests/Tools.wlt:850,1-857,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -812,14 +875,14 @@ VerificationTest[
     ],
     "Some Wolfram|Alpha context.",
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvided-StandaloneResultUnchanged@@Tests/Tools.wlt:802,1-816,2"
+    TestID   -> "DocumentationProvided-StandaloneResultUnchanged@@Tests/Tools.wlt:865,1-879,2"
 ]
 
 VerificationTest[
     MemberQ[ $capturedWAArguments, "DocumentationProvided" -> _ ],
     False,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvided-NotPassedStandalone@@Tests/Tools.wlt:818,1-823,2"
+    TestID   -> "DocumentationProvided-NotPassedStandalone@@Tests/Tools.wlt:881,1-886,2"
 ]
 
 (* The combined WolframContext tool passes the option when the loaded Chatbook supports it: *)
@@ -838,14 +901,14 @@ VerificationTest[
     ],
     _String? (StringContainsQ[ "Some Wolfram|Alpha context." ]),
     SameTest -> MatchQ,
-    TestID   -> "DocumentationProvided-CombinedResult@@Tests/Tools.wlt:826,1-842,2"
+    TestID   -> "DocumentationProvided-CombinedResult@@Tests/Tools.wlt:889,1-905,2"
 ]
 
 VerificationTest[
     MemberQ[ $capturedWAArguments, "DocumentationProvided" -> True ],
     True,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvided-PassedFromCombined@@Tests/Tools.wlt:844,1-849,2"
+    TestID   -> "DocumentationProvided-PassedFromCombined@@Tests/Tools.wlt:907,1-912,2"
 ]
 
 (* The combined tool must not pass the option to an older Chatbook that does not support it: *)
@@ -865,7 +928,7 @@ VerificationTest[
     MemberQ[ $capturedWAArguments, "DocumentationProvided" -> _ ],
     False,
     SameTest -> SameQ,
-    TestID   -> "DocumentationProvided-NotPassedUnsupported@@Tests/Tools.wlt:852,1-869,2"
+    TestID   -> "DocumentationProvided-NotPassedUnsupported@@Tests/Tools.wlt:915,1-932,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)
@@ -883,14 +946,14 @@ VerificationTest[
     $testReportTool = $DefaultMCPTools[ "TestReport" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "TestReport-GetTool@@Tests/Tools.wlt:882,1-887,2"
+    TestID   -> "TestReport-GetTool@@Tests/Tools.wlt:945,1-950,2"
 ]
 
 VerificationTest[
     $testResourceDirectory = FileNameJoin @ { DirectoryName[ $TestFileName, 2 ], "TestResources" },
     _String? DirectoryQ,
     SameTest -> MatchQ,
-    TestID   -> "TestReport-TestResourceDirectory@@Tests/Tools.wlt:889,1-894,2"
+    TestID   -> "TestReport-TestResourceDirectory@@Tests/Tools.wlt:952,1-957,2"
 ]
 
 VerificationTest[
@@ -900,7 +963,7 @@ VerificationTest[
     |>,
     _String? (StringContainsQ[ "# Test Results Summary"~~__~~"TestFile1.wlt" ]),
     SameTest -> MatchQ,
-    TestID   -> "TestReport-SingleFile@@Tests/Tools.wlt:896,1-904,2"
+    TestID   -> "TestReport-SingleFile@@Tests/Tools.wlt:959,1-967,2"
 ]
 
 VerificationTest[
@@ -914,7 +977,7 @@ VerificationTest[
     |>,
     _String? (StringContainsQ[ "# Test Results Summary"~~__~~"TestFile1.wlt"~~__~~"TestFile2.wlt" ]),
     SameTest -> MatchQ,
-    TestID   -> "TestReport-MultipleFiles@@Tests/Tools.wlt:906,1-918,2"
+    TestID   -> "TestReport-MultipleFiles@@Tests/Tools.wlt:969,1-981,2"
 ]
 
 VerificationTest[
@@ -924,7 +987,7 @@ VerificationTest[
     |>,
     _String? (StringContainsQ[ "# Test Results Summary"~~__~~"TestFile1.wlt"~~__~~"TestFile2.wlt" ]),
     SameTest -> MatchQ,
-    TestID   -> "TestReport-Directory@@Tests/Tools.wlt:920,1-928,2"
+    TestID   -> "TestReport-Directory@@Tests/Tools.wlt:983,1-991,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -960,7 +1023,7 @@ skipIfGitHubActions @ VerificationTest[
     ],
     True,
     SameTest -> MatchQ,
-    TestID   -> "TestReport-McpRootRelativePath@@Tests/Tools.wlt:937,23-964,2"
+    TestID   -> "TestReport-McpRootRelativePath@@Tests/Tools.wlt:1000,23-1027,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -973,7 +1036,7 @@ VerificationTest[
     Failure[ "AgentTools::TestFileNotFound", _Association ],
     { AgentTools::TestFileNotFound },
     SameTest -> MatchQ,
-    TestID   -> "TestReport-NonexistentFile-GH#65@@Tests/Tools.wlt:971,1-977,2"
+    TestID   -> "TestReport-NonexistentFile-GH#65@@Tests/Tools.wlt:1034,1-1040,2"
 ]
 
 VerificationTest[
@@ -981,7 +1044,7 @@ VerificationTest[
     _? (FreeQ[ "AgentTools::Internal" ]),
     { AgentTools::TestFileNotFound },
     SameTest -> MatchQ,
-    TestID   -> "TestReport-NoInternalFailure-GH#65@@Tests/Tools.wlt:979,1-985,2"
+    TestID   -> "TestReport-NoInternalFailure-GH#65@@Tests/Tools.wlt:1042,1-1048,2"
 ]
 
 VerificationTest[
@@ -994,7 +1057,7 @@ VerificationTest[
     _? (FreeQ[ "AgentTools::Internal" ]),
     { AgentTools::TestFileNotFound },
     SameTest -> MatchQ,
-    TestID   -> "TestReport-MixedValidInvalidPaths-GH#65@@Tests/Tools.wlt:987,1-998,2"
+    TestID   -> "TestReport-MixedValidInvalidPaths-GH#65@@Tests/Tools.wlt:1050,1-1061,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1011,7 +1074,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "ToolProperties-AllHaveNames@@Tests/Tools.wlt:1007,1-1015,2"
+    TestID   -> "ToolProperties-AllHaveNames@@Tests/Tools.wlt:1070,1-1078,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1024,7 +1087,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "ToolProperties-AllHaveDescriptions@@Tests/Tools.wlt:1020,1-1028,2"
+    TestID   -> "ToolProperties-AllHaveDescriptions@@Tests/Tools.wlt:1083,1-1091,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1037,5 +1100,5 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "ToolProperties-AllHaveParameters@@Tests/Tools.wlt:1033,1-1041,2"
+    TestID   -> "ToolProperties-AllHaveParameters@@Tests/Tools.wlt:1096,1-1104,2"
 ]

--- a/Tests/Utilities.wlt
+++ b/Tests/Utilities.wlt
@@ -593,7 +593,7 @@ VerificationTest[
     },
     { "set", $Failed },
     SameTest -> SameQ,
-    TestID   -> "EnvironmentBlock-SetsAndRestores@@Tests/Utilities.wlt:474,1-482,2"
+    TestID   -> "EnvironmentBlock-SetsAndRestores@@Tests/Utilities.wlt:589,1-597,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -605,7 +605,7 @@ VerificationTest[
     environmentBlock[ "LLMKIT_ENABLED" -> None, Wolfram`AgentTools`Common`llmKitEnabledQ[ ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "LLMKitEnabledQ-NotSet@@Tests/Utilities.wlt:489,1-494,2"
+    TestID   -> "LLMKitEnabledQ-NotSet@@Tests/Utilities.wlt:604,1-609,2"
 ]
 
 (* Disabled when the variable is "false" *)
@@ -613,7 +613,7 @@ VerificationTest[
     environmentBlock[ "LLMKIT_ENABLED" -> "false", Wolfram`AgentTools`Common`llmKitEnabledQ[ ] ],
     False,
     SameTest -> Equal,
-    TestID   -> "LLMKitEnabledQ-FalseLowercase@@Tests/Utilities.wlt:497,1-502,2"
+    TestID   -> "LLMKitEnabledQ-FalseLowercase@@Tests/Utilities.wlt:612,1-617,2"
 ]
 
 (* The check is case-insensitive *)
@@ -621,14 +621,14 @@ VerificationTest[
     environmentBlock[ "LLMKIT_ENABLED" -> "False", Wolfram`AgentTools`Common`llmKitEnabledQ[ ] ],
     False,
     SameTest -> Equal,
-    TestID   -> "LLMKitEnabledQ-FalseMixedCase@@Tests/Utilities.wlt:505,1-510,2"
+    TestID   -> "LLMKitEnabledQ-FalseMixedCase@@Tests/Utilities.wlt:620,1-625,2"
 ]
 
 VerificationTest[
     environmentBlock[ "LLMKIT_ENABLED" -> "FALSE", Wolfram`AgentTools`Common`llmKitEnabledQ[ ] ],
     False,
     SameTest -> Equal,
-    TestID   -> "LLMKitEnabledQ-FalseUppercase@@Tests/Utilities.wlt:512,1-517,2"
+    TestID   -> "LLMKitEnabledQ-FalseUppercase@@Tests/Utilities.wlt:627,1-632,2"
 ]
 
 (* Any other value leaves LLMKit enabled *)
@@ -636,14 +636,14 @@ VerificationTest[
     environmentBlock[ "LLMKIT_ENABLED" -> "true", Wolfram`AgentTools`Common`llmKitEnabledQ[ ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "LLMKitEnabledQ-TrueString@@Tests/Utilities.wlt:520,1-525,2"
+    TestID   -> "LLMKitEnabledQ-TrueString@@Tests/Utilities.wlt:635,1-640,2"
 ]
 
 VerificationTest[
     environmentBlock[ "LLMKIT_ENABLED" -> "1", Wolfram`AgentTools`Common`llmKitEnabledQ[ ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "LLMKitEnabledQ-OneString@@Tests/Utilities.wlt:527,1-532,2"
+    TestID   -> "LLMKitEnabledQ-OneString@@Tests/Utilities.wlt:642,1-647,2"
 ]
 
 (* A value that reads as boolean False also disables LLMKit *)
@@ -651,14 +651,14 @@ VerificationTest[
     environmentBlock[ "LLMKIT_ENABLED" -> "0", Wolfram`AgentTools`Common`llmKitEnabledQ[ ] ],
     False,
     SameTest -> Equal,
-    TestID   -> "LLMKitEnabledQ-ZeroDisables@@Tests/Utilities.wlt:535,1-540,2"
+    TestID   -> "LLMKitEnabledQ-ZeroDisables@@Tests/Utilities.wlt:650,1-655,2"
 ]
 
 VerificationTest[
     environmentBlock[ "LLMKIT_ENABLED" -> "no", Wolfram`AgentTools`Common`llmKitEnabledQ[ ] ],
     False,
     SameTest -> Equal,
-    TestID   -> "LLMKitEnabledQ-NoDisables@@Tests/Utilities.wlt:542,1-547,2"
+    TestID   -> "LLMKitEnabledQ-NoDisables@@Tests/Utilities.wlt:657,1-662,2"
 ]
 
 (* A value that does not interpret as a Boolean leaves LLMKit enabled *)
@@ -666,7 +666,7 @@ VerificationTest[
     environmentBlock[ "LLMKIT_ENABLED" -> "maybe", Wolfram`AgentTools`Common`llmKitEnabledQ[ ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "LLMKitEnabledQ-NonBooleanEnabled@@Tests/Utilities.wlt:550,1-555,2"
+    TestID   -> "LLMKitEnabledQ-NonBooleanEnabled@@Tests/Utilities.wlt:665,1-670,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -692,5 +692,30 @@ VerificationTest[
     ],
     { False, False },
     SameTest -> SameQ,
-    TestID   -> "LLMKitSubscribedQ-DisabledShortCircuits@@Tests/Utilities.wlt:565,1-581,2"
+    TestID   -> "LLMKitSubscribedQ-DisabledShortCircuits@@Tests/Utilities.wlt:680,1-696,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Dependencies*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*chatbookVersionCheck*)
+
+(* Ensures the available Chatbook satisfies $minimumChatbookVersion (installing or updating if necessary): *)
+VerificationTest[
+    Wolfram`AgentTools`Common`chatbookVersionCheck[ ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "ChatbookVersionCheck@@Tests/Utilities.wlt:707,1-712,2"
+]
+
+(* The minimum Chatbook version must support the "PropagateMessages" option that the
+   WolframLanguageEvaluator tool passes to WolframLanguageToolEvaluate (added in Chatbook 2.7.0): *)
+VerificationTest[
+    Quiet @ Options[ Wolfram`Chatbook`WolframLanguageToolEvaluate, "PropagateMessages" ],
+    { _Rule | _RuleDelayed },
+    SameTest -> MatchQ,
+    TestID   -> "ChatbookVersionCheck-PropagateMessagesSupported@@Tests/Utilities.wlt:716,1-721,2"
 ]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -280,9 +280,9 @@ All available tags can be found [here](https://github.com/WolframResearch/AgentT
 
 ## Architecture
 
-The Docker image is built on `wolframresearch/wolframengine:14.3` and includes:
+The Docker image is built on `wolframresearch/wolframengine:15.0` and includes:
 
-- Wolfram Engine 14.3
+- Wolfram Engine 15.0
 - AgentTools paclet (Kernel/, Scripts/)
 - Pre-built MX files for faster startup
 - Pre-installed dependencies (Chatbook, LLMFunctions, SemanticSearch paclets)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide helps you set up your development environment and understand the work
 
 ## Prerequisites
 
-- **Wolfram Language** (Mathematica 14.3+ or Wolfram Engine)
+- **Wolfram Language** (Mathematica 15.0+ or Wolfram Engine)
 - **wolframscript** (for running build scripts)
 - **Git**
 


### PR DESCRIPTION
## Summary

The WolframLanguageEvaluator tool captures messages during evaluation (without letting them print at top level) so they can be included in the tool result. However, `WolframLanguageToolEvaluate`'s quieting detection misses messages that internal kernel code issues and then suppresses (e.g. `General::ivar` fired inside `FullSimplify`/`Integrate` internals), so tool results could include false entries for messages that were never actually shown to the user:

```
General::ivar: -- Message text not found -- (x^n)
CholeskyDecomposition::npdef: -- Message text not found -- ({{0, 0, 0, 0}, ...})
...
Out[1]= x*(a - (b*p*ExpIntegralEi[Log[d*x^n]/n])/(d*x^n)^n^(-1) + b*Log[c*Log[d*x^n]^p])
```

- Pass `"PropagateMessages" -> True` to `WolframLanguageToolEvaluate` so messages fire normally at top level and only genuinely issued messages appear in tool results. Top-level messages are not a problem for the MCP server, since `StartMCPServer` already handles them. `$minimumChatbookVersion` is bumped to **2.7.0**, which added this option.
- Chatbook 2.7.0 requires WL 15.0 (a 14.3 kernel resolves Wolfram/Chatbook to 2.5.0 at best), and upcoming work will depend on more new Chatbook functionality, so the paclet's `WolframVersion` is raised to **`15.0+`**. CI workflows and the Docker base image move from `wolframengine:14.3` to `wolframengine:15.0`, and the documented system requirements are updated to match.
- New regression tests cover the message-reporting behavior end to end.

## Test plan

- [x] New `Tests/Tools.wlt` "Messages" subsection: genuinely issued messages still appear in tool results (`First::nofirst`); messages quieted by the evaluated code or suppressed via `Internal`DeactivateMessages` stay out; the `FullSimplify`/`Integrate` repro contains the expected result and no `-- Message text not found --` / `::ivar` / `General::messages` entries
- [x] New `Tests/Utilities.wlt` "Dependencies" section: `chatbookVersionCheck` passes and the minimum Chatbook version actually provides the `"PropagateMessages"` option
- [x] Verified the repro directly on WL 15.0 + Chatbook 2.7.0: with `"PropagateMessages" -> False` the false entries appear; with `True` the result is clean
- [x] `TestReport` on `Tests/Tools.wlt` + `Tests/Utilities.wlt`: 167/167 passing locally (WL 15.0, Chatbook 2.7.0)
- [ ] Build workflow green on the `wolframengine:15.0` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)