### PR TITLE
Fix notebook text color under shadow DOM and set an explicit evaluator code font

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: verify
+description: Runtime-verify AgentTools changes — drive the real MCP tool pipeline and render MCP Apps viewers in a browser to observe results at their surface.
+---
+
+# Verifying AgentTools changes at runtime
+
+## Wolfram Language side (tools, server, UI results)
+
+- **Always set `WOLFRAMSCRIPT_KERNELPATH="C:/Program Files/Wolfram Research/Wolfram/15.0/wolfram.exe"`** (or newer). Plain `wolframscript` may pick an older kernel; AgentTools requires 15.0+, and under an older kernel `PacletDirectoryLoad` + ``Get["Wolfram`AgentTools`"]`` *silently* falls back to the installed Repository paclet — you exercise the wrong code. Confirm with ``FindFile["Wolfram`AgentTools`"]`` → must resolve under the dev directory.
+- Load the dev paclet: ``PacletDirectoryLoad["H:\\Documents\\AgentTools"]; Get["Wolfram`AgentTools`"]``.
+- To drive a tool exactly as the MCP server dispatches it, call its registered `"Function"` (see `$defaultMCPTools[name]` in `Kernel/Tools/*.wl`) with the parsed-args association, e.g. ``Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`evaluateWolframLanguage[<|"code" -> ...|>]``.
+- To trigger the MCP Apps UI path (cloud-deployed notebook + `_meta.notebookUrl`), first set ``Wolfram`AgentTools`Common`$clientSupportsUI = True`` and be cloud-connected. Export the result with ``Developer`WriteRawJSONFile`` — it is the exact content/_meta payload a host forwards to a viewer.
+- For an A/B against pre-change behavior, `git worktree add <scratch>/head-copy HEAD` and point `PacletDirectoryLoad` at the worktree in a second wolframscript run. Use a *different* input (the deploy target is content-hashed, same input overwrites the same cloud object). Remove the worktree afterwards.
+
+## MCP Apps viewers (Assets/Apps/*.html)
+
+- All viewers speak the same iframe protocol: they send `ui/initialize` (reply with `{protocolVersion, hostInfo, hostContext}`), then notify `ui/notifications/initialized`; after that, post `{jsonrpc:"2.0", method:"ui/notifications/tool-result", params:{content, _meta}}` into the iframe.
+- Harness that works: a `host.html` that iframes the viewer and plays the host role over postMessage + a no-dep node static server + Playwright (`npm i playwright` locally; chromium via `npx playwright install chromium`). Set `colorScheme: "dark"` on the browser context to reproduce dark-host bugs; the embed needs real network (unpkg CDN + wolframcloud.com) and takes 10–60 s.
+- The notebook embedder (`useShadowDOM: true`) attaches an **open shadow root to a wrapper `<div>` it creates inside the container**, not to the container itself. Wait for embed completion by recursively searching open shadow roots for expected notebook text; read computed styles with `getComputedStyle` on shadow-tree elements.
+- Playwright frame-picking gotcha: the host page URL carries the viewer filename in its query string, so match `f !== page.mainFrame()` when locating the viewer frame.
+- Verified evidence to capture: computed `color` of shadow text leaves (dark-theme leak shows as `rgb(224, 224, 224)`), computed `font-family`, and full-page screenshots.

--- a/Assets/Apps/evaluator-viewer.html
+++ b/Assets/Apps/evaluator-viewer.html
@@ -64,6 +64,8 @@
         }
         @keyframes spin { to { transform: rotate(360deg); } }
         #notebook-container {
+            /* Set default color for notebook text explicitly to avoid css color override: bugs:477936 */
+            color: black;
             width: 100%;
             min-height: 100px;
         }
@@ -126,10 +128,6 @@
             height: 3px;
             border-radius: 3px;
             background: rgba(127, 127, 127, 0.75);
-        }
-        /* Set default color for notebook text explicitly to avoid css color override: bugs:477936*/
-        .notebook {
-            color: black;
         }
     </style>
 </head>

--- a/Assets/Apps/notebook-viewer.html
+++ b/Assets/Apps/notebook-viewer.html
@@ -34,6 +34,8 @@
             line-height: 1.5;
         }
         #container {
+            /* Set default color for notebook text explicitly to avoid css color override: bugs:477936 */
+            color: black;
             width: 100%;
             min-height: 100px;
         }
@@ -103,10 +105,6 @@
             height: 3px;
             border-radius: 3px;
             background: rgba(127, 127, 127, 0.75);
-        }
-        /* Set default color for notebook text explicitly to avoid css color override: bugs:477936*/
-        .notebook {
-            color: black;
         }
     </style>
 </head>

--- a/Assets/Apps/wolframalpha-viewer.html
+++ b/Assets/Apps/wolframalpha-viewer.html
@@ -133,6 +133,8 @@
         }
         @keyframes spin { to { transform: rotate(360deg); } }
         #notebook-container {
+            /* Set default color for notebook text explicitly to avoid css color override: bugs:477936 */
+            color: black;
             width: 100%;
             min-height: 100px;
         }
@@ -196,11 +198,6 @@
             border-radius: 3px;
             background: rgba(127, 127, 127, 0.75);
         }
-        /* Set default color for notebook text explicitly to avoid css color override: bugs:477936*/
-        .notebook {
-            color: black;
-        }
-
     </style>
 </head>
 <body>

--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -365,7 +365,8 @@ makeEvaluatorUIResult[
         nb = Notebook[
             { Cell @ CellGroupData[ { inputCell, outputCell }, Open ] },
             CellLabelAutoDelete    -> False,
-            ScreenStyleEnvironment -> "Elegant"
+            ScreenStyleEnvironment -> "Elegant",
+            StyleHints             -> <| "CodeFont" -> "Source Sans Pro" |>
         ];
 
         deployed = ConfirmMatch[


### PR DESCRIPTION
## Summary

- [477936] Follow-up to #232/#233: with the notebook embedder's shadow DOM option enabled, the page-level `.notebook { color: black }` rule added in #233 can no longer match the notebook (the `.notebook` element now lives inside the shadow root), so dark-mode hosts leaked their light foreground color into unstyled notebook text. This moves `color: black` onto the embed container (`#notebook-container` / `#container`) in all three viewers — inherited properties cross the shadow boundary, so the default text color reaches the notebook again while syntax colors and cell-label colors are untouched.
- Gives evaluator notebooks an explicit `StyleHints -> <| "CodeFont" -> "Source Sans Pro" |>`, since the cloud renderer does not apply the Elegant screen style environment's code font on its own (it fell back to monospace Source Code Pro).
- Also adds a `.claude/skills/verify` skill capturing the runtime-verification recipe used below.

## Test plan

Verified end-to-end at the rendered surface (real tool pipeline → real cloud deploy → actual viewer HTML in Chromium via an MCP Apps host harness over postMessage):

- ✅ Fixed viewers, dark host: embedded notebook text computes to `rgb(0, 0, 0)`; no element inherits the host theme color. Checked all three viewers (evaluator, notebook, Wolfram|Alpha) plus light mode.
- ✅ Regression reproduction: the pre-fix viewer under a dark host renders the unstyled input tokens (`^ 2 + 1`, `5`) at `rgb(224, 224, 224)` on the white notebook — near-invisible — while syntax-colored tokens and the `FontColor -> Black` output cell were unaffected, matching the reported partial-invisibility symptom.
- ✅ Structural check: the `.notebook` element is inside the embedder's shadow root, confirming the old rule was dead code under shadow DOM.
- ✅ Font A/B: a notebook deployed with this change renders code as `Source Sans Pro`; one deployed from `main` renders `Source Code Pro` monospace in the same viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmYEaD6JGTcVrJs1d1wraY