### PR TITLE
Enable the notebook embedder's shadow DOM option in the MCP Apps viewers

### DIFF
--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -478,7 +478,8 @@
                     allowInteract: true,
                     showRenderProgress: true,
                     width: null,
-                    maxHeight: Infinity
+                    maxHeight: Infinity,
+                    useShadowDOM: true
                 });
             }).then(function(nb) {
                 settled = true;

--- a/Assets/Apps/notebook-viewer.html
+++ b/Assets/Apps/notebook-viewer.html
@@ -446,7 +446,8 @@
                     allowInteract: allowInteract !== false,
                     showRenderProgress: true,
                     width: null,
-                    maxHeight: typeof maxHeight === "number" && maxHeight > 0 ? maxHeight : Infinity
+                    maxHeight: typeof maxHeight === "number" && maxHeight > 0 ? maxHeight : Infinity,
+                    useShadowDOM: true
                 };
 
                 log("embedNotebook: calling WolframNotebookEmbedder.embed()");

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -580,7 +580,8 @@
                     allowInteract: true,
                     showRenderProgress: true,
                     width: null,
-                    maxHeight: Infinity
+                    maxHeight: Infinity,
+                    useShadowDOM: true
                 });
             }).then(function(nb) {
                 settled = true;


### PR DESCRIPTION
## Summary

Embedded notebooks in the MCP Apps viewers were affected by CSS conflicts with the host page. This PR passes `useShadowDOM: true` to `WolframNotebookEmbedder.embed()` in all three viewers (`evaluator-viewer.html`, `notebook-viewer.html`, `wolframalpha-viewer.html`) so the notebook renders inside a shadow root, isolating notebook styles from host page CSS.

Option name and behavior per the embedder's [LibraryInterface documentation](https://github.com/WolframResearch/wolfram-notebook-embedder/blob/master/docs/LibraryInterface.md). Note the exact casing is `useShadowDOM` — verified against both the docs and the `wolfram-notebook-embedder@0.3` bundle the viewers load (which reads `o.useShadowDOM` before calling `attachShadow`); other casings are silently ignored. The docs mark the option as experimental.

None of the viewer code reaches into the notebook's rendered DOM (all `innerHTML`/`scrollHeight`/`getBoundingClientRect` usage targets the viewers' own elements), so the shadow boundary does not affect the viewers' own sizing/reset logic.

## Test plan

- [ ] Open the evaluator viewer via the `WolframLanguageEvaluator` tool in an MCP Apps host and confirm embedded notebook output renders correctly (e.g. a `Plot` with tick labels, axes labels, and gridlines)
- [ ] Open the notebook viewer and confirm cloud notebooks render and remain interactive (`allowInteract`), including with an explicit `maxHeight`
- [ ] Open the Wolfram|Alpha viewer and confirm pod notebooks render correctly
- [ ] Confirm host-page CSS no longer leaks into embedded notebook content in each viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)