### PR TITLE
Work around parallel kernel export failures in the documentation build

### DIFF
--- a/Scripts/BuildPaclet.wls
+++ b/Scripts/BuildPaclet.wls
@@ -15,6 +15,7 @@ $check   = getBooleanArgument[ { "c", "check"    }, True  ];
 $install = getBooleanArgument[ { "i", "install"  }, False ];
 $mx      = getBooleanArgument[ { "m", "mx"       }, True  ];
 $keepMX  = getBooleanArgument[ { "k", "keep-mx"  }, StringQ @ Environment[ "GITHUB_ACTIONS" ] ];
+$debug   = getBooleanArgument[ { "d", "debug"    }, StringQ @ Environment[ "GITHUB_ACTIONS" ] ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
@@ -26,6 +27,8 @@ If[ $check, Get @ cFile @ FileNameJoin @ { $scriptDir, "Resources", "CodeInspect
 (* ::Subsection::Closed:: *)
 (*Other*)
 Needs[ "Wolfram`PacletCICD`" -> "cicd`" ];
+Needs[ "PacletTools`"        -> None ];
+Needs[ "DocumentationBuild`" -> None ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -40,21 +43,35 @@ debugDocBuild // Attributes = { HoldFirst };
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
 (* :!CodeAnalysis::Disable::GlobalSymbol:: *)
-debugDocBuild[ eval_ ] := (
-    Needs[ "PacletTools`"        -> None ];
-    Needs[ "DocumentationBuild`" -> None ];
-    Block[ { DocumentationBuild`Utils`SafeNotebookExport, Global`AntLog },
-        (* SafeNotebookExport tries to use parallel kernels for exporting, which we can't use in GitHub actions,
-           so we redefine it to be a simple Export instead: *)
-        DocumentationBuild`Utils`SafeNotebookExport[ file_, expr_, ___ ] := Export[ file, expr, "NB" ];
-
+debugDocBuild[ eval_ ] /; $debug := (
+    Block[ { Global`AntLog },
         (* Documentation build uses this symbol throughout for debug logging, which is normally undefined: *)
         Global`AntLog[ args___ ] := Print[ "[DocumentationBuild] ", args ];
+
+        overrideNotebookExport @ eval
+    ]
+);
+(* :!CodeAnalysis::EndBlock:: *)
+
+debugDocBuild[ eval_ ] := overrideNotebookExport @ eval;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*overrideNotebookExport*)
+overrideNotebookExport // ClearAll;
+overrideNotebookExport // Attributes = { HoldFirst };
+
+overrideNotebookExport[ eval_ ] /; StringQ @ Environment[ "GITHUB_ACTIONS" ] := (
+    Block[ { DocumentationBuild`Utils`SafeNotebookExport },
+        (* SafeNotebookExport tries to use parallel kernels for exporting, which we can't use in GitHub actions,
+            so we redefine it to be a simple Export instead: *)
+        DocumentationBuild`Utils`SafeNotebookExport[ file_, expr_, ___ ] := Export[ file, expr, "NB" ];
 
         eval
     ]
 );
-(* :!CodeAnalysis::EndBlock:: *)
+
+overrideNotebookExport[ eval_ ] := eval;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Scripts/BuildPaclet.wls
+++ b/Scripts/BuildPaclet.wls
@@ -29,13 +29,42 @@ Needs[ "Wolfram`PacletCICD`" -> "cicd`" ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
+(*Definitions*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*debugDocBuild*)
+debugDocBuild // ClearAll;
+debugDocBuild // Attributes = { HoldFirst };
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+(* :!CodeAnalysis::Disable::GlobalSymbol:: *)
+debugDocBuild[ eval_ ] := (
+    Needs[ "PacletTools`"        -> None ];
+    Needs[ "DocumentationBuild`" -> None ];
+    Block[ { DocumentationBuild`Utils`SafeNotebookExport, Global`AntLog },
+        (* SafeNotebookExport tries to use parallel kernels for exporting, which we can't use in GitHub actions,
+           so we redefine it to be a simple Export instead: *)
+        DocumentationBuild`Utils`SafeNotebookExport[ file_, expr_, ___ ] := Export[ file, expr, "NB" ];
+
+        (* Documentation build uses this symbol throughout for debug logging, which is normally undefined: *)
+        Global`AntLog[ args___ ] := Print[ "[DocumentationBuild] ", args ];
+
+        eval
+    ]
+);
+(* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
 (*Run*)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Build*)
 result = Quiet[
-    checkResult @ cicd`BuildPaclet[
+    debugDocBuild @ checkResult @ cicd`BuildPaclet[
         $defNB,
         "Check"      -> $check,
         "ExitOnFail" -> True,
@@ -46,8 +75,7 @@ result = Quiet[
         (* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
         CloudObject`Private`webLoginDialogInput::ninit,
         DocumentationSearch`Skeletonizer`Private`convertToString::unke,
-        DocumentationSearch`Skeletonizer`Private`skeletonizeFiles::msgs,
-        WaitAll::nopar
+        DocumentationSearch`Skeletonizer`Private`skeletonizeFiles::msgs
         (* :!CodeAnalysis::EndBlock:: *)
     }
 ];


### PR DESCRIPTION
## Summary

- The documentation build emitted `WaitAll::nopar` messages in GitHub Actions because ``DocumentationBuild`Utils`SafeNotebookExport`` tries to launch parallel kernels, which are unavailable there.
- Adds an `overrideNotebookExport` wrapper in `Scripts/BuildPaclet.wls` that redefines `SafeNotebookExport` as a plain `Export`. The override only applies when running in GitHub Actions, since parallel kernels are available locally.
- Adds a `debugDocBuild` wrapper that defines `AntLog` to print `[DocumentationBuild]`-prefixed debug output during the build, controlled by a new `-d`/`--debug` flag that defaults to on in GitHub Actions and off locally.
- Wraps the ``cicd`BuildPaclet`` call in `debugDocBuild` (which applies `overrideNotebookExport` in both the debug and non-debug paths) and removes the now-unneeded `WaitAll::nopar` entry from the `Quiet` list.

## Test plan

- [x] `CodeInspector` reports no issues for `Scripts/BuildPaclet.wls`
- [ ] CI build workflow passes on this branch
- [ ] Build logs show no `WaitAll::nopar` messages and include `[DocumentationBuild]` debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)